### PR TITLE
Change code to remove the clang-tidy warning of init list

### DIFF
--- a/include/modmesh/grid.hpp
+++ b/include/modmesh/grid.hpp
@@ -180,7 +180,7 @@ private:
         else // NOLINT(readability-else-after-return,llvm-else-after-return)
         {
             // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-            return std::unique_ptr<real_type[]>();
+            return std::unique_ptr<real_type[]>{};
         }
     }
 


### PR DESCRIPTION
Github Action upgraded clang-tidy to 13 and it now detects modernize-return-braced-init-list.  Change code to make the code use the braced init list: https://github.com/solvcon/modmesh/runs/3897868232?check_suite_focus=true#step:7:65