### PR TITLE
Implement kalman filter

### DIFF
--- a/cpp/modmesh/linalg/CMakeLists.txt
+++ b/cpp/modmesh/linalg/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 set(MODMESH_LINALG_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/linalg.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/factorization.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kalman_filter.hpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_LINALG_SOURCES
@@ -17,7 +18,8 @@ set(MODMESH_LINALG_PYMODHEADERS
 
 set(MODMESH_LINALG_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/linalg_pymod.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_linalg.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_factorization.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_kalman_filter.cpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_LINALG_FILES

--- a/cpp/modmesh/linalg/kalman_filter.hpp
+++ b/cpp/modmesh/linalg/kalman_filter.hpp
@@ -1,0 +1,528 @@
+#pragma once
+
+/*
+ * Copyright (c) 2025, Chun-Shih Chang <austin20463@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/linalg/factorization.hpp>
+#include <modmesh/math/math.hpp>
+
+namespace modmesh
+{
+
+namespace detail
+{
+template <typename T>
+struct select_real_t;
+} /* end namespace detail */
+
+/**
+ * Reference: FilterPy KalmanFilter documentation
+ * https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html
+ */
+template <typename T>
+class KalmanFilter
+{
+
+public:
+
+    using value_type = T;
+    using real_type = typename detail::select_real_t<value_type>::type;
+    using array_type = SimpleArray<T>;
+
+private:
+
+    size_t m_state_size; // state dimension
+    size_t m_measurement_size; // measurement dimension
+    size_t m_control_size; // control dimension
+
+    array_type m_f; // state transition matrix (state_sizexstate_size)
+    array_type m_q; // process noise covariance (state_sizexstate_size)
+    array_type m_h; // measurement matrix (measurement_sizexstate_size)
+    array_type m_r; // measurement noise covariance (measurement_sizexmeasurement_size)
+    array_type m_p; // state covariance (state_sizexstate_size)
+    array_type m_b; // control matrix (state_sizexcontrol_size)
+    array_type m_x; // state vector (state_sizex1)
+    array_type m_i; // identity matrix (state_sizexstate_size)
+
+    real_type m_jitter; // regularization jitter for numerical stability
+
+public:
+
+    /**
+     * @brief Construct a Kalman filter.
+     *
+     * @details
+     * Creates a Kalman filter with the specified system matrices and noise
+     * parameters. The process and measurement noise covariances are created
+     * from scalar variance values (multiplied by identity matrices). The
+     * initial state covariance is set to the identity matrix.
+     *
+     * Control input: an external force or command applied to the system
+     * (e.g., thrust in aircraft, motor command in robot). If the control
+     * matrix B is empty (size 0), control input u is disabled. See
+     * https://kalmanfilter.net/multiExamples.html for examples.
+     *
+     * @param x Initial state vector.
+     * @param f State transition matrix F.
+     * @param b Control matrix B (empty to disable control input u).
+     * @param h Measurement matrix H.
+     * @param process_noise Process noise standard deviation.
+     * @param measurement_noise Measurement noise standard deviation.
+     * @param jitter Numerical stability jitter.
+     */
+    KalmanFilter(
+        array_type const & x,
+        array_type const & f,
+        array_type const & b,
+        array_type const & h,
+        real_type process_noise,
+        real_type measurement_noise,
+        real_type jitter)
+        : m_state_size(x.shape(0))
+        , m_measurement_size(h.shape(0))
+        , m_control_size((b.ndim() == 2) ? b.shape(1) : 0)
+        , m_f(f)
+        , m_q(create_noise_matrix(m_state_size, process_noise * process_noise))
+        , m_h(h)
+        , m_r(create_noise_matrix(m_measurement_size, measurement_noise * measurement_noise))
+        , m_p(array_type::eye(m_state_size))
+        , m_b(b)
+        , m_x(x)
+        , m_i(array_type::eye(m_state_size))
+        , m_jitter(jitter)
+    {
+        check_dimensions();
+    }
+
+    array_type const & state() const { return m_x; }
+    array_type const & covariance() const { return m_p; }
+
+    /**
+     * @brief Predict step without control input u.
+     *
+     * @details
+     * Advances the state using only the transition model and process noise.
+     * Represents a passive system with no external actuation.
+     *
+     * @note Common in finance, tracking, or passive simulation tasks.
+     *
+     * @see predict(const array_type&), update(const array_type&)
+     */
+    void predict()
+    {
+        // x <- F x  (m_x <- m_f @ m_x)
+        predict_state();
+
+        // P <- F P F^H + Q  (m_p <- m_f @ m_p @ m_f^H + m_q)
+        predict_covariance();
+
+        // P <- 0.5(P + P^H)  (m_p <- 0.5(m_p + m_p^H))
+        m_p = symmetrize(m_p);
+    }
+
+    /**
+     * @brief Predict step with control input u.
+     *
+     * @details
+     * Updates the state while applying a known control SimpleArray.
+     * The control term affects only the state mean.
+     *
+     * @note Example: in a vehicle model, the state may contain position and velocity,
+     * while the control input represents acceleration (throttle or brake). The
+     * control term updates how the state evolves between sensor measurements.
+     *
+     * @param u Control input.
+     *
+     * @see predict(), update(const array_type&)
+     */
+    void predict(array_type const & u)
+    {
+        check_control(u);
+
+        // x <- F x + B u  (m_x <- m_f @ m_x + m_b @ u)
+        predict_state(u);
+
+        // P <- F P F^H + Q  (m_p <- m_f @ m_p @ m_f^H + m_q)
+        predict_covariance();
+
+        // P <- 0.5(P + P^H)  (m_p <- 0.5(m_p + m_p^H))
+        m_p = symmetrize(m_p);
+    }
+
+    /**
+     * @brief Update step (measurement correction).
+     *
+     * @details
+     * Incorporates a new measurement to refine the predicted state and covariance
+     * using the Kalman gain.
+     *
+     * @param z Measurement input.
+     *
+     * @see predict(), predict(const array_type&)
+     */
+    void update(array_type const & z)
+    {
+        check_measurement(z);
+
+        // y <- z - H x  (y <- z - m_h @ m_x)
+        array_type y = innovation(z);
+
+        // S <- H P H^H + R + jitter I  (s <- m_h @ m_p @ m_h^H + m_r + m_jitter @ I)
+        array_type s = innovation_covariance();
+
+        // K <- P H^H S^{-1} via LLT solve  (k <- m_p @ m_h^H @ s^{-1})
+        array_type k = kalman_gain(s);
+
+        // x <- x + K y  (m_x <- m_x + k @ y)
+        update_state(k, y);
+
+        // P <- (I-K H) P (I-K H)^H + K R K^H  (m_p <- (I-k@m_h) @ m_p @ (I-k@m_h)^H + k @ m_r @ k^H)
+        update_covariance(k);
+    }
+
+private:
+
+    static array_type create_noise_matrix(size_t size, real_type noise_var)
+    {
+        return array_type::eye(size).mul(static_cast<T>(noise_var));
+    }
+    void check_dimensions();
+    void check_measurement(array_type const & z);
+    void check_control(array_type const & u);
+    static array_type symmetrize(array_type const & p);
+    static array_type hermitian(array_type const & a);
+
+    // Predict
+    void predict_state();
+    void predict_state(array_type const & u);
+    void predict_covariance();
+
+    // Update
+    array_type innovation(array_type const & z);
+    array_type innovation_covariance();
+    array_type kalman_gain(array_type const & s);
+    void update_state(array_type const & k, array_type const & y);
+    void update_covariance(array_type const & k);
+
+}; /* end class KalmanFilter */
+
+template <typename T>
+void KalmanFilter<T>::check_dimensions()
+{
+    if (m_f.ndim() != 2 || m_f.shape(0) != m_state_size || m_f.shape(1) != m_state_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The state transition SimpleArray f must be state_sizexstate_size, but got shape (";
+        for (ssize_t i = 0; i < m_f.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_f.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (m_h.ndim() != 2 || m_h.shape(0) != m_measurement_size || m_h.shape(1) != m_state_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The measurement SimpleArray h must be measurement_sizexstate_size, but got shape (";
+        for (ssize_t i = 0; i < m_h.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_h.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (m_q.ndim() != 2 || m_q.shape(0) != m_state_size || m_q.shape(1) != m_state_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The process noise covariance SimpleArray q must be state_sizexstate_size, but got shape (";
+        for (ssize_t i = 0; i < m_q.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_q.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (m_r.ndim() != 2 || m_r.shape(0) != m_measurement_size || m_r.shape(1) != m_measurement_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The measurement noise covariance SimpleArray r must be measurement_sizexmeasurement_size, but got shape (";
+        for (ssize_t i = 0; i < m_r.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_r.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (m_p.ndim() != 2 || m_p.shape(0) != m_state_size || m_p.shape(1) != m_state_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The state covariance SimpleArray p must be state_sizexstate_size, but got shape (";
+        for (ssize_t i = 0; i < m_p.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_p.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+    if (m_x.ndim() != 1 || m_x.shape(0) != m_state_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_dimensions: The state SimpleArray x must be 1D of length state_size, but got shape (";
+        for (ssize_t i = 0; i < m_x.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << m_x.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+
+    if (m_control_size > 0)
+    {
+        if (m_b.ndim() != 2)
+        {
+            Formatter oss;
+            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be 2D when control_size > 0, but got " << m_b.ndim() << "D";
+            throw std::invalid_argument(oss.str());
+        }
+        if (m_b.shape(0) != m_state_size || m_b.shape(1) != m_control_size)
+        {
+            Formatter oss;
+            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizexcontrol_size, but got shape (";
+            for (ssize_t i = 0; i < m_b.ndim(); ++i)
+            {
+                if (i > 0)
+                {
+                    oss << ", ";
+                }
+                oss << m_b.shape(i);
+            }
+            oss << ")";
+            throw std::invalid_argument(oss.str());
+        }
+    }
+    else
+    {
+        if (m_b.ndim() != 2 || m_b.shape(1) != 0)
+        {
+            Formatter oss;
+            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizex0 when control_size = 0, but got shape (";
+            for (ssize_t i = 0; i < m_b.ndim(); ++i)
+            {
+                if (i > 0)
+                {
+                    oss << ", ";
+                }
+                oss << m_b.shape(i);
+            }
+            oss << ")";
+            throw std::invalid_argument(oss.str());
+        }
+    }
+}
+
+template <typename T>
+void KalmanFilter<T>::predict_state()
+{
+    // x <- F x  (m_x <- m_f @ m_x)
+    array_type x_col = m_x.reshape(small_vector<size_t>{m_state_size, 1});
+    x_col = m_f.matmul(x_col);
+    m_x = x_col.reshape(small_vector<size_t>{m_state_size});
+}
+
+template <typename T>
+void KalmanFilter<T>::predict_state(array_type const & u)
+{
+    // x <- F x + B u  (m_x <- m_f @ m_x + m_b @ u)
+    array_type x_col = m_x.reshape(small_vector<size_t>{m_state_size, 1});
+    array_type u_col = u.reshape(small_vector<size_t>{m_control_size, 1});
+    x_col = m_f.matmul(x_col).add(m_b.matmul(u_col));
+    m_x = x_col.reshape(small_vector<size_t>{m_state_size});
+}
+
+template <typename T>
+void KalmanFilter<T>::predict_covariance()
+{
+    // P <- F P F^H + Q  (m_p <- m_f @ m_p @ m_f^H + m_q)
+    array_type f_h = hermitian(m_f);
+    m_p = m_f.matmul(m_p).matmul(f_h).add(m_q);
+}
+
+template <typename T>
+typename KalmanFilter<T>::array_type KalmanFilter<T>::symmetrize(array_type const & p)
+{
+    // P <- 0.5(P + P^H)  (p <- 0.5(p + p^H))
+    array_type p_h = p;
+    hermitian(p_h);
+    return p.add(p_h).mul(static_cast<T>(0.5));
+}
+
+template <typename T>
+void KalmanFilter<T>::check_measurement(array_type const & z)
+{
+    if (z.ndim() != 1 || z.shape(0) != m_measurement_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_measurement: The measurement SimpleArray z must be 1D of length measurement_size (" << m_measurement_size << "), but got shape (";
+        for (ssize_t i = 0; i < z.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << z.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+}
+
+template <typename T>
+void KalmanFilter<T>::check_control(array_type const & u)
+{
+    if (m_control_size == 0)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_control: Control input not supported: control_size is 0";
+        throw std::invalid_argument(oss.str());
+    }
+    if (u.ndim() != 1 || u.shape(0) != m_control_size)
+    {
+        Formatter oss;
+        oss << "KalmanFilter::check_control: The control SimpleArray u must be 1D of length control_size (" << m_control_size << "), but got shape (";
+        for (ssize_t i = 0; i < u.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                oss << ", ";
+            }
+            oss << u.shape(i);
+        }
+        oss << ")";
+        throw std::invalid_argument(oss.str());
+    }
+}
+
+template <typename T>
+typename KalmanFilter<T>::array_type KalmanFilter<T>::innovation(array_type const & z)
+{
+    // y <- z - H x  (y <- z - m_h @ m_x)
+    array_type x_col = m_x.reshape(small_vector<size_t>{m_state_size, 1});
+    array_type hx = m_h.matmul(x_col);
+    array_type hx_vec = hx.reshape(small_vector<size_t>{m_measurement_size});
+    return z.sub(hx_vec);
+}
+
+template <typename T>
+typename KalmanFilter<T>::array_type KalmanFilter<T>::innovation_covariance()
+{
+    // S <- H P H^H + R + jitter I  (s <- m_h @ m_p @ m_h^H + m_r + m_jitter @ I)
+    array_type h_h = hermitian(m_h);
+    array_type hph_h = m_h.matmul(m_p).matmul(h_h);
+    array_type s = hph_h.add(m_r).add(create_noise_matrix(m_measurement_size, m_jitter));
+
+    // S <- 0.5(S + S^H)  (s <- 0.5(s + s^H))
+    return symmetrize(s);
+}
+
+template <typename T>
+typename KalmanFilter<T>::array_type KalmanFilter<T>::kalman_gain(array_type const & s)
+{
+    // K <- P H^H S^{-1} via LLT solve
+    array_type B = m_h.matmul(m_p); // H@P = B
+    array_type X = llt_solve(s, B); // S@X = B
+    return hermitian(X); // K = X^H
+}
+
+template <typename T>
+void KalmanFilter<T>::update_state(array_type const & k, array_type const & y)
+{
+    // x <- x + K y  (m_x <- m_x + k @ y)
+    array_type y_col = y.reshape(small_vector<size_t>{m_measurement_size, 1});
+    array_type ky = k.matmul(y_col);
+    array_type ky_vec = ky.reshape(small_vector<size_t>{m_state_size});
+    m_x = m_x.add(ky_vec);
+}
+
+template <typename T>
+void KalmanFilter<T>::update_covariance(array_type const & k)
+{
+    // P <- (I-K H) P (I-K H)^H + K R K^H  (m_p <- (I-k@m_h)@m_p@(I-k@m_h)^H + k@m_r@k^H)
+    array_type kh = k.matmul(m_h);
+    array_type i_minus_kh = m_i.sub(kh);
+    array_type i_minus_kh_h = hermitian(i_minus_kh);
+    array_type k_h = hermitian(k);
+    array_type term1 = i_minus_kh.matmul(m_p).matmul(i_minus_kh_h);
+    array_type term2 = k.matmul(m_r).matmul(k_h);
+    m_p = term1.add(term2);
+
+    // P <- 0.5(P + P^H)  (m_p <- 0.5(m_p + m_p^H))
+    m_p = symmetrize(m_p);
+}
+
+template <typename T>
+typename KalmanFilter<T>::array_type KalmanFilter<T>::hermitian(array_type const & a)
+{
+    array_type out = a;
+    out.transpose();
+    if constexpr (is_complex_v<T>)
+    {
+        for (auto ptr = out.begin(); ptr != out.end(); ++ptr)
+        {
+            *ptr = ptr->conj();
+        }
+    }
+    return out;
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/linalg.hpp
+++ b/cpp/modmesh/linalg/linalg.hpp
@@ -33,5 +33,6 @@
  */
 
 #include <modmesh/linalg/factorization.hpp>
+#include <modmesh/linalg/kalman_filter.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/pymod/linalg_pymod.cpp
+++ b/cpp/modmesh/linalg/pymod/linalg_pymod.cpp
@@ -47,7 +47,8 @@ void initialize_linalg(pybind11::module & mod)
 {
     auto initialize_impl = [](pybind11::module & mod)
     {
-        wrap_linalg(mod);
+        wrap_factorization(mod);
+        wrap_kalman_filter(mod);
     };
 
     OneTimeInitializer<linalg_pymod_tag>::me()(mod, initialize_impl);

--- a/cpp/modmesh/linalg/pymod/linalg_pymod.hpp
+++ b/cpp/modmesh/linalg/pymod/linalg_pymod.hpp
@@ -42,7 +42,8 @@ namespace python
 {
 
 void initialize_linalg(pybind11::module & mod);
-void wrap_linalg(pybind11::module & mod);
+void wrap_factorization(pybind11::module & mod);
+void wrap_kalman_filter(pybind11::module & mod);
 
 } /* end namespace python */
 

--- a/cpp/modmesh/linalg/pymod/wrap_factorization.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_factorization.cpp
@@ -53,17 +53,17 @@ void def_llt_solve(pybind11::module & mod)
         pybind11::arg("b"));
 }
 
-void wrap_linalg(pybind11::module & mod)
+void wrap_factorization(pybind11::module & mod)
 {
-    def_llt_factorization<double>(mod);
     def_llt_factorization<float>(mod);
-    def_llt_factorization<Complex<double>>(mod);
+    def_llt_factorization<double>(mod);
     def_llt_factorization<Complex<float>>(mod);
+    def_llt_factorization<Complex<double>>(mod);
 
-    def_llt_solve<double>(mod);
     def_llt_solve<float>(mod);
-    def_llt_solve<Complex<double>>(mod);
+    def_llt_solve<double>(mod);
     def_llt_solve<Complex<float>>(mod);
+    def_llt_solve<Complex<double>>(mod);
 }
 
 } /* end namespace python */

--- a/cpp/modmesh/linalg/pymod/wrap_kalman_filter.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_kalman_filter.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025, Chun-Shih Chang <austin20463@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/modmesh.hpp>
+#include <modmesh/linalg/pymod/linalg_pymod.hpp>
+#include <pybind11/operators.h>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapKalmanFilter
+    : public WrapBase<WrapKalmanFilter<T>, KalmanFilter<T>>
+{
+    using base_type = WrapBase<WrapKalmanFilter<T>, KalmanFilter<T>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using array_type = SimpleArray<T>;
+    using real_type = typename wrapped_type::real_type;
+
+    friend base_type;
+
+    WrapKalmanFilter(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(
+                py::init(
+                    [](array_type const & x, array_type const & f, py::object const & b, array_type const & h, real_type process_noise, real_type measurement_noise, real_type jitter)
+                    {
+                        array_type b_array;
+                        if (b.is_none())
+                        {
+                            b_array = array_type(small_vector<size_t>{x.shape(0), 0});
+                        }
+                        else
+                        {
+                            b_array = b.cast<array_type>();
+                        }
+                        return wrapped_type(x, f, b_array, h, process_noise, measurement_noise, jitter);
+                    }),
+                py::arg("x"),
+                py::arg("f"),
+                py::arg("b") = py::none(),
+                py::arg("h"),
+                py::arg("process_noise"),
+                py::arg("measurement_noise"),
+                py::arg("jitter") = static_cast<real_type>(1e-9))
+            .def_property_readonly(
+                "state",
+                &wrapped_type::state)
+            .def_property_readonly(
+                "covariance",
+                &wrapped_type::covariance)
+            .def(
+                "predict",
+                [](wrapped_type & self)
+                { self.predict(); })
+            .def(
+                "predict",
+                [](wrapped_type & self, array_type const & u)
+                { self.predict(u); },
+                py::arg("u"))
+            .def(
+                "update",
+                &wrapped_type::update,
+                py::arg("z"));
+    }
+
+}; /* end class WrapKalmanFilter */
+
+void wrap_kalman_filter(pybind11::module & mod)
+{
+    WrapKalmanFilter<float>::commit(mod, "KalmanFilterFp32", "Kalman Filter (float)");
+    WrapKalmanFilter<double>::commit(mod, "KalmanFilterFp64", "Kalman Filter (double)");
+    WrapKalmanFilter<Complex<float>>::commit(mod, "KalmanFilterComplex64", "Kalman Filter (complex float)");
+    WrapKalmanFilter<Complex<double>>::commit(mod, "KalmanFilterComplex128", "Kalman Filter (complex double)");
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/math/pymod/wrap_Complex.cpp
+++ b/cpp/modmesh/math/pymod/wrap_Complex.cpp
@@ -32,6 +32,7 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
+#include <pybind11/complex.h>
 
 namespace modmesh
 {
@@ -71,7 +72,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapComplex
                 py::init(
                     [](const wrapped_type & other)
                     { return std::make_shared<wrapped_type>(wrapped_type{other.real_v, other.imag_v}); }),
-                py::arg("other"))
+                py::arg("complex"))
+            .def(
+                py::init(
+                    [](const std::complex<value_type> & c)
+                    { return std::make_shared<wrapped_type>(wrapped_type{c.real(), c.imag()}); }),
+                py::arg("np_complex"))
             .def(py::self + py::self) // NOLINT(misc-redundant-expression)
             .def(py::self + value_type()) // NOLINT(misc-redundant-expression)
             .def(value_type() + py::self) // NOLINT(misc-redundant-expression)

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -131,6 +131,10 @@ list_of_transform = [
 list_of_linalg = [
     'llt_factorization',
     'llt_solve',
+    'KalmanFilterFp32',
+    'KalmanFilterFp64',
+    'KalmanFilterComplex64',
+    'KalmanFilterComplex128',
 ]
 
 # universe directory symbols

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-import modmesh
+import modmesh as mm
 
 
 class TestLinalgFactorization(unittest.TestCase):
@@ -15,8 +15,8 @@ class TestLinalgFactorization(unittest.TestCase):
             [0.25, 0.375, 0.5, 0.75]
         ])
         A_np = L_desired @ L_desired.T
-        A = modmesh.SimpleArrayFloat64(array=A_np)
-        L = modmesh.llt_factorization(A)
+        A = mm.SimpleArrayFloat64(array=A_np)
+        L = mm.llt_factorization(A)
         assert L.shape == (4, 4)
         L_np = np.array(L)
         np.testing.assert_allclose(L_np, L_desired, rtol=1e-10)
@@ -30,8 +30,8 @@ class TestLinalgFactorization(unittest.TestCase):
             [0.125, 0.1875, 0.25, 0.375, 0.5]
         ])
         A_np = L_desired @ L_desired.T
-        A = modmesh.SimpleArrayFloat64(array=A_np)
-        L = modmesh.llt_factorization(A)
+        A = mm.SimpleArrayFloat64(array=A_np)
+        L = mm.llt_factorization(A)
         assert L.shape == (5, 5)
         L_np = np.array(L)
         np.testing.assert_allclose(L_np, L_desired, rtol=1e-10)
@@ -45,20 +45,20 @@ class TestLinalgFactorization(unittest.TestCase):
             [0.125+0.0625j, 0.1875+0.09375j, 0.25+0.0j, 0.375+0.0j, 0.5+0.0j]
         ])
         A_np = L_desired @ L_desired.conj().T
-        A = modmesh.SimpleArrayComplex128(array=A_np)
-        L = modmesh.llt_factorization(A)
+        A = mm.SimpleArrayComplex128(array=A_np)
+        L = mm.llt_factorization(A)
         assert L.shape == (5, 5)
         L_np = np.array(L)
         np.testing.assert_allclose(L_np, L_desired, rtol=1e-10)
 
     def test_llt_factorization_invalid_input(self):
-        A = modmesh.SimpleArrayFloat64([2, 3])
+        A = mm.SimpleArrayFloat64([2, 3])
         with self.assertRaisesRegex(
                 Exception,
                 r"Llt::factorize: The first argument a must be a square "
                 r"2D SimpleArray"
         ):
-            modmesh.llt_factorization(A)
+            mm.llt_factorization(A)
 
 
 class TestLinalgSolver(unittest.TestCase):
@@ -72,9 +72,9 @@ class TestLinalgSolver(unittest.TestCase):
         ])
         A_np = B_np.T @ B_np + np.eye(4)
         b_np = np.array([1.0, 2.0, 3.0, 4.0])
-        A = modmesh.SimpleArrayFloat64(array=A_np)
-        b = modmesh.SimpleArrayFloat64(array=b_np)
-        x = modmesh.llt_solve(A, b)
+        A = mm.SimpleArrayFloat64(array=A_np)
+        b = mm.SimpleArrayFloat64(array=b_np)
+        x = mm.llt_solve(A, b)
         assert x.shape == (4,)
         x_np = np.array(x)
         A_np = np.array(A)
@@ -92,9 +92,9 @@ class TestLinalgSolver(unittest.TestCase):
         ])
         A_np = B_np.T @ B_np + np.eye(5)
         b_np = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        A = modmesh.SimpleArrayFloat64(array=A_np)
-        b = modmesh.SimpleArrayFloat64(array=b_np)
-        x = modmesh.llt_solve(A, b)
+        A = mm.SimpleArrayFloat64(array=A_np)
+        b = mm.SimpleArrayFloat64(array=b_np)
+        x = mm.llt_solve(A, b)
         assert x.shape == (5,)
         x_np = np.array(x)
         A_np = np.array(A)
@@ -112,9 +112,9 @@ class TestLinalgSolver(unittest.TestCase):
         ])
         A_np = B_np.conj().T @ B_np + np.eye(5, dtype=complex)
         b_np = np.array([1.0+0.0j, 2.0+0.0j, 3.0+0.0j, 4.0+0.0j, 5.0+0.0j])
-        A = modmesh.SimpleArrayComplex128(array=A_np)
-        b = modmesh.SimpleArrayComplex128(array=b_np)
-        x = modmesh.llt_solve(A, b)
+        A = mm.SimpleArrayComplex128(array=A_np)
+        b = mm.SimpleArrayComplex128(array=b_np)
+        x = mm.llt_solve(A, b)
         assert x.shape == (5,)
         x_np = np.array(x)
         A_np = np.array(A)
@@ -123,10 +123,10 @@ class TestLinalgSolver(unittest.TestCase):
         np.testing.assert_allclose(Ax_np, b_np, rtol=1e-10)
 
     def test_llt_solve_invalid_input(self):
-        A = modmesh.SimpleArrayFloat64([2, 3])
-        b = modmesh.SimpleArrayFloat64([2])
+        A = mm.SimpleArrayFloat64([2, 3])
+        b = mm.SimpleArrayFloat64([2])
         with self.assertRaises(Exception):
-            modmesh.llt_solve(A, b)
+            mm.llt_solve(A, b)
 
     def test_llt_solve_2d_multi_rhs_double(self):
         B_np = np.array([
@@ -144,9 +144,9 @@ class TestLinalgSolver(unittest.TestCase):
             [10.0, 11.0, 12.0],
             [13.0, 14.0, 15.0]
         ])
-        A = modmesh.SimpleArrayFloat64(array=A_np)
-        b_2d = modmesh.SimpleArrayFloat64(array=b_2d_np)
-        x_2d = modmesh.llt_solve(A, b_2d)
+        A = mm.SimpleArrayFloat64(array=A_np)
+        b_2d = mm.SimpleArrayFloat64(array=b_2d_np)
+        x_2d = mm.llt_solve(A, b_2d)
         assert x_2d.shape == (5, 3)
         x_2d_np = np.array(x_2d)
         A_np = np.array(A)
@@ -168,9 +168,9 @@ class TestLinalgSolver(unittest.TestCase):
             [7.0+0.0j, 8.0+0.5j, 9.0+1.0j],
             [10.0+0.0j, 11.0+0.5j, 12.0+1.0j]
         ])
-        A = modmesh.SimpleArrayComplex128(array=A_np)
-        b_2d = modmesh.SimpleArrayComplex128(array=b_2d_np)
-        x_2d = modmesh.llt_solve(A, b_2d)
+        A = mm.SimpleArrayComplex128(array=A_np)
+        b_2d = mm.SimpleArrayComplex128(array=b_2d_np)
+        x_2d = mm.llt_solve(A, b_2d)
         assert x_2d.shape == (4, 3)
         x_2d_np = np.array(x_2d)
         A_np = np.array(A)
@@ -180,27 +180,27 @@ class TestLinalgSolver(unittest.TestCase):
 
     def test_llt_solve_shape_mismatch_errors(self):
         # Test 1: A is not square
-        A_rect = modmesh.SimpleArrayFloat64(array=np.array([
+        A_rect = mm.SimpleArrayFloat64(array=np.array([
             [1.0, 2.0, 3.0, 4.0],
             [5.0, 6.0, 7.0, 8.0],
             [9.0, 10.0, 11.0, 12.0]
         ]))
-        b = modmesh.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
+        b = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
         with self.assertRaisesRegex(
                 Exception,
                 r"Llt::solve: The first argument a must be a square "
                 r"2D SimpleArray"
         ):
-            modmesh.llt_solve(A_rect, b)
+            mm.llt_solve(A_rect, b)
 
         # Test 2: A and b dimension mismatch (1D case)
-        A_square = modmesh.SimpleArrayFloat64(array=np.array([
+        A_square = mm.SimpleArrayFloat64(array=np.array([
             [1.0, 2.0, 3.0, 4.0],
             [5.0, 6.0, 7.0, 8.0],
             [9.0, 10.0, 11.0, 12.0],
             [13.0, 14.0, 15.0, 16.0]
         ]))
-        b_wrong_size = modmesh.SimpleArrayFloat64(array=np.array(
+        b_wrong_size = mm.SimpleArrayFloat64(array=np.array(
             [1.0, 2.0, 3.0]
         ))
         with self.assertRaisesRegex(
@@ -208,10 +208,10 @@ class TestLinalgSolver(unittest.TestCase):
                 r"Llt::solve: The first argument a and the second "
                 r"argument b dimension mismatch"
         ):
-            modmesh.llt_solve(A_square, b_wrong_size)
+            mm.llt_solve(A_square, b_wrong_size)
 
         # Test 3: A and b dimension mismatch (2D case)
-        b_2d_wrong_size = modmesh.SimpleArrayFloat64(array=np.array([
+        b_2d_wrong_size = mm.SimpleArrayFloat64(array=np.array([
             [1.0, 2.0],
             [3.0, 4.0],
             [5.0, 6.0]
@@ -221,10 +221,10 @@ class TestLinalgSolver(unittest.TestCase):
                 r"Llt::solve: The first argument a and the second "
                 r"argument b dimension mismatch"
         ):
-            modmesh.llt_solve(A_square, b_2d_wrong_size)
+            mm.llt_solve(A_square, b_2d_wrong_size)
 
         # Test 4: b is 3D (should fail)
-        b_3d = modmesh.SimpleArrayFloat64(array=np.array([
+        b_3d = mm.SimpleArrayFloat64(array=np.array([
             [[1.0], [2.0]],
             [[3.0], [4.0]],
             [[5.0], [6.0]],
@@ -234,7 +234,7 @@ class TestLinalgSolver(unittest.TestCase):
                 Exception,
                 r"Llt::solve: The second argument b must be 1D or 2D"
         ):
-            modmesh.llt_solve(A_square, b_3d)
+            mm.llt_solve(A_square, b_3d)
 
     def test_llt_solve_non_spd_matrix(self):
         # Create a non-SPD matrix
@@ -242,11 +242,432 @@ class TestLinalgSolver(unittest.TestCase):
             [1.0, 2.0],
             [2.0, 1.0]
         ])
-        b = modmesh.SimpleArrayFloat64(array=np.array([1.0, 2.0]))
-        A = modmesh.SimpleArrayFloat64(array=A_nspd)
+        b = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0]))
+        A = mm.SimpleArrayFloat64(array=A_nspd)
         with self.assertRaisesRegex(
                 Exception,
                 r"Llt::factorize: Cholesky failed: SimpleArray not "
                 r"\(numerically\) SPD"
         ):
-            modmesh.llt_solve(A, b)
+            mm.llt_solve(A, b)
+
+
+class KalmanFilterInitTC(unittest.TestCase):
+
+    def test_transition_dimension_error(self):
+        x0 = mm.SimpleArrayFloat64([2])
+        f_wrong = mm.SimpleArrayFloat64([1, 2])
+        h = mm.SimpleArrayFloat64([1, 2])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_dimensions: The state "
+                "transition SimpleArray f must be state_sizexstate_size, "
+                "but got shape \\(1, 2\\)"):
+            mm.KalmanFilterFp64(
+                x=x0, f=f_wrong, h=h, process_noise=0.1, measurement_noise=1.0)
+
+    def test_measurement_dimension_error(self):
+        x0 = mm.SimpleArrayFloat64([2])
+        f = mm.SimpleArrayFloat64([2, 2])
+        h_wrong = mm.SimpleArrayFloat64([1, 1])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_dimensions: The "
+                "measurement SimpleArray h must be "
+                "measurement_sizexstate_size, but got shape \\(1, 1\\)"):
+            mm.KalmanFilterFp64(
+                x=x0, f=f, h=h_wrong, process_noise=0.1, measurement_noise=1.0)
+
+    def test_state_dimension_error(self):
+        x0_wrong = mm.SimpleArrayFloat64([2, 2])
+        f = mm.SimpleArrayFloat64([2, 2])
+        h = mm.SimpleArrayFloat64([1, 2])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_dimensions: The state SimpleArray "
+                "x must be 1D of length state_size, but got shape \\(2, 2\\)"):
+            mm.KalmanFilterFp64(
+                x=x0_wrong, f=f, h=h, process_noise=0.1, measurement_noise=1.0)
+
+    def test_control_1d_error(self):
+        x0 = mm.SimpleArrayFloat64([2])
+        f = mm.SimpleArrayFloat64([2, 2])
+        b_wrong = mm.SimpleArrayFloat64([2])
+        h = mm.SimpleArrayFloat64([1, 2])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_dimensions: The control SimpleArray "
+                "b must be state_sizex0 when control_size = 0, but got "
+                "shape \\(2\\)"):
+            mm.KalmanFilterFp64(
+                x=x0, f=f, b=b_wrong, h=h, process_noise=0.1,
+                measurement_noise=1.0)
+
+    def test_control_2d_error(self):
+        x0 = mm.SimpleArrayFloat64([2])
+        f = mm.SimpleArrayFloat64([2, 2])
+        b_wrong = mm.SimpleArrayFloat64([1, 2])
+        h = mm.SimpleArrayFloat64([1, 2])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_dimensions: The control SimpleArray "
+                "b must be state_sizexcontrol_size, but got shape \\(1, 2\\)"):
+            mm.KalmanFilterFp64(
+                x=x0, f=f, b=b_wrong, h=h, process_noise=0.1,
+                measurement_noise=1.0)
+
+
+class KalmanFilterPredictTC(unittest.TestCase):
+
+    def kf_predict_numpy(self, x, p, f, q):
+        x_pred = f @ x
+        p_pred = f @ p @ f.conj().T + q
+        return x_pred, p_pred
+
+    def test_predict_fp64(self):
+        n = 2
+        x0 = np.array([1.0, 2.0])
+        f = np.array([[1.1, 0.2],
+                      [0.1, 0.9]])
+        p0 = np.eye(n)
+        sigma_w = 0.316
+        q = (sigma_w**2) * np.eye(n)
+        x_pred_np, p_pred_np = self.kf_predict_numpy(x0, p0, f, q)
+
+        x_sa = mm.SimpleArrayFloat64(array=x0)
+        f_sa = mm.SimpleArrayFloat64(array=f)
+        h_sa = mm.SimpleArrayFloat64([1, n])
+        kf = mm.KalmanFilterFp64(
+            x=x_sa, f=f_sa, h=h_sa,
+            process_noise=sigma_w,
+            measurement_noise=1.0,
+        )
+        kf.predict()
+
+        x_pred_mm = kf.state.ndarray
+        p_pred_mm = kf.covariance.ndarray
+        np.testing.assert_allclose(x_pred_mm, x_pred_np, atol=1e-12, rtol=0.0)
+        np.testing.assert_allclose(p_pred_mm, p_pred_np, atol=1e-12, rtol=0.0)
+
+    def test_predict_cp128(self):
+        n = 2
+        x0 = np.array([1.0+0.5j, 2.0-0.3j], dtype=np.complex128)
+        f = np.array([[1.1+0.1j, 0.2-0.1j],
+                      [0.1+0.1j, 0.9+0.0j]], dtype=np.complex128)
+        p0 = np.eye(n, dtype=np.complex128)
+        sigma_w = 0.316
+        q = (sigma_w**2) * np.eye(n, dtype=np.complex128)
+        x_pred_np, p_pred_np = self.kf_predict_numpy(x0, p0, f, q)
+
+        x_sa = mm.SimpleArrayComplex128(array=x0)
+        f_sa = mm.SimpleArrayComplex128(array=f)
+        h_sa = mm.SimpleArrayComplex128([1, n])
+        kf = mm.KalmanFilterComplex128(
+            x=x_sa, f=f_sa, h=h_sa,
+            process_noise=sigma_w,
+            measurement_noise=1.0,
+        )
+        kf.predict()
+
+        x_pred_mm = kf.state.ndarray
+        p_pred_mm = kf.covariance.ndarray
+        np.testing.assert_allclose(x_pred_mm, x_pred_np, atol=1e-12, rtol=0.0)
+        np.testing.assert_allclose(p_pred_mm, p_pred_np, atol=1e-12, rtol=0.0)
+
+
+# The bug is reported in issue #604:
+# https://github.com/solvcon/modmesh/issues/604
+# Issue #604: SimpleArrayComplex128[i] = numpy.complex128 fails with cast error
+# This _wrap_complex function provides a workaround for the type conversion
+# issue when assigning numpy.complex128 values to SimpleArrayComplex128
+# elements
+def _wrap_complex(val, cls):
+    if not np.iscomplexobj(val):
+        return val.item() if hasattr(val, "item") else val
+    z = complex(val)
+    name = getattr(cls, "__name__", "")
+    if name.endswith("Complex128"):
+        return mm.complex128(z)
+    if name.endswith("Complex64"):
+        return mm.complex64(z)
+    return z
+
+
+class TestKnownIssues604(unittest.TestCase):
+
+    @unittest.expectedFailure
+    def test_issue_604_numpy_complex128_assignment(self):
+        sa = mm.SimpleArrayComplex128([3])
+        z = np.complex128(1.0 + 2.0j)
+        sa[0] = z
+        self.assertEqual(complex(sa[0]), complex(z))
+
+    @unittest.expectedFailure
+    def test_python_complex_assignment(self):
+        sa = mm.SimpleArrayComplex128([1])
+        z = complex(5.0, -6.0)
+        sa[0] = z
+        self.assertEqual(complex(sa[0]), z)
+
+
+# The bug is reported in issue #603:
+# https://github.com/solvcon/modmesh/issues/603
+# Issue #603: F-contiguous check in SimpleArray breaks when creating
+# SimpleArray
+# with shape = (n, 1) or shape = (1, n) from ndarray
+# This sa_from_np function provides a workaround for the F-contiguous check
+# issue by manually creating SimpleArray and copying elements instead of using
+# constructor
+def sa_from_np(arr: np.ndarray, cls):
+    arr = np.asarray(arr)
+    if arr.ndim == 1:
+        sa = cls([arr.shape[0]])
+        for i in range(arr.shape[0]):
+            sa[i] = _wrap_complex(arr[i], cls)
+        return sa
+    if arr.ndim == 2:
+        m, n = arr.shape
+        sa = cls([m, n])
+        for i in range(m):
+            for j in range(n):
+                sa[i, j] = _wrap_complex(arr[i, j], cls)
+        return sa
+    raise ValueError("sa_from_np supports only 1D or 2D arrays")
+
+
+class TestKnownIssues603(unittest.TestCase):
+
+    @unittest.expectedFailure
+    def test_issue_603_shape_n_by_1(self):
+        narr = np.array([[1.0], [0.0]])
+        sa = mm.SimpleArrayFloat64(array=narr)
+        self.assertEqual(sa.shape(), [2, 1])
+
+    @unittest.expectedFailure
+    def test_issue_603_shape_1_by_n(self):
+        narr = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+        sa = mm.SimpleArrayFloat64(array=narr)
+        self.assertEqual(sa.shape(), [1, 5])
+
+
+class KalmanFilterUpdateTC(unittest.TestCase):
+
+    def kf_update_numpy(self, x_pred, p_pred, h, r_var, z):
+        k = h.shape[0]
+        y = z - h @ x_pred
+        s = h @ p_pred @ h.conj().T + r_var * np.eye(k, dtype=h.dtype)
+        k_gain = p_pred @ h.conj().T @ np.linalg.inv(s)
+        x_upd = x_pred + k_gain @ y
+        i_n = np.eye(p_pred.shape[0], dtype=p_pred.dtype)
+        a = i_n - k_gain @ h
+        p_upd = (a @ p_pred @ a.conj().T +
+                 k_gain @ (r_var * np.eye(k, dtype=h.dtype)) @
+                 k_gain.conj().T)
+        return x_upd, p_upd
+
+    def test_update_fp64(self):
+        n = 2
+        x_pred = np.array([0.3, -0.2])
+        p_pred = np.eye(n)
+        f = np.eye(n)
+        h = np.array([[1.0, 0.2]])
+        sigma_v = 0.4
+        r_var = sigma_v**2
+        z = np.array([0.15])
+
+        x_upd_np, p_upd_np = self.kf_update_numpy(
+            x_pred, p_pred, h, r_var, z)
+
+        x_sa = sa_from_np(x_pred, mm.SimpleArrayFloat64)
+        f_sa = sa_from_np(f, mm.SimpleArrayFloat64)
+        h_sa = sa_from_np(h, mm.SimpleArrayFloat64)
+        z_sa = sa_from_np(z, mm.SimpleArrayFloat64)
+
+        kf = mm.KalmanFilterFp64(
+            x=x_sa, f=f_sa, h=h_sa,
+            process_noise=1.0, measurement_noise=sigma_v)
+        kf.update(z_sa)
+
+        x_upd_mm = kf.state.ndarray
+        p_upd_mm = kf.covariance.ndarray
+
+        np.testing.assert_allclose(x_upd_mm, x_upd_np, atol=1e-10, rtol=1e-10)
+        np.testing.assert_allclose(p_upd_mm, p_upd_np, atol=1e-10, rtol=1e-10)
+        np.testing.assert_allclose(p_upd_mm, p_upd_mm.T, atol=1e-12, rtol=0.0)
+        self.assertTrue(np.all(np.diag(p_upd_mm) > 0.0))
+
+    def test_update_cp128(self):
+        n = 2
+        x_pred = np.array([0.3 + 0.1j, -0.2 - 0.05j], dtype=np.complex128)
+        p_pred = np.eye(n, dtype=np.complex128)
+        f = np.eye(n, dtype=np.complex128)
+        h = np.array([[1.0 + 0.0j, 0.2 - 0.1j]], dtype=np.complex128)
+        sigma_v = 0.5
+        r_var = sigma_v**2
+        z = np.array([0.15 - 0.2j], dtype=np.complex128)
+
+        x_upd_np, p_upd_np = self.kf_update_numpy(
+            x_pred, p_pred, h, r_var, z)
+
+        x_sa = sa_from_np(x_pred, mm.SimpleArrayComplex128)
+        f_sa = sa_from_np(f, mm.SimpleArrayComplex128)
+        h_sa = sa_from_np(h, mm.SimpleArrayComplex128)
+        z_sa = sa_from_np(z, mm.SimpleArrayComplex128)
+
+        kf = mm.KalmanFilterComplex128(
+            x=x_sa, f=f_sa, h=h_sa,
+            process_noise=1.0, measurement_noise=sigma_v)
+        kf.update(z_sa)
+
+        x_upd_mm = kf.state.ndarray
+        p_upd_mm = kf.covariance.ndarray
+
+        np.testing.assert_allclose(x_upd_mm, x_upd_np, atol=1e-9, rtol=1e-9)
+        np.testing.assert_allclose(p_upd_mm, p_upd_np, atol=1e-9, rtol=1e-9)
+        np.testing.assert_allclose(p_upd_mm, p_upd_mm.conj().T,
+                                   atol=1e-12, rtol=0.0)
+        self.assertTrue(np.all(np.real(np.diag(p_upd_mm)) > 0.0))
+        self.assertTrue(np.all(np.abs(np.imag(np.diag(p_upd_mm))) < 1e-12))
+
+    def test_update_measurement_dimension_error(self):
+        n = 2
+        x0 = mm.SimpleArrayFloat64([n])
+        f = mm.SimpleArrayFloat64([n, n])
+        h = mm.SimpleArrayFloat64([1, n])
+
+        kf = mm.KalmanFilterFp64(
+            x=x0, f=f, h=h,
+            process_noise=0.1, measurement_noise=1.0)
+
+        # Test wrong measurement dimension
+        z_wrong = mm.SimpleArrayFloat64([2])  # Should be length 1
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_measurement: The measurement "
+                "SimpleArray z must be 1D of length measurement_size \\(1\\), "
+                "but got shape \\(2\\)"):
+            kf.update(z_wrong)
+
+    def test_update_measurement_2d_error(self):
+        n = 2
+        x0 = mm.SimpleArrayFloat64([n])
+        f = mm.SimpleArrayFloat64([n, n])
+        h = mm.SimpleArrayFloat64([1, n])
+
+        kf = mm.KalmanFilterFp64(
+            x=x0, f=f, h=h,
+            process_noise=0.1, measurement_noise=1.0)
+
+        # Test 2D measurement (should be 1D)
+        z_2d = mm.SimpleArrayFloat64([1, 1])  # 2D array
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_measurement: The measurement "
+                "SimpleArray z must be 1D of length measurement_size \\(1\\), "
+                "but got shape \\(1, 1\\)"):
+            kf.update(z_2d)
+
+
+class KalmanFilterControlTC(unittest.TestCase):
+
+    def kf_control_predict_numpy(self, x, p, f, q, b, u):
+        x_pred = f @ x + b @ u
+        p_pred = f @ p @ f.conj().T + q
+        return x_pred, p_pred
+
+    def test_control_predict_fp64(self):
+        n, k = 3, 1
+        x0 = np.array([0.2, -0.1, 0.3])
+        p0 = np.eye(n)
+        f = np.array([[1.0, 0.1, 0.0],
+                      [0.0, 1.0, 0.2],
+                      [0.0, 0.0, 1.0]])
+        b = np.array([[0.5, 0.0],
+                      [0.1, 0.3],
+                      [0.0, 0.2]])
+        u = np.array([1.0, -2.0])
+        h = np.zeros((k, n))
+        h[0, 0] = 1.0
+        sigma_w = 0.05
+        q = (sigma_w**2) * np.eye(n)
+
+        x_pred_np, p_pred_np = self.kf_control_predict_numpy(
+            x0, p0, f, q, b, u
+        )
+
+        x_sa = sa_from_np(x0, mm.SimpleArrayFloat64)
+        f_sa = sa_from_np(f, mm.SimpleArrayFloat64)
+        b_sa = sa_from_np(b, mm.SimpleArrayFloat64)
+        h_sa = sa_from_np(h, mm.SimpleArrayFloat64)
+        u_sa = sa_from_np(u, mm.SimpleArrayFloat64)
+
+        kf = mm.KalmanFilterFp64(
+            x=x_sa, f=f_sa, b=b_sa, h=h_sa,
+            process_noise=sigma_w, measurement_noise=1.0
+        )
+        kf.predict(u_sa)
+
+        x_pred_mm = kf.state.ndarray
+        p_pred_mm = kf.covariance.ndarray
+
+        np.testing.assert_allclose(x_pred_mm, x_pred_np, atol=1e-12, rtol=0.0)
+        np.testing.assert_allclose(p_pred_mm, p_pred_np, atol=1e-12, rtol=0.0)
+
+    def test_simple_predict_with_control(self):
+        n, k = 2, 1
+        x0 = np.array([0.0, 0.0])
+        f = np.array([[1.0, 0.1],
+                      [0.0, 1.0]])
+        h = np.zeros((k, n))
+        h[0, 0] = 1.0
+        u = np.array([1.0])
+
+        x_sa = sa_from_np(x0, mm.SimpleArrayFloat64)
+        f_sa = sa_from_np(f, mm.SimpleArrayFloat64)
+        h_sa = sa_from_np(h, mm.SimpleArrayFloat64)
+        u_sa = sa_from_np(u, mm.SimpleArrayFloat64)
+
+        kf = mm.KalmanFilterFp64(
+            x=x_sa, f=f_sa, h=h_sa,
+            process_noise=0.0, measurement_noise=1.0
+        )
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_control: Control input not "
+                "supported: control_size is 0"):
+            kf.predict(u_sa)
+
+    def test_wrong_shape_control_predict(self):
+        n, k = 2, 1
+        x0 = np.array([0.0, 0.0])
+        f = np.array([[1.0, 0.1],
+                      [0.0, 1.0]])
+        b = np.array([[0.5],
+                      [0.1]])
+        h = np.zeros((k, n))
+        h[0, 0] = 1.0
+        u_wrong = np.array([1.0, 2.0])
+
+        x_sa = sa_from_np(x0, mm.SimpleArrayFloat64)
+        f_sa = sa_from_np(f, mm.SimpleArrayFloat64)
+        b_sa = sa_from_np(b, mm.SimpleArrayFloat64)
+        h_sa = sa_from_np(h, mm.SimpleArrayFloat64)
+        u_wrong_sa = sa_from_np(u_wrong, mm.SimpleArrayFloat64)
+
+        kf = mm.KalmanFilterFp64(
+            x=x_sa, f=f_sa, b=b_sa, h=h_sa,
+            process_noise=0.0, measurement_noise=1.0
+        )
+        with self.assertRaisesRegex(
+                ValueError,
+                "KalmanFilter::check_control: The control SimpleArray u "
+                "must be 1D of length control_size \\(1\\), but got shape "
+                "\\(2\\)"):
+            kf.predict(u_wrong_sa)


### PR DESCRIPTION
According to issue #601, I implemented the Kalman filter.

By the way, since this PR contains quite a lot of code, I decided to include some temporary workarounds for certain function implementations and bug fixes. These include (but are not limited to):

 - [ ] symmetrize for 2D SimpleArray
 - [ ] hermitian for 2D SimpleArray
 - [ ] Matrix multiplication between 2D and 1D SimpleArray
 - [ ] Fixes related to issues #603 and #604
 - [ ] Unit tests for prediction — i.e., given a reasonable random sequence, the prediction should succeed