### PR TITLE
Init svg pybind module

### DIFF
--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(transform)
 add_subdirectory(math)
 add_subdirectory(linalg)
 add_subdirectory(simd)
+add_subdirectory(svg)
 
 if(USE_PYTEST_HELPER_BINDING)
     add_subdirectory(testhelper)
@@ -100,6 +101,7 @@ set(MODMESH_TERMINAL_FILES
     ${MODMESH_MATH_FILES}
     ${MODMESH_LINALG_FILES}
     ${MODMESH_SIMD_FILES}
+    ${MODMESH_SVG_FILES}
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_GRAPHIC_FILES

--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -33,6 +33,7 @@
 #include <modmesh/math/pymod/math_pymod.hpp>
 #include <modmesh/transform/pymod/transform_pymod.hpp>
 #include <modmesh/linalg/pymod/linalg_pymod.hpp>
+#include <modmesh/svg/pymod/svg_pymod.hpp>
 
 #ifdef USE_PYTEST_HELPER_BINDING
 #include <modmesh/testhelper/pymod/testbuffer_pymod.hpp>
@@ -58,6 +59,8 @@ void initialize(pybind11::module_ mod)
     initialize_inout(mod);
     initialize_math(mod);
     initialize_linalg(mod);
+    pybind11::module_ svg_mod = mod.def_submodule("svg", "svg");
+    initialize_svg(svg_mod);
     pybind11::module_ spacetime_mod = mod.def_submodule("spacetime", "spacetime");
     initialize_spacetime(spacetime_mod);
     pybind11::module_ onedim_mod = mod.def_submodule("onedim", "onedim");

--- a/cpp/modmesh/svg/CMakeLists.txt
+++ b/cpp/modmesh/svg/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+# BSD-style license; see COPYING
+
+cmake_minimum_required(VERSION 3.16)
+
+set(MODMESH_SVG_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/svg.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_SVG_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/svg.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_SVG_PYMODHEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/svg_pymod.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_SVG_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/svg_pymod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_svg.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_SVG_FILES
+    ${MODMESH_SVG_HEADERS}
+    ${MODMESH_SVG_SOURCES}
+    ${MODMESH_SVG_PYMODHEADERS}
+    ${MODMESH_SVG_PYMODSOURCES}
+    CACHE FILEPATH "" FORCE)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/svg/pymod/svg_pymod.cpp
+++ b/cpp/modmesh/svg/pymod/svg_pymod.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/svg/pymod/svg_pymod.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+struct svg_pymod_tag;
+
+template <>
+OneTimeInitializer<svg_pymod_tag> & OneTimeInitializer<svg_pymod_tag>::me()
+{
+    static OneTimeInitializer<svg_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_svg(pybind11::module & mod)
+{
+    auto initialize_implementation = [](pybind11::module & mod)
+    {
+        wrap_svg(mod);
+    };
+
+    OneTimeInitializer<svg_pymod_tag>::me()(mod, initialize_implementation);
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/svg/pymod/svg_pymod.hpp
+++ b/cpp/modmesh/svg/pymod/svg_pymod.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/*
+ * Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <modmesh/python/common.hpp>
+#include <modmesh/svg/svg.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+void initialize_svg(pybind11::module & mod);
+void wrap_svg(pybind11::module & mod);
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/svg/pymod/wrap_svg.cpp
+++ b/cpp/modmesh/svg/pymod/wrap_svg.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/svg/pymod/svg_pymod.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+void wrap_svg(pybind11::module & mod)
+{
+    namespace py = pybind11;
+
+    mod
+        .def("create_svg_header", svg::create_svg_header, py::arg("width"), py::arg("height"))
+        //
+        ;
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/svg/svg.cpp
+++ b/cpp/modmesh/svg/svg.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/svg/svg.hpp>
+#include <sstream>
+
+namespace modmesh
+{
+
+namespace svg
+{
+
+std::string create_svg_header(double width, double height)
+{
+    std::ostringstream output_stream;
+    output_stream << "<svg width=\"" << width << "\" height=\"" << height << "\" ";
+    output_stream << "xmlns=\"http://www.w3.org/2000/svg\">";
+    return output_stream.str();
+}
+
+} /* end namespace svg */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/svg/svg.hpp
+++ b/cpp/modmesh/svg/svg.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/*
+ * Copyright (c) 2025, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string>
+
+namespace modmesh
+{
+
+namespace svg
+{
+
+// TODO: DUMMY function for initialization. Will remove later.
+std::string create_svg_header(double width, double height);
+
+} /* end namespace svg */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -153,6 +153,10 @@ list_of_universe = [
     'WorldFp64',
 ]
 
+list_of_svg = [
+    'svg',
+]
+
 __all__ = (  # noqa: F822
     list_of_buffer +
     list_of_inout +
@@ -164,7 +168,8 @@ __all__ = (  # noqa: F822
     list_of_toggle +
     list_of_transform +
     list_of_linalg +
-    list_of_universe
+    list_of_universe +
+    list_of_svg
 )
 
 
@@ -192,6 +197,7 @@ _load(list_of_toggle)
 _load(list_of_transform)
 _load(list_of_linalg)
 _load(list_of_universe)
+_load(list_of_svg)
 
 # Walk through the thirdparty folder and register all library
 # into a dictionary.

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -424,6 +424,7 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.x1), [20.0, 30.0, 10.0])
         self.assertEqual(list(sp2d.y1), [10.0, 10.0, 10.0])
 
+
 class SvgBindingTC(ModMeshTB, unittest.TestCase):
 
     # TODO: DUMMY test for initialization. Will remove later.

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -26,6 +26,7 @@
 
 import unittest
 
+import modmesh
 from modmesh.testing import TestBase as ModMeshTB
 from modmesh.plot.svg import EPath
 
@@ -422,5 +423,13 @@ class SvgParserTC(ModMeshTB, unittest.TestCase):
         self.assertEqual(list(sp2d.y0), [10.0, 10.0, 10.0])
         self.assertEqual(list(sp2d.x1), [20.0, 30.0, 10.0])
         self.assertEqual(list(sp2d.y1), [10.0, 10.0, 10.0])
+
+class SvgBindingTC(ModMeshTB, unittest.TestCase):
+
+    # TODO: DUMMY test for initialization. Will remove later.
+    def test_create_svg_header_basic(self):
+        header = modmesh.svg.create_svg_header(100, 200)
+        self.assertIsInstance(header, str)
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Part of #505.

Set up the SVG C++ backend with pybind. Will move helper functions of Python SVG parser to C++ later. Eventually move most of the logic from Python to C++.