### PR TITLE
DRAFT: Improve take_along_axis using SIMD

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -37,6 +37,10 @@
 #include <numeric>
 #include <algorithm>
 
+#if defined(__aarch64__)
+#include <arm_neon.h>
+#endif /* defined(__aarch64__) */
+
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
@@ -224,6 +228,10 @@ public:
     SimpleArray<uint64_t> argsort(void);
     template <typename I>
     A take_along_axis(SimpleArray<I> const & indices);
+#if defined(__aarch64__)
+    template <typename I>
+    A take_along_axis_simd(SimpleArray<I> const & indices);
+#endif /* defined(__aarch64__) */
 
 }; /* end class SimpleArrayMixinSort */
 
@@ -239,6 +247,16 @@ void SimpleArrayMixinSort<A, T>::sort(void)
 
     std::sort(athis->begin(), athis->end());
 }
+
+#if defined(__aarch64__)
+
+template <typename T, typename I>
+void buffer_cpy(T * dest, T const * data, I const * begin, I const * const end);
+
+template <typename T>
+T const * check_index_range(SimpleArray<T> const & indices, size_t max_idx);
+
+#endif /* defined(__aarch64__) */
 
 } /* end namespace detail */
 
@@ -875,6 +893,108 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     }
     return ret;
 }
+
+#define check_type_range(typ, max_val)                              \
+    do {                                                            \
+        constexpr typ __type_max = std::numeric_limits<typ>::max(); \
+        constexpr typ __type_min = std::numeric_limits<typ>::min(); \
+        if (max_val >= __type_max && __type_min == 0)               \
+        {                                                           \
+            return nullptr;                                         \
+        }                                                           \
+    } while (0)
+
+template <typename T>
+T const * detail::check_index_range(SimpleArray<T> const & indices, size_t max_idx)
+{
+    check_type_range(T, max_idx);
+
+    T const * src = indices.begin();
+    T const * const end = indices.end();
+    while (src < end)
+    {
+        T const idx = *src;
+        if (idx < 0 || idx > max_idx)
+        {
+            return src;
+        }
+        ++src;
+    }
+    return nullptr;
+}
+
+#if defined(__aarch64__)
+#define DECL_CHECK_IDX_RNG_SIMD(typ) \
+    template <>                      \
+    typ const * detail::check_index_range<typ>(SimpleArray<typ> const & indices, size_t max_idx)
+
+DECL_CHECK_IDX_RNG_SIMD(uint8_t);
+DECL_CHECK_IDX_RNG_SIMD(uint16_t);
+DECL_CHECK_IDX_RNG_SIMD(uint32_t);
+DECL_CHECK_IDX_RNG_SIMD(uint64_t);
+DECL_CHECK_IDX_RNG_SIMD(int8_t);
+DECL_CHECK_IDX_RNG_SIMD(int16_t);
+DECL_CHECK_IDX_RNG_SIMD(int32_t);
+DECL_CHECK_IDX_RNG_SIMD(int64_t);
+
+#undef DECL_CHECK_IDX_RNG_SIMD
+
+template <typename T, typename I>
+void detail::buffer_cpy(T * dest, T const * data, I const * begin, I const * const end)
+{
+    T * dst = dest;
+    I const * src = begin;
+    while (src < end)
+    {
+        T const * valp = data + static_cast<size_t>(*src);
+        *dst = *valp;
+        ++dst;
+        ++src;
+    }
+}
+
+template <typename A, typename T>
+template <typename I>
+A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const & indices)
+{
+    static_assert(std::is_integral_v<I>, "I must be integral type");
+    auto athis = static_cast<A *>(this);
+    if (athis->ndim() != 1)
+    {
+        throw std::runtime_error(Formatter() << "SimpleArray::take_along_axis(): currently only support 1D array"
+                                             << " but the array is " << athis->ndim() << " dimension");
+    }
+
+    size_t max_idx = athis->shape()[0];
+    I const * oor_ptr = check_index_range(indices, max_idx);
+    if (oor_ptr != nullptr)
+    {
+        size_t offset = oor_ptr - indices.begin();
+        shape_type const & stride = indices.stride();
+        const size_t ndim = stride.size();
+        Formatter err_msg;
+        err_msg << "SimpleArray::take_along_axis(): indices[" << offset / stride[0];
+        offset %= stride[0];
+        for (size_t dim = 1; dim < ndim; ++dim)
+        {
+            err_msg << ", " << offset / stride[dim];
+            offset %= stride[dim];
+        }
+        err_msg << "] is " << *oor_ptr << ", which is out of range of the array size "
+                << max_idx;
+
+        throw std::out_of_range(err_msg);
+    }
+
+    I const * src = indices.begin();
+    I const * const end = indices.end();
+    A ret(indices.shape());
+    T * data = athis->begin();
+    T * dest = ret.begin();
+    detail::buffer_cpy(dest, data, src, end);
+    return ret;
+}
+#endif /* defined(__aarch64__) */
 
 template <typename S>
 using is_simple_array = std::is_same<

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -876,12 +876,21 @@ class SimpleArrayBasicTC(unittest.TestCase):
         for i in range(len(idx)):
             self.assertEqual(ret_arr[i], data[idx[i]])
 
+        ret_arr = data_arr.take_along_axis_simd(idx_arr)
+        for i in range(len(idx)):
+            self.assertEqual(ret_arr[i], data[idx[i]])
+
         # test 2-D indices
         idx = [[0, 2, 4, 6], [1, 3, 5, 7]]
         narr = np.array(idx, dtype='uint64')
         idx_arr = modmesh.SimpleArrayUint64(array=narr)
 
         ret_arr = data_arr.take_along_axis(idx_arr)
+        for i in range(len(idx)):
+            for j in range(len(idx[i])):
+                self.assertEqual(ret_arr[i, j], data[idx_arr[i, j]])
+
+        ret_arr = data_arr.take_along_axis_simd(idx_arr)
         for i in range(len(idx)):
             for j in range(len(idx[i])):
                 self.assertEqual(ret_arr[i, j], data[idx_arr[i, j]])
@@ -897,6 +906,13 @@ class SimpleArrayBasicTC(unittest.TestCase):
             "which is out of range of the array size 10"
         ):
             ret_arr = data_arr.take_along_axis(idx_arr)
+
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::take_along_axis\(\): indices\[2, 1\] is 20, " +
+            "which is out of range of the array size 10"
+        ):
+            ret_arr = data_arr.take_along_axis_simd(idx_arr)
 
 
 class SimpleArrayCalculatorsTC(unittest.TestCase):


### PR DESCRIPTION
# Description

The `take_along_axis` function improved in PR #486 can be further improved using SIMD.
This PR use Neon (Arm SIMD Instruction Set) to enhance `take_along_axis` in some data type.

> NOTE: Currently only the index check part of take_along_axis is improved. The data copy part of it is still ongoing.

# Profile Result

From the following results, it is obvious that SIMD actually did some improvement on take_along_axis.

## N = 256 type: uint16

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |5.629E-03|1.000|
|sa      |1.954E-03|0.347|
|simd    |1.433E-03|0.255|

## N = 1K type: uint16

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |3.842E-03|1.000|
|sa      |1.929E-03|0.502|
|simd    |1.604E-03|0.418|

## N = 4K type: uint16

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |8.091E-03|1.000|
|sa      |4.000E-03|0.494|
|simd    |2.796E-03|0.346|

## N = 16K type: uint16

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |2.306E-02|1.000|
|sa      |1.297E-02|0.562|
|simd    |7.779E-03|0.337|

## N = 64K type: uint32

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |9.521E-02|1.000|
|sa      |6.014E-02|0.632|
|simd    |3.932E-02|0.413|

## N = 256K type: uint32

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |3.963E-01|1.000|
|sa      |3.399E-01|0.858|
|simd    |2.661E-01|0.671|

## N = 1M type: uint32

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |2.024E+00|1.000|
|sa      |1.632E+00|0.806|
|simd    |1.360E+00|0.672|

## N = 4M type: uint32

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |1.531E+01|1.000|
|sa      |1.072E+01|0.700|
|simd    |9.474E+00|0.619|

## N = 16M type: uint64

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |1.470E+02|1.000|
|sa      |8.936E+01|0.608|
|simd    |8.608E+01|0.586|

## N = 64M type: uint64

|func    | Per Call (ms)| cmp to np |
|-|-|-|
|np      |7.290E+02|1.000|
|sa      |6.456E+02|0.886|
|simd    |6.359E+02|0.872|



## Profiling Codes

```python
import functools
import modmesh
import numpy as np

def profile_function(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        _ = modmesh.CallProfilerProbe(func.__name__)
        result = func(*args, **kwargs)
        return result
    return wrapper

def make_container(data, simple_array=True):
    if np.isdtype(data.dtype, np.uint8):
        return modmesh.SimpleArrayUint8(array=np.array(data, dtype='uint8')) if simple_array else np.array(data, dtype='uint8')
    elif np.isdtype(data.dtype, np.uint16):
        return modmesh.SimpleArrayUint16(array=np.array(data, dtype='uint16')) if simple_array else np.array(data, dtype='uint16')
    elif np.isdtype(data.dtype, np.uint32):
        return modmesh.SimpleArrayUint32(array=np.array(data, dtype='uint32')) if simple_array else np.array(data, dtype='uint32')
    elif np.isdtype(data.dtype, np.uint64):
        return modmesh.SimpleArrayUint64(array=np.array(data, dtype='uint64')) if simple_array else np.array(data, dtype='uint64')

@profile_function
def profile_take_along_axis_np(narr, indices):
    return np.take_along_axis(narr, indices, -1)

@profile_function
def profile_take_along_axis_sa(sarr, indices):
    return sarr.take_along_axis(indices)

@profile_function
def profile_take_along_axis_simd(sarr, indices):
    return sarr.take_along_axis_simd(indices)


def test(pow, it = 10):
    N = 2 ** pow
    ORDER = ["", "K", "M", "G", "T"][pow // 10]
    dtype = ["uint8", "uint16", "uint32", "uint64"][pow // 8]

    modmesh.call_profiler.reset()
    test_data = np.arange(0, N, dtype=dtype)
    indices = np.arange(0, N-1, dtype=dtype)
    np.random.shuffle(test_data)
    np.random.shuffle(indices)
    for _ in range(it):
        profile_take_along_axis_np(test_data, indices)
        profile_take_along_axis_sa(make_container(test_data), make_container(indices))
        profile_take_along_axis_simd(make_container(test_data), make_container(indices))

    res = modmesh.call_profiler.result()["children"]

    print(f"## N = {2 ** (pow % 10)}{ORDER} type: {dtype}\n")
    out = {}
    for r in res:
        name = r["name"].replace("profile_take_along_axis_", "")
        time = r["total_time"] / r["count"]
        out[name] = time
    
    print(f"|{"func":8s}| Per Call (ms)| cmp to np |")
    base = out["np"]
    for k, v in out.items():
        print(f"|{k:8s}|{v:.3E}|{v/base:.3f}|")

    print()


def main():

    pow = 6
    it = 10

    for _ in range(it):
        pow = pow + 2
        test(pow)

if __name__ == '__main__':
    main()
```