### PR TITLE
mirroring against Cartesian axes for point, segment, and curve pads

### DIFF
--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -1200,7 +1200,7 @@ public:
     Bezier3d & operator=(Bezier3d &&) = default;
     ~Bezier3d() = default;
 
-#define DECL_VALUE_ACCESSOR(C, I)                    \
+#define DECL_VALUE_ACCESSOR(C, I)                     \
     value_type C##I() const { return m_data.f.C##I; } \
     value_type & C##I() { return m_data.f.C##I; }
     // clang-format off

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -36,6 +36,16 @@ namespace modmesh
 {
 
 /**
+ * Axis enumeration for 3D space.
+ */
+enum class Axis
+{
+    X = 0,
+    Y = 1,
+    Z = 2
+};
+
+/**
  * Point in three-dimensional space.
  *
  * @tparam T floating-point type
@@ -170,6 +180,17 @@ public:
 
     value_type calc_length2() const { return m_coord[0] * m_coord[0] + m_coord[1] * m_coord[1] + m_coord[2] * m_coord[2]; }
     value_type calc_length() const { return std::sqrt(calc_length2()); }
+
+    void mirror(Axis axis)
+    {
+        switch (axis)
+        {
+        case Axis::X: m_coord[0] = -m_coord[0]; break;
+        case Axis::Y: m_coord[1] = -m_coord[1]; break;
+        case Axis::Z: m_coord[2] = -m_coord[2]; break;
+        default: throw std::invalid_argument("Point3d::mirror: invalid axis"); break;
+        }
+    }
 
 private:
 
@@ -519,6 +540,38 @@ public:
         }
     }
 
+    void mirror(Axis axis)
+    {
+        switch (axis)
+        {
+        case Axis::X:
+            for (size_t i = 0; i < m_x.size(); ++i)
+            {
+                m_x[i] = -m_x[i];
+            }
+            break;
+        case Axis::Y:
+            for (size_t i = 0; i < m_y.size(); ++i)
+            {
+                m_y[i] = -m_y[i];
+            }
+            break;
+        case Axis::Z:
+            if (m_ndim != 3)
+            {
+                throw std::out_of_range(Formatter() << "PointPad::mirror: ndim must be 3 but is " << int(m_ndim));
+            }
+            for (size_t i = 0; i < m_z.size(); ++i)
+            {
+                m_z[i] = -m_z[i];
+            }
+            break;
+        default:
+            throw std::invalid_argument("PointPad::mirror: invalid axis");
+            break;
+        }
+    }
+
 private:
 
     uint8_t m_ndim;
@@ -647,6 +700,28 @@ public:
     }
 
     size_t size() const { return 2; }
+
+    void mirror(Axis axis)
+    {
+        switch (axis)
+        {
+        case Axis::X:
+            m_data.f.x0 = -m_data.f.x0;
+            m_data.f.x1 = -m_data.f.x1;
+            break;
+        case Axis::Y:
+            m_data.f.y0 = -m_data.f.y0;
+            m_data.f.y1 = -m_data.f.y1;
+            break;
+        case Axis::Z:
+            m_data.f.z0 = -m_data.f.z0;
+            m_data.f.z1 = -m_data.f.z1;
+            break;
+        default:
+            throw std::invalid_argument("Segment3d::mirror: invalid axis");
+            break;
+        }
+    }
 
 private:
 
@@ -1023,6 +1098,36 @@ public:
         }
     }
 
+    void mirror(Axis axis)
+    {
+        size_t const nseg = size();
+        for (size_t i = 0; i < nseg; ++i)
+        {
+            switch (axis)
+            {
+            case Axis::X:
+                x0(i) = -x0(i);
+                x1(i) = -x1(i);
+                break;
+            case Axis::Y:
+                y0(i) = -y0(i);
+                y1(i) = -y1(i);
+                break;
+            case Axis::Z:
+                if (ndim() != 3)
+                {
+                    throw std::out_of_range(
+                        Formatter() << "SegmentPad::mirror: cannot mirror Z axis for ndim " << int(ndim()));
+                }
+                z0(i) = -z0(i);
+                z1(i) = -z1(i);
+                break;
+            default:
+                throw std::invalid_argument(Formatter() << "SegmentPad::mirror: invalid axis " << int(axis));
+            }
+        }
+    }
+
 private:
 
     void check_constructor_point_size(point_pad_type const & p0, point_pad_type const & p1)
@@ -1096,8 +1201,8 @@ public:
     ~Bezier3d() = default;
 
 #define DECL_VALUE_ACCESSOR(C, I)                    \
-    real_type C##I() const { return m_data.f.C##I; } \
-    real_type & C##I() { return m_data.f.C##I; }
+    value_type C##I() const { return m_data.f.C##I; } \
+    value_type & C##I() { return m_data.f.C##I; }
     // clang-format off
     DECL_VALUE_ACCESSOR(x, 0)
     DECL_VALUE_ACCESSOR(x, 1)
@@ -1131,6 +1236,33 @@ public:
 #undef DECL_POINT_ACCESSOR
 
     std::shared_ptr<SegmentPad<T>> sample(size_t nlocus) const;
+
+    void mirror(Axis axis)
+    {
+        switch (axis)
+        {
+        case Axis::X:
+            x0() = -x0();
+            x1() = -x1();
+            x2() = -x2();
+            x3() = -x3();
+            break;
+        case Axis::Y:
+            y0() = -y0();
+            y1() = -y1();
+            y2() = -y2();
+            y3() = -y3();
+            break;
+        case Axis::Z:
+            z0() = -z0();
+            z1() = -z1();
+            z2() = -z2();
+            z3() = -z3();
+            break;
+        default:
+            throw std::invalid_argument(Formatter() << "Bezier3d::mirror: invalid axis " << int(axis));
+        }
+    }
 
 private:
 
@@ -1352,6 +1484,14 @@ public:
     std::shared_ptr<point_pad_type> p3() { return m_p3; }
 
     std::shared_ptr<SegmentPad<T>> sample(value_type length) const;
+
+    void mirror(Axis axis)
+    {
+        m_p0->mirror(axis);
+        m_p1->mirror(axis);
+        m_p2->mirror(axis);
+        m_p3->mirror(axis);
+    }
 
 private:
 

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -181,13 +181,17 @@ public:
     value_type calc_length2() const { return m_coord[0] * m_coord[0] + m_coord[1] * m_coord[1] + m_coord[2] * m_coord[2]; }
     value_type calc_length() const { return std::sqrt(calc_length2()); }
 
+    void mirror_x() { m_coord[0] = -m_coord[0]; }
+    void mirror_y() { m_coord[1] = -m_coord[1]; }
+    void mirror_z() { m_coord[2] = -m_coord[2]; }
+
     void mirror(Axis axis)
     {
         switch (axis)
         {
-        case Axis::X: m_coord[0] = -m_coord[0]; break;
-        case Axis::Y: m_coord[1] = -m_coord[1]; break;
-        case Axis::Z: m_coord[2] = -m_coord[2]; break;
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
         default: throw std::invalid_argument("Point3d::mirror: invalid axis"); break;
         }
     }
@@ -540,35 +544,42 @@ public:
         }
     }
 
+    void mirror_x()
+    {
+        for (size_t i = 0; i < m_x.size(); ++i)
+        {
+            m_x[i] = -m_x[i];
+        }
+    }
+
+    void mirror_y()
+    {
+        for (size_t i = 0; i < m_y.size(); ++i)
+        {
+            m_y[i] = -m_y[i];
+        }
+    }
+
+    void mirror_z()
+    {
+        if (m_ndim != 3)
+        {
+            throw std::out_of_range(Formatter() << "PointPad::mirror_z: ndim must be 3 but is " << int(m_ndim));
+        }
+        for (size_t i = 0; i < m_z.size(); ++i)
+        {
+            m_z[i] = -m_z[i];
+        }
+    }
+
     void mirror(Axis axis)
     {
         switch (axis)
         {
-        case Axis::X:
-            for (size_t i = 0; i < m_x.size(); ++i)
-            {
-                m_x[i] = -m_x[i];
-            }
-            break;
-        case Axis::Y:
-            for (size_t i = 0; i < m_y.size(); ++i)
-            {
-                m_y[i] = -m_y[i];
-            }
-            break;
-        case Axis::Z:
-            if (m_ndim != 3)
-            {
-                throw std::out_of_range(Formatter() << "PointPad::mirror: ndim must be 3 but is " << int(m_ndim));
-            }
-            for (size_t i = 0; i < m_z.size(); ++i)
-            {
-                m_z[i] = -m_z[i];
-            }
-            break;
-        default:
-            throw std::invalid_argument("PointPad::mirror: invalid axis");
-            break;
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
+        default: throw std::invalid_argument("PointPad::mirror: invalid axis"); break;
         }
     }
 
@@ -701,25 +712,32 @@ public:
 
     size_t size() const { return 2; }
 
+    void mirror_x()
+    {
+        m_data.f.x0 = -m_data.f.x0;
+        m_data.f.x1 = -m_data.f.x1;
+    }
+
+    void mirror_y()
+    {
+        m_data.f.y0 = -m_data.f.y0;
+        m_data.f.y1 = -m_data.f.y1;
+    }
+
+    void mirror_z()
+    {
+        m_data.f.z0 = -m_data.f.z0;
+        m_data.f.z1 = -m_data.f.z1;
+    }
+
     void mirror(Axis axis)
     {
         switch (axis)
         {
-        case Axis::X:
-            m_data.f.x0 = -m_data.f.x0;
-            m_data.f.x1 = -m_data.f.x1;
-            break;
-        case Axis::Y:
-            m_data.f.y0 = -m_data.f.y0;
-            m_data.f.y1 = -m_data.f.y1;
-            break;
-        case Axis::Z:
-            m_data.f.z0 = -m_data.f.z0;
-            m_data.f.z1 = -m_data.f.z1;
-            break;
-        default:
-            throw std::invalid_argument("Segment3d::mirror: invalid axis");
-            break;
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
+        default: throw std::invalid_argument("Segment3d::mirror: invalid axis"); break;
         }
     }
 
@@ -1098,33 +1116,49 @@ public:
         }
     }
 
-    void mirror(Axis axis)
+    void mirror_x()
     {
         size_t const nseg = size();
         for (size_t i = 0; i < nseg; ++i)
         {
-            switch (axis)
-            {
-            case Axis::X:
-                x0(i) = -x0(i);
-                x1(i) = -x1(i);
-                break;
-            case Axis::Y:
-                y0(i) = -y0(i);
-                y1(i) = -y1(i);
-                break;
-            case Axis::Z:
-                if (ndim() != 3)
-                {
-                    throw std::out_of_range(
-                        Formatter() << "SegmentPad::mirror: cannot mirror Z axis for ndim " << int(ndim()));
-                }
-                z0(i) = -z0(i);
-                z1(i) = -z1(i);
-                break;
-            default:
-                throw std::invalid_argument(Formatter() << "SegmentPad::mirror: invalid axis " << int(axis));
-            }
+            x0(i) = -x0(i);
+            x1(i) = -x1(i);
+        }
+    }
+
+    void mirror_y()
+    {
+        size_t const nseg = size();
+        for (size_t i = 0; i < nseg; ++i)
+        {
+            y0(i) = -y0(i);
+            y1(i) = -y1(i);
+        }
+    }
+
+    void mirror_z()
+    {
+        if (ndim() != 3)
+        {
+            throw std::out_of_range(
+                Formatter() << "SegmentPad::mirror_z: cannot mirror Z axis for ndim " << int(ndim()));
+        }
+        size_t const nseg = size();
+        for (size_t i = 0; i < nseg; ++i)
+        {
+            z0(i) = -z0(i);
+            z1(i) = -z1(i);
+        }
+    }
+
+    void mirror(Axis axis)
+    {
+        switch (axis)
+        {
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
+        default: throw std::invalid_argument("SegmentPad::mirror: invalid axis"); break;
         }
     }
 
@@ -1237,30 +1271,38 @@ public:
 
     std::shared_ptr<SegmentPad<T>> sample(size_t nlocus) const;
 
+    void mirror_x()
+    {
+        x0() = -x0();
+        x1() = -x1();
+        x2() = -x2();
+        x3() = -x3();
+    }
+
+    void mirror_y()
+    {
+        y0() = -y0();
+        y1() = -y1();
+        y2() = -y2();
+        y3() = -y3();
+    }
+
+    void mirror_z()
+    {
+        z0() = -z0();
+        z1() = -z1();
+        z2() = -z2();
+        z3() = -z3();
+    }
+
     void mirror(Axis axis)
     {
         switch (axis)
         {
-        case Axis::X:
-            x0() = -x0();
-            x1() = -x1();
-            x2() = -x2();
-            x3() = -x3();
-            break;
-        case Axis::Y:
-            y0() = -y0();
-            y1() = -y1();
-            y2() = -y2();
-            y3() = -y3();
-            break;
-        case Axis::Z:
-            z0() = -z0();
-            z1() = -z1();
-            z2() = -z2();
-            z3() = -z3();
-            break;
-        default:
-            throw std::invalid_argument(Formatter() << "Bezier3d::mirror: invalid axis " << int(axis));
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
+        default: throw std::invalid_argument("Bezier3d::mirror: invalid axis"); break;
         }
     }
 
@@ -1485,12 +1527,39 @@ public:
 
     std::shared_ptr<SegmentPad<T>> sample(value_type length) const;
 
+    void mirror_x()
+    {
+        m_p0->mirror_x();
+        m_p1->mirror_x();
+        m_p2->mirror_x();
+        m_p3->mirror_x();
+    }
+
+    void mirror_y()
+    {
+        m_p0->mirror_y();
+        m_p1->mirror_y();
+        m_p2->mirror_y();
+        m_p3->mirror_y();
+    }
+
+    void mirror_z()
+    {
+        m_p0->mirror_z();
+        m_p1->mirror_z();
+        m_p2->mirror_z();
+        m_p3->mirror_z();
+    }
+
     void mirror(Axis axis)
     {
-        m_p0->mirror(axis);
-        m_p1->mirror(axis);
-        m_p2->mirror(axis);
-        m_p3->mirror(axis);
+        switch (axis)
+        {
+        case Axis::X: mirror_x(); break;
+        case Axis::Y: mirror_y(); break;
+        case Axis::Z: mirror_z(); break;
+        default: throw std::invalid_argument("CurvePad::mirror: invalid axis"); break;
+        }
     }
 
 private:

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -118,6 +118,32 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
        ;
 #undef DECL_WRAP
     // clang-format on
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("Point3d::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
+        //
+        ;
 }
 
 template <typename T>
@@ -256,6 +282,32 @@ WrapPointPad<T>::WrapPointPad(pybind11::module & mod, const char * pyname, const
         ;
 #undef DECL_WRAP
     // clang-format on
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("PointPad::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
+        //
+        ;
 }
 
 template <typename T>
@@ -358,6 +410,32 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
     (*this)
         .def(py::self == py::self) // NOLINT(misc-redundant-expression)
         .def(py::self != py::self) // NOLINT(misc-redundant-expression)
+        //
+        ;
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("Segment3d::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
         //
         ;
 }
@@ -559,6 +637,32 @@ WrapSegmentPad<T>::WrapSegmentPad(pybind11::module & mod, const char * pyname, c
         ;
 #undef DECL_WRAP
     // clang-format on
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("SegmentPad::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
+        //
+        ;
 }
 
 template <typename T>
@@ -646,6 +750,32 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
     // Sampling
     (*this)
         .def("sample", &wrapped_type::sample, py::arg("nlocus"))
+        //
+        ;
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("Bezier3d::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
         //
         ;
 }
@@ -779,6 +909,32 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
         ;
 #undef DECL_WRAP
     // clang-format on
+
+    (*this)
+        .def(
+            "mirror",
+            [](wrapped_type & self, std::string const & axis)
+            {
+                if (axis == "x" || axis == "X")
+                {
+                    self.mirror(Axis::X);
+                }
+                else if (axis == "y" || axis == "Y")
+                {
+                    self.mirror(Axis::Y);
+                }
+                else if (axis == "z" || axis == "Z")
+                {
+                    self.mirror(Axis::Z);
+                }
+                else
+                {
+                    throw std::invalid_argument("CurvePad::mirror: axis must be 'x', 'y', or 'z'");
+                }
+            },
+            py::arg("axis"))
+        //
+        ;
 }
 
 template <typename T>

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -215,6 +215,29 @@ class Point3dTB(ModMeshTB):
         p1 /= 4
         self.assertEqual(list(p1), [6, 8, 10])
 
+    def test_mirror(self):
+        Point = self.Point
+
+        p1 = Point(1, 2, 3)
+        p1.mirror(axis='x')
+        self.assertEqual(list(p1), [-1, 2, 3])
+
+        p2 = Point(1, 2, 3)
+        p2.mirror('y')
+        self.assertEqual(list(p2), [1, -2, 3])
+
+        p3 = Point(1, 2, 3)
+        p3.mirror('z')
+        self.assertEqual(list(p3), [1, 2, -3])
+
+        p4 = Point(1, 2, 3)
+        p4.mirror('X')
+        self.assertEqual(list(p4), [-1, 2, 3])
+
+        with self.assertRaisesRegex(
+                ValueError, "Point3d::mirror: axis must be 'x', 'y', or 'z'"):
+            Point(1, 2, 3).mirror('w')
+
 
 class Point3dFp32TC(Point3dTB, unittest.TestCase):
 
@@ -289,6 +312,35 @@ class Segment3dTB(ModMeshTB):
         s = Segment(Point(x=3.1, y=7.4, z=0.6), Point(x=-1.2, y=-4.1, z=9.2))
         self.assert_allclose(tuple(s.p0), (3.1, 7.4, 0.6))
         self.assert_allclose(tuple(s.p1), (-1.2, -4.1, 9.2))
+
+    def test_mirror(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        s1 = Segment(Point(1, 2, 3), Point(4, 5, 6))
+        s1.mirror('x')
+        self.assertEqual(list(s1.p0), [-1, 2, 3])
+        self.assertEqual(list(s1.p1), [-4, 5, 6])
+
+        s2 = Segment(Point(1, 2, 3), Point(4, 5, 6))
+        s2.mirror('y')
+        self.assertEqual(list(s2.p0), [1, -2, 3])
+        self.assertEqual(list(s2.p1), [4, -5, 6])
+
+        s3 = Segment(Point(1, 2, 3), Point(4, 5, 6))
+        s3.mirror('z')
+        self.assertEqual(list(s3.p0), [1, 2, -3])
+        self.assertEqual(list(s3.p1), [4, 5, -6])
+
+        s4 = Segment(Point(1, 2, 3), Point(4, 5, 6))
+        s4.mirror('Y')
+        self.assertEqual(list(s4.p0), [1, -2, 3])
+        self.assertEqual(list(s4.p1), [4, -5, 6])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::mirror: axis must be 'x', 'y', or 'z'"):
+            Segment(Point(1, 2, 3), Point(4, 5, 6)).mirror('w')
 
 
 class Segment3dFp32TC(Segment3dTB, unittest.TestCase):
@@ -402,6 +454,45 @@ class Bezier3dTB(ModMeshTB):
             [[3.09375, 0.5625, 0.0], [3.58203125, 0.328125, 0.0]])
         self.assert_allclose(
             list(segs[7]), [[3.58203125, 0.328125, 0.0], [4.0, 0.0, 0.0]])
+
+    def test_mirror(self):
+        Point = self.Point
+        Bezier = self.Bezier
+
+        b1 = Bezier(Point(0, 0, 0), Point(1, 1, 0),
+                    Point(3, 1, 0), Point(4, 0, 0))
+        b1.mirror('x')
+        self.assertEqual(list(b1[0]), [0, 0, 0])
+        self.assertEqual(list(b1[1]), [-1, 1, 0])
+        self.assertEqual(list(b1[2]), [-3, 1, 0])
+        self.assertEqual(list(b1[3]), [-4, 0, 0])
+
+        b2 = Bezier(Point(0, 0, 0), Point(1, 1, 0),
+                    Point(3, 1, 0), Point(4, 0, 0))
+        b2.mirror('y')
+        self.assertEqual(list(b2[0]), [0, 0, 0])
+        self.assertEqual(list(b2[1]), [1, -1, 0])
+        self.assertEqual(list(b2[2]), [3, -1, 0])
+        self.assertEqual(list(b2[3]), [4, 0, 0])
+
+        b3 = Bezier(Point(1, 2, 3), Point(4, 5, 6),
+                    Point(7, 8, 9), Point(10, 11, 12))
+        b3.mirror('z')
+        self.assertEqual(list(b3[0]), [1, 2, -3])
+        self.assertEqual(list(b3[1]), [4, 5, -6])
+        self.assertEqual(list(b3[2]), [7, 8, -9])
+        self.assertEqual(list(b3[3]), [10, 11, -12])
+
+        b4 = Bezier(Point(1, 2, 3), Point(4, 5, 6),
+                    Point(7, 8, 9), Point(10, 11, 12))
+        b4.mirror('Z')
+        self.assertEqual(list(b4[0]), [1, 2, -3])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "Bezier3d::mirror: axis must be 'x', 'y', or 'z'"):
+            Bezier(Point(0, 0, 0), Point(1, 1, 0),
+                   Point(3, 1, 0), Point(4, 0, 0)).mirror('w')
 
 
 class Bezier3dFp32TC(Bezier3dTB, unittest.TestCase):
@@ -661,6 +752,45 @@ class PointPadTB(ModMeshTB):
         self.assert_allclose(pp.z_at(0), 2.31)
         self.assert_allclose(pp.z_at(1), 8.23)
         self.assert_allclose(pp.z_at(2), 3.3 * 5.1)
+
+    def test_mirror_2d(self):
+        PointPad = self.PointPad
+
+        pp = PointPad(ndim=2)
+        pp.append(1.0, 2.0)
+        pp.append(3.0, 4.0)
+        pp.append(5.0, 6.0)
+
+        pp.mirror('x')
+        self.assert_allclose(pp.x_at(0), -1.0)
+        self.assert_allclose(pp.y_at(0), 2.0)
+        self.assert_allclose(pp.x_at(1), -3.0)
+        self.assert_allclose(pp.y_at(1), 4.0)
+
+        pp.mirror('y')
+        self.assert_allclose(pp.x_at(0), -1.0)
+        self.assert_allclose(pp.y_at(0), -2.0)
+        self.assert_allclose(pp.x_at(1), -3.0)
+        self.assert_allclose(pp.y_at(1), -4.0)
+
+    def test_mirror_3d(self):
+        PointPad = self.PointPad
+
+        pp = PointPad(ndim=3)
+        pp.append(1.0, 2.0, 3.0)
+        pp.append(4.0, 5.0, 6.0)
+
+        pp.mirror('z')
+        self.assert_allclose(pp.z_at(0), -3.0)
+        self.assert_allclose(pp.z_at(1), -6.0)
+
+        pp.mirror('X')
+        self.assert_allclose(pp.x_at(0), -1.0)
+        self.assert_allclose(pp.x_at(1), -4.0)
+
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::mirror: axis must be 'x', 'y', or 'z'"):
+            pp.mirror('w')
 
 
 class PointPadFp32TC(PointPadTB, unittest.TestCase):
@@ -990,6 +1120,47 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(list(sp.y1), list(sp.p1.y))
         self.assert_allclose(list(sp.z1), list(sp.p1.z))
 
+    def test_mirror_2d(self):
+        SegmentPad = self.SegmentPad
+
+        sp = SegmentPad(ndim=2)
+        sp.append(1.0, 2.0, 3.0, 4.0)
+        sp.append(5.0, 6.0, 7.0, 8.0)
+
+        sp.mirror('x')
+        self.assert_allclose(sp.x0_at(0), -1.0)
+        self.assert_allclose(sp.x1_at(0), -3.0)
+        self.assert_allclose(sp.x0_at(1), -5.0)
+        self.assert_allclose(sp.x1_at(1), -7.0)
+
+        sp.mirror('y')
+        self.assert_allclose(sp.y0_at(0), -2.0)
+        self.assert_allclose(sp.y1_at(0), -4.0)
+        self.assert_allclose(sp.y0_at(1), -6.0)
+        self.assert_allclose(sp.y1_at(1), -8.0)
+
+    def test_mirror_3d(self):
+        SegmentPad = self.SegmentPad
+
+        sp = SegmentPad(ndim=3)
+        sp.append(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        sp.append(7.0, 8.0, 9.0, 10.0, 11.0, 12.0)
+
+        sp.mirror('z')
+        self.assert_allclose(sp.z0_at(0), -3.0)
+        self.assert_allclose(sp.z1_at(0), -6.0)
+        self.assert_allclose(sp.z0_at(1), -9.0)
+        self.assert_allclose(sp.z1_at(1), -12.0)
+
+        sp.mirror('X')
+        self.assert_allclose(sp.x0_at(0), -1.0)
+        self.assert_allclose(sp.x1_at(0), -4.0)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "SegmentPad::mirror: axis must be 'x', 'y', or 'z'"):
+            sp.mirror('w')
+
 
 class SegmentPadFp32TC(SegmentPadTB, unittest.TestCase):
 
@@ -1259,6 +1430,40 @@ class CurvePadTB(ModMeshTB):
                              [6.370370370370371, 0.6666666666666667, 0.0])
         self.assert_allclose(list(sp[9].p1),
                              [7.0, 0.0, 0.0])
+
+    def test_mirror(self):
+        CurvePad = self.CurvePad
+        Point = self.Point
+
+        cp = CurvePad(ndim=3)
+        cp.append(Point(1, 2, 3), Point(4, 5, 6),
+                  Point(7, 8, 9), Point(10, 11, 12))
+        cp.append(Point(-1, -2, -3), Point(-4, -5, -6),
+                  Point(-7, -8, -9), Point(-10, -11, -12))
+
+        cp.mirror('x')
+        self.assert_allclose(list(cp.x0), [-1, 1])
+        self.assert_allclose(list(cp.x1), [-4, 4])
+        self.assert_allclose(list(cp.x2), [-7, 7])
+        self.assert_allclose(list(cp.x3), [-10, 10])
+        self.assert_allclose(list(cp.y0), [2, -2])
+        self.assert_allclose(list(cp.z0), [3, -3])
+
+        cp.mirror('y')
+        self.assert_allclose(list(cp.y0), [-2, 2])
+        self.assert_allclose(list(cp.y1), [-5, 5])
+        self.assert_allclose(list(cp.y2), [-8, 8])
+        self.assert_allclose(list(cp.y3), [-11, 11])
+
+        cp.mirror('Z')
+        self.assert_allclose(list(cp.z0), [-3, 3])
+        self.assert_allclose(list(cp.z1), [-6, 6])
+        self.assert_allclose(list(cp.z2), [-9, 9])
+        self.assert_allclose(list(cp.z3), [-12, 12])
+
+        with self.assertRaisesRegex(
+                ValueError, "CurvePad::mirror: axis must be 'x', 'y', or 'z'"):
+            cp.mirror('w')
 
 
 class CurvePadFp32TC(CurvePadTB, unittest.TestCase):


### PR DESCRIPTION
Implementation for #612. Add `mirror` functions for point, segment and curve pads.

AI usage: 
- Manually define the `mirror` functions first, and let Copilot auto-complete them.
- Ask Copilot (agent mode) to write test cases.
- Ask Copilot (agent mode) to add branchless `mirror_x`, `mirror_y` and `mirror_z` directly