### PR TITLE
Implement element-wise addition and subtraction for `SimpleArray`

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -513,9 +513,19 @@ public:
         return A(*static_cast<A const *>(this)).iadd(other);
     }
 
+    A add(value_type scalar) const
+    {
+        return A(*static_cast<A const *>(this)).iadd(scalar);
+    }
+
     A sub(A const & other) const
     {
         return A(*static_cast<A const *>(this)).isub(other);
+    }
+
+    A sub(value_type scalar) const
+    {
+        return A(*static_cast<A const *>(this)).isub(scalar);
     }
 
     A mul(A const & other) const
@@ -561,6 +571,30 @@ public:
         return *athis;
     }
 
+    A & iadd(value_type scalar)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            const value_type * const end = athis->end();
+            value_type * ptr = athis->begin();
+
+            while (ptr < end)
+            {
+                *ptr += scalar;
+                ++ptr;
+            }
+        }
+        else
+        {
+            if (scalar)
+            {
+                std::fill(athis->begin(), athis->end(), true);
+            }
+        }
+        return *athis;
+    }
+
     A & isub(A const & other)
     {
         auto athis = static_cast<A *>(this);
@@ -575,6 +609,27 @@ public:
                 *ptr -= *other_ptr;
                 ++ptr;
                 ++other_ptr;
+            }
+        }
+        else
+        {
+            throw std::runtime_error(Formatter() << "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+        }
+        return *athis;
+    }
+
+    A & isub(value_type scalar)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            const value_type * const end = athis->end();
+            value_type * ptr = athis->begin();
+
+            while (ptr < end)
+            {
+                *ptr -= scalar;
+                ++ptr;
             }
         }
         else

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -310,8 +310,22 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("max", &wrapped_type::max)
             .def("sum", &wrapped_type::sum)
             .def("abs", &wrapped_type::abs)
-            .def("add", &wrapped_type::add)
-            .def("sub", &wrapped_type::sub)
+            .def(
+                "add",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.add(other); })
+            .def(
+                "add",
+                [](wrapped_type const & self, value_type scalar)
+                { return self.add(scalar); })
+            .def(
+                "sub",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.sub(other); })
+            .def(
+                "sub",
+                [](wrapped_type const & self, value_type scalar)
+                { return self.sub(scalar); })
             .def(
                 "mul",
                 [](wrapped_type const & self, wrapped_type const & other)
@@ -333,10 +347,22 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
              * (e.g., a = a.__iadd__(b)).
              * See: https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
              */
-            .def("iadd", [](wrapped_type & self, wrapped_type const & other)
-                 { self.iadd(other); })
-            .def("isub", [](wrapped_type & self, wrapped_type const & other)
-                 { self.isub(other); })
+            .def(
+                "iadd",
+                [](wrapped_type & self, wrapped_type const & other)
+                { self.iadd(other); })
+            .def(
+                "iadd",
+                [](wrapped_type & self, value_type scalar)
+                { self.iadd(scalar); })
+            .def(
+                "isub",
+                [](wrapped_type & self, wrapped_type const & other)
+                { self.isub(other); })
+            .def(
+                "isub",
+                [](wrapped_type & self, value_type scalar)
+                { self.isub(scalar); })
             .def(
                 "imul",
                 [](wrapped_type & self, wrapped_type const & other)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1587,7 +1587,7 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
 
     def test_add(self):
         # test integer
-        def test_add_type(type):
+        def _check_add_type(type):
             arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
             res = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
@@ -1605,16 +1605,16 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 self.assertEqual(simdres[i], res[i])
                 self.assertEqual(sres[i], nres[i])
 
-        test_add_type('int8')
-        test_add_type('int16')
-        test_add_type('int32')
-        test_add_type('int64')
-        test_add_type('uint8')
-        test_add_type('uint16')
-        test_add_type('uint32')
-        test_add_type('uint64')
-        test_add_type('float32')
-        test_add_type('float64')
+        _check_add_type('int8')
+        _check_add_type('int16')
+        _check_add_type('int32')
+        _check_add_type('int64')
+        _check_add_type('uint8')
+        _check_add_type('uint16')
+        _check_add_type('uint32')
+        _check_add_type('uint64')
+        _check_add_type('float32')
+        _check_add_type('float64')
 
         # test boolean
         arr1 = [True, True, True, False, False, False]
@@ -1632,9 +1632,300 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
             self.assertEqual(sarr1[i], res[i])
             self.assertEqual(sres[i], nres[i])
 
+    def test_add_1d(self):
+        def _check_add_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([2, 3, 4, 5, 6, 7, 8, 9], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.add(narr1, narr2)
+            sres = sarr1.add(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.iadd(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_add_1d_type('int8')
+        _check_add_1d_type('int16')
+        _check_add_1d_type('int32')
+        _check_add_1d_type('int64')
+        _check_add_1d_type('uint8')
+        _check_add_1d_type('uint16')
+        _check_add_1d_type('uint32')
+        _check_add_1d_type('uint64')
+        _check_add_1d_type('float32')
+        _check_add_1d_type('float64')
+
+        # bool
+        narr1 = np.array([True, True, False, False, True, False, True, False],
+                         dtype='bool')
+        narr2 = np.array([True, False, True, False, True, False, True, False],
+                         dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        nres = np.add(narr1, narr2)
+        sres = sarr1.add(sarr2)
+        for i in range(len(narr1)):
+            self.assertEqual(sres[i], nres[i])
+        sarr1.iadd(sarr2)
+        for i in range(len(narr1)):
+            self.assertEqual(sarr1[i], nres[i])
+
+    def test_add_2d(self):
+        def _check_add_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[2, 2, 2, 2],
+                              [3, 3, 3, 3],
+                              [4, 4, 4, 4]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.add(narr1, narr2)
+            sres = sarr1.add(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.iadd(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_add_2d_type('int8')
+        _check_add_2d_type('int16')
+        _check_add_2d_type('int32')
+        _check_add_2d_type('int64')
+        _check_add_2d_type('uint8')
+        _check_add_2d_type('uint16')
+        _check_add_2d_type('uint32')
+        _check_add_2d_type('uint64')
+        _check_add_2d_type('float32')
+        _check_add_2d_type('float64')
+
+        # bool
+        narr1 = np.array([[True, False, True, False],
+                          [False, True, False, True],
+                          [True, True, False, False]], dtype='bool')
+        narr2 = np.array([[True, True, False, False],
+                          [False, False, True, True],
+                          [True, False, True, False]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        nres = np.add(narr1, narr2)
+        sres = sarr1.add(sarr2)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                self.assertEqual(sres[i, j], nres[i, j])
+        sarr1.iadd(sarr2)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                self.assertEqual(sarr1[i, j], nres[i, j])
+
+    def test_add_3d(self):
+        def _check_add_3d_type(type):
+            narr1 = np.array([[[1, 2],
+                               [3, 4]],
+                              [[5, 6],
+                               [7, 8]]], dtype=type)
+            narr2 = np.array([[[2, 2],
+                               [2, 2]],
+                              [[3, 3],
+                               [3, 3]]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.add(narr1, narr2)
+            sres = sarr1.add(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.iadd(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_add_3d_type('int8')
+        _check_add_3d_type('int16')
+        _check_add_3d_type('int32')
+        _check_add_3d_type('int64')
+        _check_add_3d_type('uint8')
+        _check_add_3d_type('uint16')
+        _check_add_3d_type('uint32')
+        _check_add_3d_type('uint64')
+        _check_add_3d_type('float32')
+        _check_add_3d_type('float64')
+
+        # bool
+        narr1 = np.array([[[True, False],
+                           [False, True]],
+                          [[True, True],
+                           [False, False]]], dtype='bool')
+        narr2 = np.array([[[False, True],
+                           [True, False]],
+                          [[True, False],
+                           [True, False]]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        nres = np.add(narr1, narr2)
+        sres = sarr1.add(sarr2)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                for k in range(narr1.shape[2]):
+                    self.assertEqual(sres[i, j, k], nres[i, j, k])
+        sarr1.iadd(sarr2)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                for k in range(narr1.shape[2]):
+                    self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+    def test_add_scalar_1d(self):
+        def _check_add_scalar_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.add(narr1, scalar)
+            sres = sarr1.add(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.iadd(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_add_scalar_1d_type('int8')
+        _check_add_scalar_1d_type('int16')
+        _check_add_scalar_1d_type('int32')
+        _check_add_scalar_1d_type('int64')
+        _check_add_scalar_1d_type('uint8')
+        _check_add_scalar_1d_type('uint16')
+        _check_add_scalar_1d_type('uint32')
+        _check_add_scalar_1d_type('uint64')
+        _check_add_scalar_1d_type('float32')
+        _check_add_scalar_1d_type('float64')
+
+        # bool
+        narr1 = np.array([True, False, True, False, True, False, True, False],
+                         dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        nres = np.add(narr1, scalar)
+        sres = sarr1.add(scalar)
+        for i in range(len(narr1)):
+            self.assertEqual(sres[i], nres[i])
+        sarr1.iadd(scalar)
+        for i in range(len(narr1)):
+            self.assertEqual(sarr1[i], nres[i])
+
+    def test_add_scalar_2d(self):
+        def _check_add_scalar_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.add(narr1, scalar)
+            sres = sarr1.add(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.iadd(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_add_scalar_2d_type('int8')
+        _check_add_scalar_2d_type('int16')
+        _check_add_scalar_2d_type('int32')
+        _check_add_scalar_2d_type('int64')
+        _check_add_scalar_2d_type('uint8')
+        _check_add_scalar_2d_type('uint16')
+        _check_add_scalar_2d_type('uint32')
+        _check_add_scalar_2d_type('uint64')
+        _check_add_scalar_2d_type('float32')
+        _check_add_scalar_2d_type('float64')
+
+        # bool
+        narr1 = np.array([[True, False, True, False],
+                          [False, True, False, True],
+                          [True, True, False, False]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        nres = np.add(narr1, scalar)
+        sres = sarr1.add(scalar)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                self.assertEqual(sres[i, j], nres[i, j])
+        sarr1.iadd(scalar)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                self.assertEqual(sarr1[i, j], nres[i, j])
+
+    def test_add_scalar_3d(self):
+        def _check_add_scalar_3d_type(type):
+            narr1 = np.array([[[1, 2],
+                               [3, 4]],
+                              [[5, 6],
+                               [7, 8]]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.add(narr1, scalar)
+            sres = sarr1.add(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.iadd(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_add_scalar_3d_type('int8')
+        _check_add_scalar_3d_type('int16')
+        _check_add_scalar_3d_type('int32')
+        _check_add_scalar_3d_type('int64')
+        _check_add_scalar_3d_type('uint8')
+        _check_add_scalar_3d_type('uint16')
+        _check_add_scalar_3d_type('uint32')
+        _check_add_scalar_3d_type('uint64')
+        _check_add_scalar_3d_type('float32')
+        _check_add_scalar_3d_type('float64')
+
+        # bool
+        narr1 = np.array([[[True, False],
+                           [False, True]],
+                          [[True, True],
+                           [False, False]]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        nres = np.add(narr1, scalar)
+        sres = sarr1.add(scalar)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                for k in range(narr1.shape[2]):
+                    self.assertEqual(sres[i, j, k], nres[i, j, k])
+        sarr1.iadd(scalar)
+        for i in range(narr1.shape[0]):
+            for j in range(narr1.shape[1]):
+                for k in range(narr1.shape[2]):
+                    self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
     def test_sub(self):
         # test integer
-        def test_sub_type(type):
+        def _check_sub_type(type):
             arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
             narr1 = np.array(arr1, dtype=type)
@@ -1651,16 +1942,16 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 self.assertEqual(simdres[i], arr1[i])
                 self.assertEqual(sres[i], nres[i])
 
-        test_sub_type('int8')
-        test_sub_type('int16')
-        test_sub_type('int32')
-        test_sub_type('int64')
-        test_sub_type('uint8')
-        test_sub_type('uint16')
-        test_sub_type('uint32')
-        test_sub_type('uint64')
-        test_sub_type('float32')
-        test_sub_type('float64')
+        _check_sub_type('int8')
+        _check_sub_type('int16')
+        _check_sub_type('int32')
+        _check_sub_type('int64')
+        _check_sub_type('uint8')
+        _check_sub_type('uint16')
+        _check_sub_type('uint32')
+        _check_sub_type('uint64')
+        _check_sub_type('float32')
+        _check_sub_type('float64')
 
         # test boolean
         arr1 = [True, True, True, False, False, False]
@@ -1683,8 +1974,317 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         ):
             sarr2.isub(sarr1)
 
+    def test_sub_1d(self):
+        def _check_sub_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([2, 3, 4, 5, 6, 7, 8, 9], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr1, narr2)
+            sres = sarr1.sub(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.isub(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_sub_1d_type('int8')
+        _check_sub_1d_type('int16')
+        _check_sub_1d_type('int32')
+        _check_sub_1d_type('int64')
+        _check_sub_1d_type('uint8')
+        _check_sub_1d_type('uint16')
+        _check_sub_1d_type('uint32')
+        _check_sub_1d_type('uint64')
+        _check_sub_1d_type('float32')
+        _check_sub_1d_type('float64')
+
+        # bool
+        narr1 = np.array([True, True, False, False, True, False, True, False],
+                         dtype='bool')
+        narr2 = np.array([True, False, True, False, True, False, True, False],
+                         dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(sarr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(sarr2)
+
+    def test_sub_2d(self):
+        def _check_sub_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[2, 2, 2, 2],
+                              [3, 3, 3, 3],
+                              [4, 4, 4, 4]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr1, narr2)
+            sres = sarr1.sub(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.isub(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_sub_2d_type('int8')
+        _check_sub_2d_type('int16')
+        _check_sub_2d_type('int32')
+        _check_sub_2d_type('int64')
+        _check_sub_2d_type('uint8')
+        _check_sub_2d_type('uint16')
+        _check_sub_2d_type('uint32')
+        _check_sub_2d_type('uint64')
+        _check_sub_2d_type('float32')
+        _check_sub_2d_type('float64')
+
+        # bool
+        narr1 = np.array([[True, False, True, False],
+                          [False, True, False, True],
+                          [True, True, False, False]], dtype='bool')
+        narr2 = np.array([[True, True, False, False],
+                          [False, False, True, True],
+                          [True, False, True, False]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(sarr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(sarr2)
+
+    def test_sub_3d(self):
+        def _check_sub_3d_type(type):
+            narr1 = np.array([[[1, 2],
+                               [3, 4]],
+                              [[5, 6],
+                               [7, 8]]], dtype=type)
+            narr2 = np.array([[[2, 2],
+                               [2, 2]],
+                              [[3, 3],
+                               [3, 3]]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr1, narr2)
+            sres = sarr1.sub(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.isub(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_sub_3d_type('int8')
+        _check_sub_3d_type('int16')
+        _check_sub_3d_type('int32')
+        _check_sub_3d_type('int64')
+        _check_sub_3d_type('uint8')
+        _check_sub_3d_type('uint16')
+        _check_sub_3d_type('uint32')
+        _check_sub_3d_type('uint64')
+        _check_sub_3d_type('float32')
+        _check_sub_3d_type('float64')
+
+        # bool
+        narr1 = np.array([[[True, False],
+                           [False, True]],
+                          [[True, True],
+                           [False, False]]], dtype='bool')
+        narr2 = np.array([[[False, True],
+                           [True, False]],
+                          [[True, False],
+                           [True, False]]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(sarr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(sarr2)
+
+    def test_sub_scalar_1d(self):
+        def _check_sub_scalar_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.isub(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_sub_scalar_1d_type('int8')
+        _check_sub_scalar_1d_type('int16')
+        _check_sub_scalar_1d_type('int32')
+        _check_sub_scalar_1d_type('int64')
+        _check_sub_scalar_1d_type('uint8')
+        _check_sub_scalar_1d_type('uint16')
+        _check_sub_scalar_1d_type('uint32')
+        _check_sub_scalar_1d_type('uint64')
+        _check_sub_scalar_1d_type('float32')
+        _check_sub_scalar_1d_type('float64')
+
+        # bool
+        narr1 = np.array([True, False, True, False, True, False, True, False],
+                         dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(scalar)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(scalar)
+
+    def test_sub_scalar_2d(self):
+        def _check_sub_scalar_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.isub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_sub_scalar_2d_type('int8')
+        _check_sub_scalar_2d_type('int16')
+        _check_sub_scalar_2d_type('int32')
+        _check_sub_scalar_2d_type('int64')
+        _check_sub_scalar_2d_type('uint8')
+        _check_sub_scalar_2d_type('uint16')
+        _check_sub_scalar_2d_type('uint32')
+        _check_sub_scalar_2d_type('uint64')
+        _check_sub_scalar_2d_type('float32')
+        _check_sub_scalar_2d_type('float64')
+
+        # bool
+        narr1 = np.array([[True, False, True, False],
+                          [False, True, False, True],
+                          [True, True, False, False]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(scalar)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(scalar)
+
+    def test_sub_scalar_3d(self):
+        def _check_sub_scalar_3d_type(type):
+            narr1 = np.array([[[1, 2],
+                               [3, 4]],
+                              [[5, 6],
+                               [7, 8]]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.isub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_sub_scalar_3d_type('int8')
+        _check_sub_scalar_3d_type('int16')
+        _check_sub_scalar_3d_type('int32')
+        _check_sub_scalar_3d_type('int64')
+        _check_sub_scalar_3d_type('uint8')
+        _check_sub_scalar_3d_type('uint16')
+        _check_sub_scalar_3d_type('uint32')
+        _check_sub_scalar_3d_type('uint64')
+        _check_sub_scalar_3d_type('float32')
+        _check_sub_scalar_3d_type('float64')
+
+        # bool
+        narr1 = np.array([[[True, False],
+                           [False, True]],
+                          [[True, True],
+                           [False, False]]], dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        scalar = True
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.sub(scalar)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr1.isub(scalar)
+
     def test_mul(self):
-        def test_mul_type(type):
+        def _check_mul_type(type):
             arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
             res = [2, 8, 18, 32, 50, 72, 98, 128, 162, 200]
@@ -1702,15 +2302,15 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 self.assertEqual(simdres[i], res[i])
                 self.assertEqual(sres[i], nres[i])
 
-        test_mul_type('int16')
-        test_mul_type('int32')
-        test_mul_type('int64')
-        test_mul_type('uint8')
-        test_mul_type('uint16')
-        test_mul_type('uint32')
-        test_mul_type('uint64')
-        test_mul_type('float32')
-        test_mul_type('float64')
+        _check_mul_type('int16')
+        _check_mul_type('int32')
+        _check_mul_type('int64')
+        _check_mul_type('uint8')
+        _check_mul_type('uint16')
+        _check_mul_type('uint32')
+        _check_mul_type('uint64')
+        _check_mul_type('float32')
+        _check_mul_type('float64')
 
         # test boolean
         arr1 = [True, True, True, False, False, False]
@@ -1729,7 +2329,7 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
             self.assertEqual(sres[i], nres[i])
 
     def test_mul_1d(self):
-        def test_mul_1d_type(type):
+        def _check_mul_1d_type(type):
             narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
             narr2 = np.array([2, 3, 4, 5, 6, 7, 8, 9], dtype=type)
             sarr1 = self.type_convertor(type)(array=narr1)
@@ -1744,13 +2344,13 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
             for i in range(len(narr1)):
                 self.assertEqual(sarr1[i], nres[i])
 
-        test_mul_1d_type('int32')
-        test_mul_1d_type('int64')
-        test_mul_1d_type('float32')
-        test_mul_1d_type('float64')
+        _check_mul_1d_type('int32')
+        _check_mul_1d_type('int64')
+        _check_mul_1d_type('float32')
+        _check_mul_1d_type('float64')
 
     def test_mul_2d(self):
-        def test_mul_2d_type(type):
+        def _check_mul_2d_type(type):
             narr1 = np.array([[1, 2, 3, 4],
                               [5, 6, 7, 8],
                               [9, 10, 11, 12]], dtype=type)
@@ -1771,13 +2371,13 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 for j in range(narr1.shape[1]):
                     self.assertEqual(sarr1[i, j], nres[i, j])
 
-        test_mul_2d_type('int32')
-        test_mul_2d_type('int64')
-        test_mul_2d_type('float32')
-        test_mul_2d_type('float64')
+        _check_mul_2d_type('int32')
+        _check_mul_2d_type('int64')
+        _check_mul_2d_type('float32')
+        _check_mul_2d_type('float64')
 
     def test_mul_3d(self):
-        def test_mul_3d_type(type):
+        def _check_mul_3d_type(type):
             narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
             narr2 = np.arange(1, 25, dtype=type).reshape((2, 3, 4))
             sarr1 = self.type_convertor(type)(array=narr1)
@@ -1796,14 +2396,14 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                     for k in range(narr1.shape[2]):
                         self.assertEqual(sarr1[i, j, k], nres[i, j, k])
 
-        test_mul_3d_type('int32')
-        test_mul_3d_type('int64')
-        test_mul_3d_type('float32')
-        test_mul_3d_type('float64')
+        _check_mul_3d_type('int32')
+        _check_mul_3d_type('int64')
+        _check_mul_3d_type('float32')
+        _check_mul_3d_type('float64')
 
     def test_mul_scalar_1d(self):
         """Test 1D array scalar multiplication"""
-        def test_mul_scalar_1d_type(type):
+        def _check_mul_scalar_1d_type(type):
             narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
             sarr1 = self.type_convertor(type)(array=narr1)
             scalar = 3
@@ -1818,14 +2418,14 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
             for i in range(len(narr1)):
                 self.assertEqual(sarr1[i], nres[i])
 
-        test_mul_scalar_1d_type('int32')
-        test_mul_scalar_1d_type('int64')
-        test_mul_scalar_1d_type('float32')
-        test_mul_scalar_1d_type('float64')
+        _check_mul_scalar_1d_type('int32')
+        _check_mul_scalar_1d_type('int64')
+        _check_mul_scalar_1d_type('float32')
+        _check_mul_scalar_1d_type('float64')
 
     def test_mul_scalar_2d(self):
         """Test 2D array (matrix) scalar multiplication"""
-        def test_mul_scalar_2d_type(type):
+        def _check_mul_scalar_2d_type(type):
             narr1 = np.array([[1, 2, 3, 4],
                               [5, 6, 7, 8],
                               [9, 10, 11, 12]], dtype=type)
@@ -1843,14 +2443,14 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 for j in range(narr1.shape[1]):
                     self.assertEqual(sarr1[i, j], nres[i, j])
 
-        test_mul_scalar_2d_type('int32')
-        test_mul_scalar_2d_type('int64')
-        test_mul_scalar_2d_type('float32')
-        test_mul_scalar_2d_type('float64')
+        _check_mul_scalar_2d_type('int32')
+        _check_mul_scalar_2d_type('int64')
+        _check_mul_scalar_2d_type('float32')
+        _check_mul_scalar_2d_type('float64')
 
     def test_mul_scalar_3d(self):
         """Test 3D array scalar multiplication"""
-        def test_mul_scalar_3d_type(type):
+        def _check_mul_scalar_3d_type(type):
             narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
             sarr1 = self.type_convertor(type)(array=narr1)
             scalar = 5
@@ -1868,16 +2468,16 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                     for k in range(narr1.shape[2]):
                         self.assertEqual(sarr1[i, j, k], nres[i, j, k])
 
-        test_mul_scalar_3d_type('int32')
-        test_mul_scalar_3d_type('int64')
-        test_mul_scalar_3d_type('float32')
-        test_mul_scalar_3d_type('float64')
+        _check_mul_scalar_3d_type('int32')
+        _check_mul_scalar_3d_type('int64')
+        _check_mul_scalar_3d_type('float32')
+        _check_mul_scalar_3d_type('float64')
 
     def test_div(self):
         arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
 
-        def test_div_type(type):
+        def _check_div_type(type):
             res = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
             narr1 = np.array(arr1, dtype=type)
             narr2 = np.array(arr2, dtype=type)
@@ -1893,14 +2493,14 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                 self.assertEqual(simdres[i], res[i])
                 self.assertEqual(sres[i], nres[i])
 
-        test_div_type('int8')
-        test_div_type('int16')
-        test_div_type('int32')
-        test_div_type('int64')
-        test_div_type('uint8')
-        test_div_type('uint16')
-        test_div_type('uint32')
-        test_div_type('uint64')
+        _check_div_type('int8')
+        _check_div_type('int16')
+        _check_div_type('int32')
+        _check_div_type('int64')
+        _check_div_type('uint8')
+        _check_div_type('uint16')
+        _check_div_type('uint32')
+        _check_div_type('uint64')
 
         # test float
         res = [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0]


### PR DESCRIPTION
 ## Summary

This PR implements scalar-matrix addition and subtraction operations for `SimpleArray`, enabling scalar values to be added or subtracted to all array elements using `add/iadd(scalar)` and `sub/isub(scalar)` methods.

  ## Key Changes
  - Added scalar overload for `add/iadd` and `sub/isub` in `SimpleArray.hpp`
  - Updated Python bindings in `wrap_SimpleArray.cpp` for scalar addition/subtraction support
  - Added unit tests for 1D, 2D, and 3D arrays with multiple data types including boolean.

## Related Issues
- #588