### PR TITLE
Implement CallProfiler

### DIFF
--- a/cpp/modmesh/toggle/CMakeLists.txt
+++ b/cpp/modmesh/toggle/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 set(MODMESH_TOGGLE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/profile.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RadixTree.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/callprofiler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/toggle.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -162,6 +162,14 @@ public:
         }
     }
 
+    void reset()
+    {
+        m_root = std::move(std::make_unique<RadixTreeNode<T>>());
+        m_current_node = m_root.get();
+        m_id_map.clear();
+        m_unique_id = 0;
+    }
+
     RadixTreeNode<T> * get_current_node() const { return m_current_node; }
     key_type get_unique_node() const { return m_unique_id; }
 

--- a/cpp/modmesh/toggle/callprofiler.hpp
+++ b/cpp/modmesh/toggle/callprofiler.hpp
@@ -8,21 +8,22 @@
 namespace modmesh
 {
 
-// Define a structure for each node in the radix tree
+// The profiling result of the caller
 struct CallerProfile
 {
-    std::string functionName;
+    std::string callerName;
     std::chrono::milliseconds totalTime;
     int callCount = 0;
 };
 
-// Define a structure to represent a function call
+// Information of the caller stored in the profiler stack
 struct CallerInfo
 {
     std::string callerName;
     std::chrono::high_resolution_clock::time_point startTime;
 };
 
+/// The profiler that profiles the hierarchical caller stack.
 class CallProfiler
 {
 public:
@@ -55,7 +56,7 @@ public:
         // Update profiling information
         callProfile.totalTime += elapsedTime;
         callProfile.callCount++;
-        callProfile.functionName = callerName;
+        callProfile.callerName = callerName;
 
         // Pop the function from the call stack
         m_callStack.pop();
@@ -68,6 +69,7 @@ public:
         _print_profiling_result(*(m_radixTree.get_current_node()), 0, outstream);
     }
 
+    /// Result the profiler
     void reset()
     {
         while (!m_callStack.empty())
@@ -95,7 +97,7 @@ private:
         }
         else
         {
-            outstream << profile.functionName << " - Total Time: " << profile.totalTime.count() << " ms, Call Count: " << profile.callCount << std::endl;
+            outstream << profile.callerName << " - Total Time: " << profile.totalTime.count() << " ms, Call Count: " << profile.callCount << std::endl;
         }
 
         for (const auto & child : node.children())
@@ -105,11 +107,11 @@ private:
     }
 
 private:
-    std::stack<CallerInfo> m_callStack;
-    RadixTree<CallerProfile> m_radixTree;
+    std::stack<CallerInfo> m_callStack; /// the stack of the callers
+    RadixTree<CallerProfile> m_radixTree; /// the data structure of the callers
 };
 
-/// Utility to time how long a scope takes
+/// Utility to profile a call
 class CallProfilerProbe
 {
 public:

--- a/cpp/modmesh/toggle/callprofiler.hpp
+++ b/cpp/modmesh/toggle/callprofiler.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include <chrono>
+#include <ostream>
+#include <stack>
+#include <unordered_map>
+#include "RadixTree.hpp"
+
+namespace modmesh
+{
+
+// Define a structure for each node in the radix tree
+struct CallerProfile
+{
+    std::string functionName;
+    std::chrono::milliseconds totalTime;
+    int callCount = 0;
+};
+
+// Define a structure to represent a function call
+struct CallerInfo
+{
+    std::string callerName;
+    std::chrono::high_resolution_clock::time_point startTime;
+};
+
+class CallProfiler
+{
+public:
+    /// A singleton.
+    static CallProfiler & instance()
+    {
+        static CallProfiler instance;
+        return instance;
+    }
+
+    // Called when a function starts
+    void start_caller(const std::string & callerName)
+    {
+        auto startTime = std::chrono::high_resolution_clock::now();
+        m_callStack.push({callerName, startTime});
+        m_radixTree.entry(callerName);
+    }
+
+    // Called when a function ends
+    void end_caller()
+    {
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - m_callStack.top().startTime);
+
+        // Update the radix tree with profiling information
+        auto & callerName = m_callStack.top().callerName;
+
+        CallerProfile & callProfile = m_radixTree.get_current_node()->data();
+
+        // Update profiling information
+        callProfile.totalTime += elapsedTime;
+        callProfile.callCount++;
+        callProfile.functionName = callerName;
+
+        // Pop the function from the call stack
+        m_callStack.pop();
+        m_radixTree.move_current_to_parent();
+    }
+
+    /// Print the profiling information
+    void print_profiling_result(std::ostream & outstream) const
+    {
+        _print_profiling_result(*(m_radixTree.get_current_node()), 0, outstream);
+    }
+
+    void reset()
+    {
+        while (!m_callStack.empty())
+        {
+            m_callStack.pop();
+        }
+        m_radixTree.reset();
+    }
+
+private:
+    CallProfiler() = default;
+
+    void _print_profiling_result(const RadixTreeNode<CallerProfile> & node, const int depth, std::ostream & outstream) const
+    {
+        for (int i = 0; i < depth; ++i)
+        {
+            outstream << "  ";
+        }
+
+        auto profile = node.data();
+
+        if (depth == 0)
+        {
+            outstream << "Profiling Result" << std::endl;
+        }
+        else
+        {
+            outstream << profile.functionName << " - Total Time: " << profile.totalTime.count() << " ms, Call Count: " << profile.callCount << std::endl;
+        }
+
+        for (const auto & child : node.children())
+        {
+            _print_profiling_result(*child, depth + 1, outstream);
+        }
+    }
+
+private:
+    std::stack<CallerInfo> m_callStack;
+    RadixTree<CallerProfile> m_radixTree;
+};
+
+/// Utility to time how long a scope takes
+class CallProfilerProbe
+{
+public:
+    CallProfilerProbe(CallProfiler & profiler, const char * callerName)
+        : m_profiler(profiler)
+    {
+        m_profiler.start_caller(callerName);
+    }
+
+    ~CallProfilerProbe()
+    {
+        m_profiler.end_caller();
+    }
+
+private:
+    CallProfiler & m_profiler;
+};
+
+#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __FUNCTION__)
+#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
+
+} // namespace modmesh

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
     test_nopython_modmesh.cpp
     test_nopython_inout.cpp
     test_nopython_radixtree.cpp
+    test_nopython_callprofiler.cpp
 )
 target_link_libraries(
     test_nopython

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -74,9 +74,9 @@ TEST(CallProfilerCase2, construction)
 
     const char * answer = R"(Profiling Result
   foo1 - Total Time: 61 ms, Call Count: 1
-    foo2 - Total Time: 115 ms, Call Count: 1
-      foo3 - Total Time: 73 ms, Call Count: 1
-  foo2 - Total Time: 73 ms, Call Count: 1
+    foo2 - Total Time: 54 ms, Call Count: 1
+      foo3 - Total Time: 19 ms, Call Count: 1
+  foo2 - Total Time: 54 ms, Call Count: 1
     foo3 - Total Time: 19 ms, Call Count: 1
   foo3 - Total Time: 38 ms, Call Count: 2
 )";

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -1,0 +1,85 @@
+#include <modmesh/toggle/callprofiler.hpp>
+#include <gtest/gtest.h>
+#include <thread>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+TEST(CallProfiler, construction)
+{
+    namespace mm = modmesh;
+    mm::CallProfiler::instance();
+}
+
+constexpr int uniqueTime1 = 19;
+constexpr int uniqueTime2 = 35;
+constexpr int uniqueTime3 = 7;
+
+void foo3()
+{
+    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime1));
+}
+
+void foo2()
+{
+    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime2));
+    foo3();
+}
+
+void foo1()
+{
+    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    foo2();
+    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime3));
+}
+
+TEST(CallProfilerCase1, construction)
+{
+    namespace mm = modmesh;
+
+    mm::CallProfiler& profiler = mm::CallProfiler::instance();
+    profiler.reset();
+
+    foo1();
+
+    std::stringstream ss;
+    profiler.print_profiling_result(ss);
+
+    const char * answer = R"(Profiling Result
+  foo1 - Total Time: 61 ms, Call Count: 1
+    foo2 - Total Time: 54 ms, Call Count: 1
+      foo3 - Total Time: 19 ms, Call Count: 1
+)";
+
+    EXPECT_EQ(ss.str(), answer);
+}
+
+TEST(CallProfilerCase2, construction)
+{
+    namespace mm = modmesh;
+
+    mm::CallProfiler& profiler = mm::CallProfiler::instance();
+    profiler.reset();
+
+    foo1();
+    foo2();
+    foo3();
+    foo3();
+
+    std::stringstream ss;
+    profiler.print_profiling_result(ss);
+
+    const char * answer = R"(Profiling Result
+  foo1 - Total Time: 61 ms, Call Count: 1
+    foo2 - Total Time: 115 ms, Call Count: 1
+      foo3 - Total Time: 73 ms, Call Count: 1
+  foo2 - Total Time: 73 ms, Call Count: 1
+    foo3 - Total Time: 19 ms, Call Count: 1
+  foo3 - Total Time: 38 ms, Call Count: 2
+)";
+
+    EXPECT_EQ(ss.str(), answer);
+}


### PR DESCRIPTION
This work is based on the previous #245

This work introduces a new profiler, called `CallProfiler`, which can print the profiling result of a hierarchical caller stack.

The example output looks like this (please refer to `test_nopython_callprofiler.cpp`):

```c++
constexpr int uniqueTime1 = 19;
constexpr int uniqueTime2 = 35;
constexpr int uniqueTime3 = 7;

void foo3()
{
    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime1));
}

void foo2()
{
    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime2));
    foo3();
}

void foo1()
{
    modmesh::USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
    foo2();
    std::this_thread::sleep_for(std::chrono::milliseconds(uniqueTime3));
}


int main()
{
    auto & profiler = modmesh::Profiler::instance();

    foo1();
    foo2();
    foo3();
    foo3();
  
    profiler.print_profiling_result();
}
```

```log
Profiling Result
  foo1 - Total Time: 61 ms, Call Count: 1
    foo2 - Total Time: 54 ms, Call Count: 1
      foo3 - Total Time: 19 ms, Call Count: 1
  foo2 - Total Time: 54 ms, Call Count: 1
    foo3 - Total Time: 19 ms, Call Count: 1
  foo3 - Total Time: 38 ms, Call Count: 2
```

cc @q40603 