### PR TITLE
Extend element wise subtraction

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -518,6 +518,11 @@ public:
         return A(*static_cast<A const *>(this)).isub(other);
     }
 
+    A sub(value_type scalar) const
+    {
+        return A(*static_cast<A const *>(this)).isub(scalar);
+    }
+
     A mul(A const & other) const
     {
         return A(*static_cast<A const *>(this)).imul(other);
@@ -575,6 +580,27 @@ public:
                 *ptr -= *other_ptr;
                 ++ptr;
                 ++other_ptr;
+            }
+        }
+        else
+        {
+            throw std::runtime_error(Formatter() << "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+        }
+        return *athis;
+    }
+
+    A & isub(value_type scalar)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            const value_type * const end = athis->end();
+            value_type * ptr = athis->begin();
+
+            while (ptr < end)
+            {
+                *ptr -= scalar;
+                ++ptr;
             }
         }
         else

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -311,7 +311,14 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("sum", &wrapped_type::sum)
             .def("abs", &wrapped_type::abs)
             .def("add", &wrapped_type::add)
-            .def("sub", &wrapped_type::sub)
+            .def(
+                "sub",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.sub(other); })
+            .def(
+                "sub",
+                [](wrapped_type const & self, value_type scalar)
+                { return self.sub(scalar); })
             .def(
                 "mul",
                 [](wrapped_type const & self, wrapped_type const & other)
@@ -335,8 +342,14 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
              */
             .def("iadd", [](wrapped_type & self, wrapped_type const & other)
                  { self.iadd(other); })
-            .def("isub", [](wrapped_type & self, wrapped_type const & other)
-                 { self.isub(other); })
+            .def(
+                "isub",
+                [](wrapped_type & self, wrapped_type const & other)
+                { self.isub(other); })
+            .def(
+                "isub",
+                [](wrapped_type & self, value_type scalar)
+                { self.isub(scalar); })
             .def(
                 "imul",
                 [](wrapped_type & self, wrapped_type const & other)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1683,6 +1683,148 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         ):
             sarr2.isub(sarr1)
 
+    def test_sub_1d(self):
+        def test_sub_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([10, 20, 30, 40, 50, 60, 70, 80], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr2, narr1)
+            sres = sarr2.sub(sarr1)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr2.isub(sarr1)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr2[i], nres[i])
+
+        test_sub_1d_type('int32')
+        test_sub_1d_type('int64')
+        test_sub_1d_type('float32')
+        test_sub_1d_type('float64')
+
+    def test_sub_2d(self):
+        def test_sub_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[10, 20, 30, 40],
+                              [50, 60, 70, 80],
+                              [90, 100, 110, 120]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr2, narr1)
+            sres = sarr2.sub(sarr1)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr2.isub(sarr1)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr2[i, j], nres[i, j])
+
+        test_sub_2d_type('int32')
+        test_sub_2d_type('int64')
+        test_sub_2d_type('float32')
+        test_sub_2d_type('float64')
+
+    def test_sub_3d(self):
+        def test_sub_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            narr2 = np.arange(24, 48, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            nres = np.subtract(narr2, narr1)
+            sres = sarr2.sub(sarr1)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr2.isub(sarr1)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr2[i, j, k], nres[i, j, k])
+
+        test_sub_3d_type('int32')
+        test_sub_3d_type('int64')
+        test_sub_3d_type('float32')
+        test_sub_3d_type('float64')
+
+    def test_sub_scalar_1d(self):
+        def test_sub_scalar_1d_type(type):
+            narr1 = np.array([10, 20, 30, 40, 50, 60, 70, 80], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 5
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.isub(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        test_sub_scalar_1d_type('int32')
+        test_sub_scalar_1d_type('int64')
+        test_sub_scalar_1d_type('float32')
+        test_sub_scalar_1d_type('float64')
+
+    def test_sub_scalar_2d(self):
+        def test_sub_scalar_2d_type(type):
+            narr1 = np.array([[10, 20, 30, 40],
+                              [50, 60, 70, 80],
+                              [90, 100, 110, 120]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 10
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.isub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        test_sub_scalar_2d_type('int32')
+        test_sub_scalar_2d_type('int64')
+        test_sub_scalar_2d_type('float32')
+        test_sub_scalar_2d_type('float64')
+
+    def test_sub_scalar_3d(self):
+        def test_sub_scalar_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            nres = np.subtract(narr1, scalar)
+            sres = sarr1.sub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.isub(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        test_sub_scalar_3d_type('int32')
+        test_sub_scalar_3d_type('int64')
+        test_sub_scalar_3d_type('float32')
+        test_sub_scalar_3d_type('float64')
+
     def test_mul(self):
         def test_mul_type(type):
             arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
 ## Summary

 This PR extends element-wise subtraction operations for `SimpleArray`, adding support for scalar subtraction (array - scalar) across 1D, 2D, and 3D arrays.

  ## Key Changes
  - Added scalar overload for `sub(value_type scalar)` and `isub(value_type scalar)` in `SimpleArray.hpp`
  - Updated Python bindings in `wrap_SimpleArray.cpp` for scalar subtraction support
  - Added unit tests for 1D, 2D, and 3D arrays with multiple data types

## Related Issues
- #588