### PR TITLE
SVG: categorize tests for commands

### DIFF
--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -30,15 +30,18 @@ from modmesh.testing import TestBase as ModMeshTB
 from modmesh.plot.svg import EPath
 
 
-class SvgParserTC(ModMeshTB, unittest.TestCase):
+class SvgParserTB(ModMeshTB, unittest.TestCase):
 
     def assert_allclose(self, *args, **kw):
         if 'rtol' not in kw:
             kw['rtol'] = 1.e-15
         return super().assert_allclose(*args, **kw)
 
+
+class SvgParserGeneralTC(SvgParserTB):
+
     def test_single_closed_path(self):
-        d_attr = """ M10 10 L60 10 L60 60 L10 60 Z """
+        d_attr = "M10 10 L60 10 L60 60 L10 60 Z"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         self.assertEqual(len(path_element.get_cmds()), 5)
@@ -51,10 +54,7 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
              ('Z', [])])
 
     def test_multiple_closed_paths(self):
-        d_attr = """
-                M10 10 L60 10 L60 60 L10 60 Z
-                M100 10 L150 60 L100 60 Z
-                """
+        d_attr = "M10 10 L60 10 L60 60 L10 60 Z M100 10 L150 60 L100 60 Z"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         self.assertEqual(len(path_element.get_cmds()), 9)
@@ -70,11 +70,30 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
              ('L', [100.0, 60.0]),
              ('Z', [])])
 
-    def test_moveto_command(self):
-        d_attr = """
-                M 10 10 h 10
-                m  0 10 h 10
-                """
+
+class SvgMoveToCommandTC(SvgParserTB):
+    """
+    Test 'M' and 'm' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#moveto_path_commands
+    """  # noqa: E501
+
+    def test_moveto_absolute(self):
+        d_attr = "M 10 10 h 10"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 1)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0])
+        self.assertEqual(list(sp2d.y0), [10.0])
+        self.assertEqual(list(sp2d.x1), [20.0])
+        self.assertEqual(list(sp2d.y1), [10.0])
+
+    def test_moveto_relative(self):
+        d_attr = "M 10 10 h 10 m 0 10 h 10"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -88,11 +107,9 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.x1), [20.0, 30.0])
         self.assertEqual(list(sp2d.y1), [10.0, 20.0])
 
-        # Implicit lineTo command
-        d_attr = """
-                M 10 10 20 10
-                m 0 10 10 0
-                """
+    def test_moveto_absolute_and_relative(self):
+        d_attr = "M 10 10 h 10 m  0 10 h 10"
+        fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
         cp2d = path_element.get_closed_paths()[1]
@@ -105,16 +122,120 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.x1), [20.0, 30.0])
         self.assertEqual(list(sp2d.y1), [10.0, 20.0])
 
-    def test_lineto_command(self):
-        d_attr = """
-                M 10 10
-                L 20 10
-                l 10 0
-                V 20
-                v 10
-                H 20
-                h -10
-                """
+    def test_moveto_implicit_lineto(self):
+        d_attr = "M 10 10 20 10 m 0 10 10 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 20.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 20.0])
+        self.assertEqual(list(sp2d.x1), [20.0, 30.0])
+        self.assertEqual(list(sp2d.y1), [10.0, 20.0])
+
+
+class SvgLineToCommandTC(SvgParserTB):
+    """
+    Test 'L', 'l', 'H', 'h', 'V', and 'v' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#lineto_path_commands
+    """  # noqa: E501
+
+    def test_lineto_absolute(self):
+        d_attr = "M 10 10 L 30 20 L 50 30"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 20.0])
+        self.assertEqual(list(sp2d.x1), [30.0, 50.0])
+        self.assertEqual(list(sp2d.y1), [20.0, 30.0])
+
+    def test_lineto_relative(self):
+        d_attr = "M 10 10 l 20 10 l 20 10"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 20.0])
+        self.assertEqual(list(sp2d.x1), [30.0, 50.0])
+        self.assertEqual(list(sp2d.y1), [20.0, 30.0])
+
+    def test_horizontal_lineto_absolute(self):
+        d_attr = "M 10 10 H 30 H 50"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 10.0])
+        self.assertEqual(list(sp2d.x1), [30.0, 50.0])
+        self.assertEqual(list(sp2d.y1), [10.0, 10.0])
+
+    def test_horizontal_lineto_relative(self):
+        d_attr = "M 10 10 h 20 h 20"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 10.0])
+        self.assertEqual(list(sp2d.x1), [30.0, 50.0])
+        self.assertEqual(list(sp2d.y1), [10.0, 10.0])
+
+    def test_vertical_lineto_absolute(self):
+        d_attr = "M 10 10 V 30 V 50"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 10.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.x1), [10.0, 10.0])
+        self.assertEqual(list(sp2d.y1), [30.0, 50.0])
+
+    def test_vertical_lineto_relative(self):
+        d_attr = "M 10 10 v 20 v 20"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 2)
+        self.assertEqual(len(cp2d), 0)
+        self.assertEqual(list(sp2d.x0), [10.0, 10.0])
+        self.assertEqual(list(sp2d.y0), [10.0, 30.0])
+        self.assertEqual(list(sp2d.x1), [10.0, 10.0])
+        self.assertEqual(list(sp2d.y1), [30.0, 50.0])
+
+    def test_lineto_all_variants(self):
+        d_attr = "M 10 10 L 20 10 l 10 0 V 20 v 10 H 20 h -10"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -128,15 +249,9 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.x1), [20.0, 30.0, 30.0, 30.0, 20.0, 10.0])
         self.assertEqual(list(sp2d.y1), [10.0, 10.0, 20.0, 30.0, 30.0, 30.0])
 
-        d_attr = """
-                M 10 10
-                L 20 10 30 10
-                l 10 0 10 0
-                V 20 30
-                v 10 10
-                H 40 30
-                h -10 -10
-                """
+    def test_lineto_multiple_coordinates(self):
+        d_attr = "M 10 10 L 20 10 30 10 l 10 0 10 0 V 20 30 v 10 10 H 40 30 h -10 -10"  # noqa: E501
+        fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
         cp2d = path_element.get_closed_paths()[1]
@@ -153,14 +268,75 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.y1), [10.0, 10.0, 10.0, 10.0, 20.0, 30.0,
                                          40.0, 50.0, 50.0, 50.0, 50.0, 50.0])
 
-    def test_cbc_command(self):
-        d_attr = """
-                M 10 90
-                C 30 90 25 10 50 10
-                S 70 90 90 90
-                c 20 0 15 -80 40 -80
-                s 20 80 40 80
-                """
+
+class SvgCubicBezierCurveCommandTC(SvgParserTB):
+    """
+    Test 'C', 'c', 'S', and 's' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#cubic_b%C3%A9zier_curve
+    """  # noqa: E501
+
+    def test_absolute(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 1)
+        self.assertEqual(list(cp2d[0][0]), [10, 90, 0])
+        self.assertEqual(list(cp2d[0][1]), [30, 90, 0])
+        self.assertEqual(list(cp2d[0][2]), [25, 10, 0])
+        self.assertEqual(list(cp2d[0][3]), [50, 10, 0])
+
+    def test_relative(self):
+        d_attr = "M 10 90 c 20 0 15 -80 40 -80"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 1)
+        self.assertEqual(list(cp2d[0][0]), [10, 90, 0])
+        self.assertEqual(list(cp2d[0][1]), [30, 90, 0])
+        self.assertEqual(list(cp2d[0][2]), [25, 10, 0])
+        self.assertEqual(list(cp2d[0][3]), [50, 10, 0])
+
+    def test_smooth_cubic_bezier_absolute(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10 S 70 90 90 90"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 2)
+        self.assertEqual(list(cp2d[1][0]), [50, 10, 0])
+        self.assertEqual(list(cp2d[1][1]), [75, 10, 0])
+        self.assertEqual(list(cp2d[1][2]), [70, 90, 0])
+        self.assertEqual(list(cp2d[1][3]), [90, 90, 0])
+
+    def test_smooth_cubic_bezier_relative(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10 s 20 80 40 80"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 2)
+        self.assertEqual(list(cp2d[1][0]), [50, 10, 0])
+        self.assertEqual(list(cp2d[1][1]), [75, 10, 0])
+        self.assertEqual(list(cp2d[1][2]), [70, 90, 0])
+        self.assertEqual(list(cp2d[1][3]), [90, 90, 0])
+
+    def test_cubic_bezier_basic(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10 S 70 90 90 90 c 20 0 15 -80 40 -80 s 20 80 40 80"  # noqa: E501
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -189,14 +365,8 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(cp2d[3][2]), [150, 90, 0])
         self.assertEqual(list(cp2d[3][3]), [170, 90, 0])
 
-        # Test with implicit cubic Bézier curves
-        d_attr = """
-                M 10 90
-                C 30 90 25 10 50 10 75 10 70 90 90 90
-                S 105 10 130 10 150 90 170 90
-                c 20 0 15 -80 40 -80 25 0 20 80 40 80
-                s 15 -80 40 -80 20 80 40 80
-                """
+    def test_cubic_bezier_implicit_curves(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10 75 10 70 90 90 90 S 105 10 130 10 150 90 170 90 c 20 0 15 -80 40 -80 25 0 20 80 40 80 s 15 -80 40 -80 20 80 40 80"  # noqa: E501
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -250,14 +420,91 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(cp2d[7][2]), [310, 90, 0])
         self.assertEqual(list(cp2d[7][3]), [330, 90, 0])
 
-    def test_qbc_command(self):
-        d_attr = """
-                M 10 50
-                Q 25 25 40 50
-                q 15 25 30 0
-                T 100 50
-                t 30 0
-                """
+    def test_cubic_bezier_point_continuity(self):
+        d_attr = "M 10 90 C 30 90 25 10 50 10 S 70 90 90 90 c 20 0 15 -80 40 -80 s 20 80 40 80"  # noqa: E501
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 4)
+
+        for i in range(len(cp2d) - 1):
+            self.assert_allclose(cp2d[i][3][0], cp2d[i + 1][0][0])
+            self.assert_allclose(cp2d[i][3][1], cp2d[i + 1][0][1])
+            self.assert_allclose(cp2d[i][3][2], cp2d[i + 1][0][2])
+
+
+class SvgQuadraticBezierCurveCommandTC(SvgParserTB):
+    """
+    Test 'Q', 'q', 'T', and 't' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#quadratic_b%C3%A9zier_curve
+    """  # noqa: E501
+
+    def test_quadratic_bezier_absolute(self):
+        d_attr = "M 10 50 Q 25 25 40 50"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 1)
+        self.assertEqual(list(cp2d[0][0]), [10, 50, 0])
+        self.assertEqual(list(cp2d[0][1]), [25, 25, 0])
+        self.assertEqual(list(cp2d[0][2]), [40, 50, 0])
+        self.assertEqual(list(cp2d[0][3]), [40, 50, 0])
+
+    def test_quadratic_bezier_relative(self):
+        d_attr = "M 10 50 q 15 -25 30 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 1)
+        self.assertEqual(list(cp2d[0][0]), [10, 50, 0])
+        self.assertEqual(list(cp2d[0][1]), [25, 25, 0])
+        self.assertEqual(list(cp2d[0][2]), [40, 50, 0])
+        self.assertEqual(list(cp2d[0][3]), [40, 50, 0])
+
+    def test_smooth_quadratic_bezier_absolute(self):
+        d_attr = "M 10 50 Q 25 25 40 50 T 70 50"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 2)
+        self.assertEqual(list(cp2d[1][0]), [40, 50, 0])
+        self.assertEqual(list(cp2d[1][1]), [55, 75, 0])
+        self.assertEqual(list(cp2d[1][2]), [70, 50, 0])
+        self.assertEqual(list(cp2d[1][3]), [70, 50, 0])
+
+    def test_smooth_quadratic_bezier_relative(self):
+        d_attr = "M 10 50 Q 25 25 40 50 t 30 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 2)
+        self.assertEqual(list(cp2d[1][0]), [40, 50, 0])
+        self.assertEqual(list(cp2d[1][1]), [55, 75, 0])
+        self.assertEqual(list(cp2d[1][2]), [70, 50, 0])
+        self.assertEqual(list(cp2d[1][3]), [70, 50, 0])
+
+    def test_quadratic_bezier_basic(self):
+        d_attr = "M 10 50 Q 25 25 40 50 q 15 25 30 0 T 100 50 t 30 0"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -287,14 +534,9 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(cp2d[3][2]), [130, 50, 0])
         self.assertEqual(list(cp2d[3][3]), [130, 50, 0])
 
-        # Test with implicit quadratic Bézier curves
-        d_attr = """
-                M 10 50
-                Q 25 25 40 50 55 75 70 50
-                q 15 -25 30 0 15 25 30 0
-                T 160 50 190 50
-                t 30 0 30 0
-                """
+    def test_quadratic_bezier_implicit_curves(self):
+        d_attr = "M 10 50 Q 25 25 40 50 55 75 70 50 q 15 -25 30 0 15 25 30 0 T 160 50 190 50 t 30 0 30 0"  # noqa: E501
+        fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
         cp2d = path_element.get_closed_paths()[1]
@@ -347,12 +589,31 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(cp2d[7][2]), [250, 50, 0])
         self.assertEqual(list(cp2d[7][3]), [250, 50, 0])
 
-    def test_arc_command(self):
-        d_attr = """
-                M 6 10
-                A 6 4 10 1 0 14 10
-                A 6 4 10 0 1 20 10
-                """
+    def test_quadratic_bezier_point_continuity(self):
+        d_attr = "M 10 50 Q 25 25 40 50 q 15 25 30 0 T 100 50 t 30 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 0)
+        self.assertEqual(len(cp2d), 4)
+
+        for i in range(len(cp2d) - 1):
+            self.assert_allclose(cp2d[i][2][0], cp2d[i + 1][0][0])
+            self.assert_allclose(cp2d[i][2][1], cp2d[i + 1][0][1])
+            self.assert_allclose(cp2d[i][2][2], cp2d[i + 1][0][2])
+
+
+class SvgEllipticalArcCurveCommandTC(SvgParserTB):
+    """
+    Test 'A' and 'a' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#elliptical_arc_curve
+    """  # noqa: E501
+
+    def test_arc_basic(self):
+        d_attr = "M 6 10 A 6 4 10 1 0 14 10 A 6 4 10 0 1 20 10"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -367,10 +628,16 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assert_allclose(sp2d.x1_at(77), 20)
         self.assert_allclose(sp2d.y1_at(77), 10)
 
-        d_attr = """
-                M 6 10
-                A 6 4 10 1 0 14 10 6 4 10 0 1 20 10
-                """
+        self.assert_allclose(sp2d.x1_at(38), 14)
+        self.assert_allclose(sp2d.y1_at(38), 10)
+
+        for i in range(len(sp2d) - 1):
+            self.assert_allclose(sp2d.x1_at(i), sp2d.x0_at(i + 1))
+            self.assert_allclose(sp2d.y1_at(i), sp2d.y0_at(i + 1))
+
+    def test_arc_implicit_curves(self):
+        d_attr = "M 6 10 A 6 4 10 1 0 14 10 6 4 10 0 1 20 10"
+        fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
         cp2d = path_element.get_closed_paths()[1]
@@ -384,13 +651,119 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assert_allclose(sp2d.x1_at(77), 20)
         self.assert_allclose(sp2d.y1_at(77), 10)
 
-    def test_close_path_command(self):
-        d_attr = """
-                M 10 10
-                L 20 10
-                l 10 0
-                Z
-                """
+        self.assert_allclose(sp2d.x1_at(38), 14)
+        self.assert_allclose(sp2d.y1_at(38), 10)
+
+        for i in range(len(sp2d) - 1):
+            self.assert_allclose(sp2d.x1_at(i), sp2d.x0_at(i + 1))
+            self.assert_allclose(sp2d.y1_at(i), sp2d.y0_at(i + 1))
+
+    def test_arc_relative(self):
+        d_attr = "M 6 10 a 6 4 10 1 0 8 0 a 6 4 10 0 1 6 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 39 * 2)
+        self.assertEqual(len(cp2d), 0)
+
+        self.assert_allclose(sp2d.x0_at(0), 6)
+        self.assert_allclose(sp2d.y0_at(0), 10)
+        self.assert_allclose(sp2d.x1_at(77), 20)
+        self.assert_allclose(sp2d.y1_at(77), 10)
+
+        self.assert_allclose(sp2d.x1_at(38), 14)
+        self.assert_allclose(sp2d.y1_at(38), 10)
+
+        for i in range(len(sp2d) - 1):
+            self.assert_allclose(sp2d.x1_at(i), sp2d.x0_at(i + 1))
+            self.assert_allclose(sp2d.y1_at(i), sp2d.y0_at(i + 1))
+
+    def test_arc_mixed_absolute_relative(self):
+        d_attr = "M 6 10 A 6 4 10 1 0 14 10 a 6 4 10 0 1 6 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 39 * 2)
+        self.assertEqual(len(cp2d), 0)
+
+        self.assert_allclose(sp2d.x0_at(0), 6)
+        self.assert_allclose(sp2d.y0_at(0), 10)
+        self.assert_allclose(sp2d.x1_at(77), 20)
+        self.assert_allclose(sp2d.y1_at(77), 10)
+
+        self.assert_allclose(sp2d.x1_at(38), 14)
+        self.assert_allclose(sp2d.y1_at(38), 10)
+
+        for i in range(len(sp2d) - 1):
+            self.assert_allclose(sp2d.x1_at(i), sp2d.x0_at(i + 1))
+            self.assert_allclose(sp2d.y1_at(i), sp2d.y0_at(i + 1))
+
+    def test_arc_point_continuity(self):
+        d_attr = "M 0 0 A 10 10 0 0 1 20 0"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 39)
+        self.assertEqual(len(cp2d), 0)
+
+        self.assert_allclose(sp2d.x0_at(0), 0, atol=1e-14)
+        self.assert_allclose(sp2d.y0_at(0), 0, atol=1e-14)
+        self.assert_allclose(sp2d.x1_at(38), 20, atol=1e-14)
+        self.assert_allclose(sp2d.y1_at(38), 0, atol=1e-14)
+
+        for i in range(len(sp2d) - 1):
+            self.assert_allclose(sp2d.x1_at(i), sp2d.x0_at(i + 1))
+            self.assert_allclose(sp2d.y1_at(i), sp2d.y0_at(i + 1))
+
+    def test_arc_circular(self):
+        d_attr = "M 100 100 A 50 50 0 1 1 200 100"
+        fill_attr = "none"
+        path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
+        sp2d = path_element.get_closed_paths()[0]
+        cp2d = path_element.get_closed_paths()[1]
+        self.assertEqual(sp2d.ndim, 2)
+        self.assertEqual(cp2d.ndim, 2)
+        self.assertEqual(len(sp2d), 39)
+        self.assertEqual(len(cp2d), 0)
+
+        self.assert_allclose(sp2d.x0_at(0), 100)
+        self.assert_allclose(sp2d.y0_at(0), 100)
+        self.assert_allclose(sp2d.x1_at(38), 200)
+        self.assert_allclose(sp2d.y1_at(38), 100)
+
+        center_x = 150
+        center_y = 100
+        radius = 50
+
+        for i in range(len(sp2d)):
+            x0 = sp2d.x0_at(i)
+            y0 = sp2d.y0_at(i)
+            distance = ((x0 - center_x)**2 + (y0 - center_y)**2)**0.5
+            self.assert_allclose(distance, radius, rtol=1e-2)
+
+            x1 = sp2d.x1_at(i)
+            y1 = sp2d.y1_at(i)
+            distance = ((x1 - center_x)**2 + (y1 - center_y)**2)**0.5
+            self.assert_allclose(distance, radius, rtol=1e-2)
+
+
+class SvgClosePathCommandTC(SvgParserTB):
+    """
+    Test 'Z' and 'z' commands in SVG path 'd' attribute.
+    See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#closepath
+    """  # noqa: E501
+
+    def test_close_path_uppercase(self):
+        d_attr = "M 10 10 L 20 10 l 10 0 Z"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]
@@ -404,12 +777,8 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.x1), [20.0, 30.0, 10.0])
         self.assertEqual(list(sp2d.y1), [10.0, 10.0, 10.0])
 
-        d_attr = """
-                M 10 10
-                L 20 10
-                l 10 0
-                z
-                """
+    def test_close_path_lowercase(self):
+        d_attr = "M 10 10 L 20 10 l 10 0 z"
         fill_attr = "none"
         path_element = EPath(d_attr=d_attr, fill_attr=fill_attr)
         sp2d = path_element.get_closed_paths()[0]


### PR DESCRIPTION
Part of #505

Categorize original test cases for each command into classes and also improve the cases.
- MoveTo: M, m
- LineTo: L, l, H, h, V, v
- Cubic Bézier curve: C, c, S, s
- Quadratic Bézier curve: Q, q, T, t
- Elliptical arc curve: A, a
- ClosePath: Z, z