### PR TITLE
Extend element wise multiplication

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -523,6 +523,11 @@ public:
         return A(*static_cast<A const *>(this)).imul(other);
     }
 
+    A mul(value_type scalar) const
+    {
+        return A(*static_cast<A const *>(this)).imul(scalar);
+    }
+
     A div(A const & other) const
     {
         return A(*static_cast<A const *>(this)).idiv(other);
@@ -601,6 +606,34 @@ public:
             for (size_t i = 0; i < size; ++i)
             {
                 athis->data(i) = athis->data(i) && other.data(i);
+            }
+        }
+        return *athis;
+    }
+
+    A & imul(value_type scalar)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            const value_type * const end = athis->end();
+            value_type * ptr = athis->begin();
+
+            while (ptr < end)
+            {
+                *ptr *= scalar;
+                ++ptr;
+            }
+        }
+        else
+        {
+            if (!scalar)
+            {
+                size_t size = athis->size();
+                for (size_t i = 0; i < size; ++i)
+                {
+                    athis->data(i) = false;
+                }
             }
         }
         return *athis;

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -312,7 +312,14 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("abs", &wrapped_type::abs)
             .def("add", &wrapped_type::add)
             .def("sub", &wrapped_type::sub)
-            .def("mul", &wrapped_type::mul)
+            .def(
+                "mul",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.mul(other); })
+            .def(
+                "mul",
+                [](wrapped_type const & self, value_type scalar)
+                { return self.mul(scalar); })
             .def("div", &wrapped_type::div)
             .def("matmul", &wrapped_type::matmul)
             .def("__matmul__", &wrapped_type::matmul)
@@ -330,8 +337,14 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                  { self.iadd(other); })
             .def("isub", [](wrapped_type & self, wrapped_type const & other)
                  { self.isub(other); })
-            .def("imul", [](wrapped_type & self, wrapped_type const & other)
-                 { self.imul(other); })
+            .def(
+                "imul",
+                [](wrapped_type & self, wrapped_type const & other)
+                { self.imul(other); })
+            .def(
+                "imul",
+                [](wrapped_type & self, value_type scalar)
+                { self.imul(scalar); })
             .def("idiv", [](wrapped_type & self, wrapped_type const & other)
                  { self.idiv(other); })
             .def("imatmul", [](wrapped_type & self, wrapped_type const & other)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1728,6 +1728,151 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
             self.assertEqual(sarr1[i], res[i])
             self.assertEqual(sres[i], nres[i])
 
+    def test_mul_1d(self):
+        def test_mul_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([2, 3, 4, 5, 6, 7, 8, 9], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.multiply(narr1, narr2)
+            sres = sarr1.mul(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.imul(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        test_mul_1d_type('int32')
+        test_mul_1d_type('int64')
+        test_mul_1d_type('float32')
+        test_mul_1d_type('float64')
+
+    def test_mul_2d(self):
+        def test_mul_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[2, 2, 2, 2],
+                              [3, 3, 3, 3],
+                              [4, 4, 4, 4]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.multiply(narr1, narr2)
+            sres = sarr1.mul(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.imul(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        test_mul_2d_type('int32')
+        test_mul_2d_type('int64')
+        test_mul_2d_type('float32')
+        test_mul_2d_type('float64')
+
+    def test_mul_3d(self):
+        def test_mul_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            narr2 = np.arange(1, 25, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.multiply(narr1, narr2)
+            sres = sarr1.mul(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.imul(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        test_mul_3d_type('int32')
+        test_mul_3d_type('int64')
+        test_mul_3d_type('float32')
+        test_mul_3d_type('float64')
+
+    def test_mul_scalar_1d(self):
+        """Test 1D array scalar multiplication"""
+        def test_mul_scalar_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.multiply(narr1, scalar)
+            sres = sarr1.mul(scalar)
+
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.imul(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        test_mul_scalar_1d_type('int32')
+        test_mul_scalar_1d_type('int64')
+        test_mul_scalar_1d_type('float32')
+        test_mul_scalar_1d_type('float64')
+
+    def test_mul_scalar_2d(self):
+        """Test 2D array (matrix) scalar multiplication"""
+        def test_mul_scalar_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 2
+
+            nres = np.multiply(narr1, scalar)
+            sres = sarr1.mul(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.imul(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        test_mul_scalar_2d_type('int32')
+        test_mul_scalar_2d_type('int64')
+        test_mul_scalar_2d_type('float32')
+        test_mul_scalar_2d_type('float64')
+
+    def test_mul_scalar_3d(self):
+        """Test 3D array scalar multiplication"""
+        def test_mul_scalar_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 5
+
+            nres = np.multiply(narr1, scalar)
+            sres = sarr1.mul(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.imul(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        test_mul_scalar_3d_type('int32')
+        test_mul_scalar_3d_type('int64')
+        test_mul_scalar_3d_type('float32')
+        test_mul_scalar_3d_type('float64')
+
     def test_div(self):
         arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]


### PR DESCRIPTION
According to pr #595, this pull request extend the element wise multiplication of simplearray, include array * array and array * scalar.
Although it cannot deal with the non contiguous array currently, it is enough for kalman filter algorithm.
In other words, the kalman filter algorithm needs the operation of  array * scalar.
For example, in the [predict and innovation phase](https://github.com/solvcon/modmesh/issues/588#issuecomment-3341283659), $$Q_t$$ and $$R_t$$ are the noise matrix:
```cpp
    static array_type create_noise_matrix(size_t size, real_type noise_std)
    {
        real_type variance = noise_std * noise_std;
        return array_type::eye(size).mul(static_cast<T>(variance));
    }
```