### PR TITLE
Add a Python matmul/imatmul operator

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -629,6 +629,8 @@ public:
         return *athis;
     }
 
+    A & imatmul(A const & other);
+
     A add_simd(A const & other) const
     {
         A const * athis = static_cast<A const *>(this);
@@ -726,8 +728,6 @@ public:
     }
 
     A matmul(A const & other) const;
-
-    A & imatmul(A const & other);
 
 private:
     static void find_two_bins(const uint32_t * freq, size_t n, int & bin1, int & bin2);

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -727,6 +727,8 @@ public:
 
     A matmul(A const & other) const;
 
+    A & imatmul(A const & other);
+
 private:
     static void find_two_bins(const uint32_t * freq, size_t n, int & bin1, int & bin2);
 }; /* end class SimpleArrayMixinCalculators */
@@ -884,6 +886,21 @@ A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
     }
 
     return result;
+}
+
+/**
+ * Perform in-place matrix multiplication for 2D arrays.
+ * This implementation supports only 2D × 2D matrix multiplication.
+ * The result replaces the content of the current array.
+ */
+template <typename A, typename T>
+A & SimpleArrayMixinCalculators<A, T>::imatmul(A const & other)
+{
+    auto athis = static_cast<A *>(this);
+    A result = athis->matmul(other);
+    *athis = std::move(result);
+
+    return *athis;
 }
 
 /**

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -315,6 +315,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("mul", &wrapped_type::mul)
             .def("div", &wrapped_type::div)
             .def("matmul", &wrapped_type::matmul)
+            .def("__matmul__", &wrapped_type::matmul)
+            .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)
+                 {
+                     self = self.matmul(other);
+                     return self;
+                 })
             .def_static("eye", &wrapped_type::eye, py::arg("n"), "Create an identity matrix of size n x n")
             // TODO: In-place operation should return reference to self to support function chaining
             .def("iadd", [](wrapped_type & self, wrapped_type const & other)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -315,10 +315,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("mul", &wrapped_type::mul)
             .def("div", &wrapped_type::div)
             .def("matmul", &wrapped_type::matmul)
+            .def("imatmul", [](wrapped_type & self, wrapped_type const & other)
+                 { self.imatmul(other); })
             .def("__matmul__", &wrapped_type::matmul)
             .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)
                  {
-                     self = self.matmul(other);
+                     self.imatmul(other);
                      return self; })
             .def_static("eye", &wrapped_type::eye, py::arg("n"), "Create an identity matrix of size n x n")
             // TODO: In-place operation should return reference to self to support function chaining

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -315,15 +315,17 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("mul", &wrapped_type::mul)
             .def("div", &wrapped_type::div)
             .def("matmul", &wrapped_type::matmul)
-            .def("imatmul", [](wrapped_type & self, wrapped_type const & other)
-                 { self.imatmul(other); })
             .def("__matmul__", &wrapped_type::matmul)
-            .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)
-                 {
-                     self.imatmul(other);
-                     return self; })
             .def_static("eye", &wrapped_type::eye, py::arg("n"), "Create an identity matrix of size n x n")
             // TODO: In-place operation should return reference to self to support function chaining
+            /*
+             * Regular in-place methods (iadd, imul, etc.) are procedural calls and do
+             * NOT need to return self. However, special __i*__ methods (__iadd__,
+             * __imatmul__, etc.) MUST return self because they implement Python's
+             * augmented assignment operators (+=, @=, etc.), which work via re-assignment
+             * (e.g., a = a.__iadd__(b)).
+             * See: https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
+             */
             .def("iadd", [](wrapped_type & self, wrapped_type const & other)
                  { self.iadd(other); })
             .def("isub", [](wrapped_type & self, wrapped_type const & other)
@@ -332,6 +334,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                  { self.imul(other); })
             .def("idiv", [](wrapped_type & self, wrapped_type const & other)
                  { self.idiv(other); })
+            .def("imatmul", [](wrapped_type & self, wrapped_type const & other)
+                 { self.imatmul(other); })
+            .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)
+                 {
+                     self.imatmul(other);
+                     return self; })
             .def("add_simd", &wrapped_type::add_simd)
             .def("sub_simd", &wrapped_type::sub_simd)
             .def("mul_simd", &wrapped_type::mul_simd)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -319,8 +319,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)
                  {
                      self = self.matmul(other);
-                     return self;
-                 })
+                     return self; })
             .def_static("eye", &wrapped_type::eye, py::arg("n"), "Create an identity matrix of size n x n")
             // TODO: In-place operation should return reference to self to support function chaining
             .def("iadd", [](wrapped_type & self, wrapped_type const & other)

--- a/tests/test_gemm.py
+++ b/tests/test_gemm.py
@@ -311,6 +311,25 @@ class GemmTestBase(mm.testing.TestBase):
         self.assertEqual(list(result.shape), [2, 2])
         np.testing.assert_array_almost_equal(result.ndarray, expected)
 
+    def test_imatmul_method(self):
+        """Test imatmul() method for in-place matrix multiplication"""
+        # Create 2x2 matrices
+        a_data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=self.dtype)
+        b_data = np.array([[5.0, 6.0], [7.0, 8.0]], dtype=self.dtype)
+
+        a = self.SimpleArray(array=a_data)
+        b = self.SimpleArray(array=b_data)
+
+        # Expected result: [[19, 22], [43, 50]]
+        expected = np.array([[19.0, 22.0], [43.0, 50.0]], dtype=self.dtype)
+
+        # Test imatmul() method
+        a.imatmul(b)
+
+        # Verify the result
+        self.assertEqual(list(a.shape), [2, 2])
+        np.testing.assert_array_almost_equal(a.ndarray, expected)
+
     def test_imatmul_operator(self):
         """Test @= operator for in-place matrix multiplication"""
         # Create 2x2 matrices

--- a/tests/test_gemm.py
+++ b/tests/test_gemm.py
@@ -293,6 +293,42 @@ class GemmTestBase(mm.testing.TestBase):
         ):
             a_3d.matmul(b_3d)
 
+    def test_matmul_operator(self):
+        """Test @ operator for matrix multiplication"""
+        # Create 2x2 matrices
+        a_data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=self.dtype)
+        b_data = np.array([[5.0, 6.0], [7.0, 8.0]], dtype=self.dtype)
+
+        a = self.SimpleArray(array=a_data)
+        b = self.SimpleArray(array=b_data)
+
+        # Expected result: [[19, 22], [43, 50]]
+        expected = np.array([[19.0, 22.0], [43.0, 50.0]], dtype=self.dtype)
+
+        # Test @ operator
+        result = a @ b
+
+        self.assertEqual(list(result.shape), [2, 2])
+        np.testing.assert_array_almost_equal(result.ndarray, expected)
+
+    def test_imatmul_operator(self):
+        """Test @= operator for in-place matrix multiplication"""
+        # Create 2x2 matrices
+        a_data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=self.dtype)
+        b_data = np.array([[5.0, 6.0], [7.0, 8.0]], dtype=self.dtype)
+
+        a = self.SimpleArray(array=a_data)
+        b = self.SimpleArray(array=b_data)
+
+        # Expected result: [[19, 22], [43, 50]]
+        expected = np.array([[19.0, 22.0], [43.0, 50.0]], dtype=self.dtype)
+
+        # Test @= operator
+        a @= b
+
+        self.assertEqual(list(a.shape), [2, 2])
+        np.testing.assert_array_almost_equal(a.ndarray, expected)
+
 
 class GemmFloat32TC(GemmTestBase, unittest.TestCase):
     """Test matrix multiplication with float32"""


### PR DESCRIPTION
## Summary

This PR implements the Python matrix multiplication operators (`@` and `@=`) for the `SimpleArray`. 
This allows for a more intuitive and Pythonic syntax (`a @ b`) as a replacement for the method call (`a.matmul(b)`).

This change builds upon the `matmul` logic introduced in #587.

## Key Changes
- Added `__matmul__`, and `__imatmul__` to `SimpleArray`.
- Added corresponding unit tests to ensure operator correctness.

## Related Issues
- #502 
- #588