### PR TITLE
Extend LLT solver to 2D array

### DIFF
--- a/cpp/modmesh/linalg/factorization.hpp
+++ b/cpp/modmesh/linalg/factorization.hpp
@@ -50,126 +50,237 @@ public:
 
     // Factorization algorithm
     // Reference: https://www.geeksforgeeks.org/dsa/cholesky-decomposition-matrix-decomposition/
-    static array_type factorize(array_type const & A);
+    static array_type factorize(array_type const & a);
     // Solver: solve A x = b where A = L L^T (or L L^H for complex)
-    static array_type solve(array_type const & A, array_type const & b);
+    static array_type solve(array_type const & a, array_type const & b);
 
 private:
 
-    // Forward substitution: solve L y = b
-    static array_type forward_substitution(array_type const & L, array_type const & b);
-    // Backward substitution: solve L^T x = y (or L^H x = y for complex)
-    static array_type backward_substitution(array_type const & L, array_type const & y);
+    // Forward substitution: solve L Y = B
+    static array_type forward_substitution(array_type const & l, array_type const & b);
+    // Backward substitution: solve L^T X = Y (or L^H X = Y for complex)
+    static array_type backward_substitution(array_type const & l, array_type const & y);
 
 }; /* end class Llt */
 
 template <typename T>
-auto Llt<T>::forward_substitution(array_type const & L, array_type const & b) -> array_type
+auto Llt<T>::forward_substitution(array_type const & l, array_type const & b) -> array_type
 {
-    const size_t n = L.shape(0);
-    array_type y(n);
-    for (size_t i = 0; i < n; ++i)
+    if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
-        T sum = 0;
-        for (size_t j = 0; j < i; ++j)
+        Formatter oss;
+        oss << "Llt::forward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
+        for (ssize_t i = 0; i < l.ndim(); ++i)
         {
-            sum += L(i, j) * y(j);
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << l.shape(i);
         }
-        y(i) = (b(i) - sum) / L(i, i);
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (b.ndim() != 2 || b.shape(0) != l.shape(0))
+    {
+        Formatter oss;
+        oss << "Llt::forward_substitution: The second argument b must be a 2D SimpleArray with first dimension matching l, but got shape (";
+        for (ssize_t i = 0; i < b.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << b.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+
+    const ssize_t m = static_cast<ssize_t>(l.shape(0));
+    const ssize_t n = static_cast<ssize_t>(b.shape(1));
+    small_vector<size_t> y_shape{static_cast<size_t>(m), static_cast<size_t>(n)};
+    array_type y(y_shape);
+    for (ssize_t k = 0; k < n; ++k)
+    {
+        for (ssize_t i = 0; i < m; ++i)
+        {
+            T sum = 0;
+            for (ssize_t j = 0; j < i; ++j)
+            {
+                sum += l(i, j) * y(j, k);
+            }
+            y(i, k) = (b(i, k) - sum) / l(i, i);
+        }
     }
     return y;
 }
 
 template <typename T>
-auto Llt<T>::backward_substitution(array_type const & L, array_type const & y) -> array_type
+auto Llt<T>::backward_substitution(array_type const & l, array_type const & y) -> array_type
 {
-    const size_t n = L.shape(0);
-    array_type x(n);
-    for (int i = n - 1; i >= 0; --i)
+    if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
-        T sum = 0;
-        for (size_t j = i + 1; j < n; ++j)
+        Formatter oss;
+        oss << "Llt::backward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
+        for (ssize_t i = 0; i < l.ndim(); ++i)
         {
-            sum += conj_mul(x(j), L(j, i));
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << l.shape(i);
         }
-        x(i) = (y(i) - sum) / L(i, i);
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (y.ndim() != 2 || y.shape(0) != l.shape(0))
+    {
+        Formatter oss;
+        oss << "Llt::backward_substitution: The second argument y must be a 2D SimpleArray with first dimension matching l, but got shape (";
+        for (ssize_t i = 0; i < y.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << y.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+
+    const ssize_t m = static_cast<ssize_t>(l.shape(0));
+    const ssize_t n = static_cast<ssize_t>(y.shape(1));
+    small_vector<size_t> x_shape{static_cast<size_t>(m), static_cast<size_t>(n)};
+    array_type x(x_shape);
+    for (ssize_t k = 0; k < n; ++k)
+    {
+        for (ssize_t i = m - 1; i >= 0; --i)
+        {
+            T sum = 0;
+            for (ssize_t j = i + 1; j < m; ++j)
+            {
+                sum += conj_mul(x(j, k), l(j, i));
+            }
+            x(i, k) = (y(i, k) - sum) / l(i, i);
+        }
     }
     return x;
 }
 
 template <typename T>
-auto Llt<T>::factorize(array_type const & A) -> array_type
+auto Llt<T>::factorize(array_type const & a) -> array_type
 {
-    if (A.ndim() != 2 || A.shape(0) != A.shape(1))
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
-        throw std::invalid_argument("Llt factorization requires a square 2D matrix");
+        Formatter oss;
+        oss << "Llt::factorize: The first argument a must be a square 2D SimpleArray, but got shape (";
+        for (ssize_t i = 0; i < a.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << a.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
     }
 
-    const size_t n = A.shape(0);
-    small_vector<size_t> shape = {n, n};
-    array_type L(shape, value_type(0));
+    const ssize_t m = static_cast<ssize_t>(a.shape(0));
+    small_vector<size_t> shape = {static_cast<size_t>(m), static_cast<size_t>(m)};
+    array_type l(shape, value_type(0));
     const real_type eps = std::numeric_limits<real_type>::epsilon();
-    for (size_t i = 0; i < n; ++i)
+    for (ssize_t i = 0; i < m; ++i)
     {
-        for (size_t j = 0; j <= i; ++j)
+        for (ssize_t j = 0; j <= i; ++j)
         {
             value_type sum = 0;
-            for (size_t k = 0; k < j; ++k)
+            for (ssize_t k = 0; k < j; ++k)
             {
-                sum += conj_mul(L(i, k), L(j, k));
+                sum += conj_mul(l(i, k), l(j, k));
             }
             if (i == j)
             {
-                real_type dr = real(A(j, j) - sum);
-                real_type tol = std::max<real_type>(1, abs(A(j, j))) * 100 * eps;
+                real_type dr = real(a(j, j) - sum);
+                real_type tol = std::max<real_type>(1, abs(a(j, j))) * 100 * eps;
                 if (dr <= tol)
                 {
-                    throw std::runtime_error("Cholesky failed: matrix not (numerically) SPD.");
+                    throw std::runtime_error("Llt::factorize: Cholesky failed: SimpleArray not (numerically) SPD.");
                 }
-                L(j, j) = std::sqrt(dr);
+                l(j, j) = std::sqrt(dr);
             }
             else
             {
-                L(i, j) = (A(i, j) - sum) / L(j, j);
+                l(i, j) = (a(i, j) - sum) / l(j, j);
             }
         }
     }
-    return L;
+    return l;
 }
 
 template <typename T>
-auto Llt<T>::solve(array_type const & A, array_type const & b) -> array_type
+auto Llt<T>::solve(array_type const & a, array_type const & b) -> array_type
 {
-    if (A.ndim() != 2 || A.shape(0) != A.shape(1))
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
-        throw std::invalid_argument("Matrix A must be square 2D");
+        Formatter oss;
+        oss << "Llt::solve: The first argument a must be a square 2D SimpleArray, but got shape (";
+        for (ssize_t i = 0; i < a.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << a.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
     }
-    if (b.ndim() != 1)
+    if (a.shape(0) != b.shape(0))
     {
-        throw std::invalid_argument("Vector b must be 1D");
+        Formatter oss;
+        oss << "Llt::solve: The first argument a and the second argument b dimension mismatch: a.shape[0]=" << a.shape(0) << ", b.shape[0]=" << b.shape(0);
+        throw std::invalid_argument(oss.str());
     }
-    if (A.shape(0) != b.shape(0))
+    if (b.ndim() != 1 && b.ndim() != 2)
     {
-        throw std::invalid_argument("Matrix A and vector b dimension mismatch");
+        Formatter oss;
+        oss << "Llt::solve: The second argument b must be 1D or 2D, but got " << b.ndim() << "D";
+        throw std::invalid_argument(oss.str());
     }
-    array_type L = factorize(A);
-    array_type y = forward_substitution(L, b);
-    array_type x = backward_substitution(L, y);
-    return x;
+
+    array_type l = factorize(a);
+
+    bool was_1d = (b.ndim() == 1);
+    if (was_1d)
+    {
+        array_type b_2d = b.reshape(small_vector<size_t>{b.shape(0), 1});
+        array_type y = forward_substitution(l, b_2d);
+        array_type x = backward_substitution(l, y);
+        return x.reshape(small_vector<size_t>{x.shape(0)});
+    }
+    else
+    {
+        array_type y = forward_substitution(l, b);
+        array_type x = backward_substitution(l, y);
+        return x;
+    }
 }
 
 } /* end namespace detail */
 
 template <typename T>
-SimpleArray<T> llt_factorization(SimpleArray<T> const & A)
+SimpleArray<T> llt_factorization(SimpleArray<T> const & a)
 {
-    return detail::Llt<T>::factorize(A);
+    return detail::Llt<T>::factorize(a);
 }
 
 template <typename T>
-SimpleArray<T> llt_solve(SimpleArray<T> const & A, SimpleArray<T> const & b)
+SimpleArray<T> llt_solve(SimpleArray<T> const & a, SimpleArray<T> const & b)
 {
-    return detail::Llt<T>::solve(A, b);
+    return detail::Llt<T>::solve(a, b);
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/linalg/pymod/wrap_linalg.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_linalg.cpp
@@ -38,18 +38,18 @@ template <typename T>
 void def_llt_factorization(pybind11::module & mod)
 {
     mod.def(
-        "llt_factorization", [](SimpleArray<T> const & A)
-        { return llt_factorization(A); },
-        pybind11::arg("A"));
+        "llt_factorization", [](SimpleArray<T> const & a)
+        { return llt_factorization(a); },
+        pybind11::arg("a"));
 }
 
 template <typename T>
 void def_llt_solve(pybind11::module & mod)
 {
     mod.def(
-        "llt_solve", [](SimpleArray<T> const & A, SimpleArray<T> const & b)
-        { return llt_solve(A, b); },
-        pybind11::arg("A"),
+        "llt_solve", [](SimpleArray<T> const & a, SimpleArray<T> const & b)
+        { return llt_solve(a, b); },
+        pybind11::arg("a"),
         pybind11::arg("b"));
 }
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,10 +1,11 @@
+import unittest
+
 import numpy as np
-import pytest
 
 import modmesh
 
 
-class TestLinalgFactorization:
+class TestLinalgFactorization(unittest.TestCase):
 
     def test_llt_factorization_double_simple(self):
         L_desired = np.array([
@@ -52,11 +53,15 @@ class TestLinalgFactorization:
 
     def test_llt_factorization_invalid_input(self):
         A = modmesh.SimpleArrayFloat64([2, 3])
-        with pytest.raises(Exception):
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::factorize: The first argument a must be a square "
+                r"2D SimpleArray"
+        ):
             modmesh.llt_factorization(A)
 
 
-class TestLinalgSolver:
+class TestLinalgSolver(unittest.TestCase):
 
     def test_llt_solve_double_simple(self):
         B_np = np.array([
@@ -120,5 +125,128 @@ class TestLinalgSolver:
     def test_llt_solve_invalid_input(self):
         A = modmesh.SimpleArrayFloat64([2, 3])
         b = modmesh.SimpleArrayFloat64([2])
-        with pytest.raises(Exception):
+        with self.assertRaises(Exception):
+            modmesh.llt_solve(A, b)
+
+    def test_llt_solve_2d_multi_rhs_double(self):
+        B_np = np.array([
+            [2.0, 1.0, 0.5, 0.25, 0.125],
+            [0.0, 1.5, 0.75, 0.375, 0.1875],
+            [0.0, 0.0, 1.0, 0.5, 0.25],
+            [0.0, 0.0, 0.0, 0.75, 0.375],
+            [0.0, 0.0, 0.0, 0.0, 0.5]
+        ])
+        A_np = B_np.T @ B_np + np.eye(5)
+        b_2d_np = np.array([
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+            [13.0, 14.0, 15.0]
+        ])
+        A = modmesh.SimpleArrayFloat64(array=A_np)
+        b_2d = modmesh.SimpleArrayFloat64(array=b_2d_np)
+        x_2d = modmesh.llt_solve(A, b_2d)
+        assert x_2d.shape == (5, 3)
+        x_2d_np = np.array(x_2d)
+        A_np = np.array(A)
+        b_2d_np = np.array(b_2d)
+        Ax_2d_np = A_np @ x_2d_np
+        np.testing.assert_allclose(Ax_2d_np, b_2d_np, rtol=1e-10)
+
+    def test_llt_solve_2d_multi_rhs_complex(self):
+        B_np = np.array([
+            [2.0+0.0j, 1.0+0.5j, 0.5+0.25j, 0.25+0.0j],
+            [0.0+0.0j, 1.5+0.0j, 0.75+0.375j, 0.375+0.0j],
+            [0.0+0.0j, 0.0+0.0j, 1.0+0.0j, 0.5+0.0j],
+            [0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.75+0.0j]
+        ])
+        A_np = B_np.conj().T @ B_np + np.eye(4, dtype=complex)
+        b_2d_np = np.array([
+            [1.0+0.0j, 2.0+0.5j, 3.0+1.0j],
+            [4.0+0.0j, 5.0+0.5j, 6.0+1.0j],
+            [7.0+0.0j, 8.0+0.5j, 9.0+1.0j],
+            [10.0+0.0j, 11.0+0.5j, 12.0+1.0j]
+        ])
+        A = modmesh.SimpleArrayComplex128(array=A_np)
+        b_2d = modmesh.SimpleArrayComplex128(array=b_2d_np)
+        x_2d = modmesh.llt_solve(A, b_2d)
+        assert x_2d.shape == (4, 3)
+        x_2d_np = np.array(x_2d)
+        A_np = np.array(A)
+        b_2d_np = np.array(b_2d)
+        Ax_2d_np = A_np @ x_2d_np
+        np.testing.assert_allclose(Ax_2d_np, b_2d_np, rtol=1e-10)
+
+    def test_llt_solve_shape_mismatch_errors(self):
+        # Test 1: A is not square
+        A_rect = modmesh.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0]
+        ]))
+        b = modmesh.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::solve: The first argument a must be a square "
+                r"2D SimpleArray"
+        ):
+            modmesh.llt_solve(A_rect, b)
+
+        # Test 2: A and b dimension mismatch (1D case)
+        A_square = modmesh.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+            [13.0, 14.0, 15.0, 16.0]
+        ]))
+        b_wrong_size = modmesh.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0, 3.0]
+        ))
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::solve: The first argument a and the second "
+                r"argument b dimension mismatch"
+        ):
+            modmesh.llt_solve(A_square, b_wrong_size)
+
+        # Test 3: A and b dimension mismatch (2D case)
+        b_2d_wrong_size = modmesh.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0]
+        ]))
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::solve: The first argument a and the second "
+                r"argument b dimension mismatch"
+        ):
+            modmesh.llt_solve(A_square, b_2d_wrong_size)
+
+        # Test 4: b is 3D (should fail)
+        b_3d = modmesh.SimpleArrayFloat64(array=np.array([
+            [[1.0], [2.0]],
+            [[3.0], [4.0]],
+            [[5.0], [6.0]],
+            [[7.0], [8.0]]
+        ]))
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::solve: The second argument b must be 1D or 2D"
+        ):
+            modmesh.llt_solve(A_square, b_3d)
+
+    def test_llt_solve_non_spd_matrix(self):
+        # Create a non-SPD matrix
+        A_nspd = np.array([
+            [1.0, 2.0],
+            [2.0, 1.0]
+        ])
+        b = modmesh.SimpleArrayFloat64(array=np.array([1.0, 2.0]))
+        A = modmesh.SimpleArrayFloat64(array=A_nspd)
+        with self.assertRaisesRegex(
+                Exception,
+                r"Llt::factorize: Cholesky failed: SimpleArray not "
+                r"\(numerically\) SPD"
+        ):
             modmesh.llt_solve(A, b)


### PR DESCRIPTION
This PR extends the Cholesky-based solver (llt_solve) to handle 2D right-hand sides (multi-RHS), while keeping 1D behavior unchanged.

What’s included

Multi-RHS support: llt_solve(A, b) now accepts b with shape (n, k) and returns x with shape (n, k).

For example:
``` python
# 1D
x = modmesh.llt_solve(A, b_1d)        # shape: (n,)

# 2D
x2 = modmesh.llt_solve(A, B_2d)       # shape: (n, k)
```