### PR TITLE
Fix SIMD dispatching malfunctioning

### DIFF
--- a/cpp/modmesh/simd/simd_support.cpp
+++ b/cpp/modmesh/simd/simd_support.cpp
@@ -83,8 +83,10 @@ SimdFeature detect_simd()
 #endif
 #endif /* defined(__aarch64__) || defined(__arm__) */
 
-    CurrentFeature = SIMD_NONE;
-
+    if (CurrentFeature == SIMD_UNKNOWN)
+    {
+        CurrentFeature = SIMD_NONE;
+    }
     return CurrentFeature;
 }
 


### PR DESCRIPTION
In the previous version, SIMD dispatching mechanism is buggy that makes all program flow go to generic flow which is designed for platforms without SIMD support. The program is therefore not accelerated at all.
This PR fix this problem.