### PR TITLE
Packaging: add PyInstaller script

### DIFF
--- a/contrib/packaging/macos.sh
+++ b/contrib/packaging/macos.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# make sure starting from project's root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/../.."
+
+python3 -m pip install pyinstaller
+
+make clean
+rm -rf build/portable/
+mkdir -p build/portable/
+cp -R ./modmesh build/portable/
+cp -R ./resources build/portable/
+cd build/portable/
+
+cat > modmesh.py <<'EOF'
+import os
+os.environ["QT3D_RENDERER"] = "opengl"
+from modmesh.pilot import launch
+if __name__ == "__main__":
+    launch()
+EOF
+
+pyinstaller --onedir \
+            --windowed \
+            --add-data "modmesh:modmesh" \
+            --hidden-import PySide6.Qt3DCore \
+            --hidden-import PySide6.Qt3DRender \
+            --hidden-import PySide6.Qt3DExtras \
+            --hidden-import PySide6.Qt3DInput \
+            --exclude-module PySide6.QtNetwork \
+            --icon="resources/pilot/solvcon.icns" \
+            modmesh.py


### PR DESCRIPTION
In this PR, we proposed a PyInstaller packaging script.
Currently only packaging the Python part of modmesh into a macOS app.
Maybe we could turn the line `make clean` into a toggle to decide whether we wants to build the C++ part or not before the packaging started.