### PR TITLE
Add the master include file for linalg module

### DIFF
--- a/cpp/modmesh/linalg/CMakeLists.txt
+++ b/cpp/modmesh/linalg/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 set(MODMESH_LINALG_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/linalg.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/factorization.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/linalg/factorization.hpp
+++ b/cpp/modmesh/linalg/factorization.hpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/buffer/SimpleArray.hpp>
+#include <modmesh/buffer/buffer.hpp>
 
 namespace modmesh
 {

--- a/cpp/modmesh/linalg/linalg.hpp
+++ b/cpp/modmesh/linalg/linalg.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2025, Chun-Shih Chang <austin20463@gmail.com>
+ * Copyright (c) 2025, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,24 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pybind11/pybind11.h> // Must be the first include.
-#include <pybind11/stl.h>
-#include <pybind11/complex.h>
+/**
+ * The interface master header file for the linear algebraic code.
+ */
 
-#include <modmesh/python/common.hpp>
-#include <modmesh/linalg/linalg.hpp>
-
-namespace modmesh
-{
-
-namespace python
-{
-
-void initialize_linalg(pybind11::module & mod);
-void wrap_linalg(pybind11::module & mod);
-
-} /* end namespace python */
-
-} /* end namespace modmesh */
+#include <modmesh/linalg/factorization.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
C++ files outside the module should `#include <modmesh/linalg/linalg.hpp` and should not include the individual files under the directory.