### PR TITLE
Use `mirror` function in SVG GUI and fix the SVG classes docstrings format

### DIFF
--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -181,9 +181,21 @@ public:
     value_type calc_length2() const { return m_coord[0] * m_coord[0] + m_coord[1] * m_coord[1] + m_coord[2] * m_coord[2]; }
     value_type calc_length() const { return std::sqrt(calc_length2()); }
 
-    void mirror_x() { m_coord[0] = -m_coord[0]; }
-    void mirror_y() { m_coord[1] = -m_coord[1]; }
-    void mirror_z() { m_coord[2] = -m_coord[2]; }
+    void mirror_x()
+    {
+        m_coord[1] = -m_coord[1];
+        m_coord[2] = -m_coord[2];
+    }
+    void mirror_y()
+    {
+        m_coord[0] = -m_coord[0];
+        m_coord[2] = -m_coord[2];
+    }
+    void mirror_z()
+    {
+        m_coord[0] = -m_coord[0];
+        m_coord[1] = -m_coord[1];
+    }
 
     void mirror(Axis axis)
     {
@@ -546,17 +558,31 @@ public:
 
     void mirror_x()
     {
-        for (size_t i = 0; i < m_x.size(); ++i)
+        for (size_t i = 0; i < m_y.size(); ++i)
         {
-            m_x[i] = -m_x[i];
+            m_y[i] = -m_y[i];
+        }
+        if (m_ndim == 3)
+        {
+            for (size_t i = 0; i < m_z.size(); ++i)
+            {
+                m_z[i] = -m_z[i];
+            }
         }
     }
 
     void mirror_y()
     {
-        for (size_t i = 0; i < m_y.size(); ++i)
+        for (size_t i = 0; i < m_x.size(); ++i)
         {
-            m_y[i] = -m_y[i];
+            m_x[i] = -m_x[i];
+        }
+        if (m_ndim == 3)
+        {
+            for (size_t i = 0; i < m_z.size(); ++i)
+            {
+                m_z[i] = -m_z[i];
+            }
         }
     }
 
@@ -566,9 +592,13 @@ public:
         {
             throw std::out_of_range(Formatter() << "PointPad::mirror_z: ndim must be 3 but is " << int(m_ndim));
         }
-        for (size_t i = 0; i < m_z.size(); ++i)
+        for (size_t i = 0; i < m_x.size(); ++i)
         {
-            m_z[i] = -m_z[i];
+            m_x[i] = -m_x[i];
+        }
+        for (size_t i = 0; i < m_y.size(); ++i)
+        {
+            m_y[i] = -m_y[i];
         }
     }
 
@@ -714,20 +744,26 @@ public:
 
     void mirror_x()
     {
-        m_data.f.x0 = -m_data.f.x0;
-        m_data.f.x1 = -m_data.f.x1;
+        m_data.f.y0 = -m_data.f.y0;
+        m_data.f.y1 = -m_data.f.y1;
+        m_data.f.z0 = -m_data.f.z0;
+        m_data.f.z1 = -m_data.f.z1;
     }
 
     void mirror_y()
     {
-        m_data.f.y0 = -m_data.f.y0;
-        m_data.f.y1 = -m_data.f.y1;
+        m_data.f.x0 = -m_data.f.x0;
+        m_data.f.x1 = -m_data.f.x1;
+        m_data.f.z0 = -m_data.f.z0;
+        m_data.f.z1 = -m_data.f.z1;
     }
 
     void mirror_z()
     {
-        m_data.f.z0 = -m_data.f.z0;
-        m_data.f.z1 = -m_data.f.z1;
+        m_data.f.x0 = -m_data.f.x0;
+        m_data.f.x1 = -m_data.f.x1;
+        m_data.f.y0 = -m_data.f.y0;
+        m_data.f.y1 = -m_data.f.y1;
     }
 
     void mirror(Axis axis)
@@ -1121,8 +1157,13 @@ public:
         size_t const nseg = size();
         for (size_t i = 0; i < nseg; ++i)
         {
-            x0(i) = -x0(i);
-            x1(i) = -x1(i);
+            y0(i) = -y0(i);
+            y1(i) = -y1(i);
+            if (ndim() == 3)
+            {
+                z0(i) = -z0(i);
+                z1(i) = -z1(i);
+            }
         }
     }
 
@@ -1131,8 +1172,13 @@ public:
         size_t const nseg = size();
         for (size_t i = 0; i < nseg; ++i)
         {
-            y0(i) = -y0(i);
-            y1(i) = -y1(i);
+            x0(i) = -x0(i);
+            x1(i) = -x1(i);
+            if (ndim() == 3)
+            {
+                z0(i) = -z0(i);
+                z1(i) = -z1(i);
+            }
         }
     }
 
@@ -1146,8 +1192,10 @@ public:
         size_t const nseg = size();
         for (size_t i = 0; i < nseg; ++i)
         {
-            z0(i) = -z0(i);
-            z1(i) = -z1(i);
+            x0(i) = -x0(i);
+            x1(i) = -x1(i);
+            y0(i) = -y0(i);
+            y1(i) = -y1(i);
         }
     }
 
@@ -1273,26 +1321,38 @@ public:
 
     void mirror_x()
     {
-        x0() = -x0();
-        x1() = -x1();
-        x2() = -x2();
-        x3() = -x3();
-    }
-
-    void mirror_y()
-    {
         y0() = -y0();
         y1() = -y1();
         y2() = -y2();
         y3() = -y3();
-    }
-
-    void mirror_z()
-    {
         z0() = -z0();
         z1() = -z1();
         z2() = -z2();
         z3() = -z3();
+    }
+
+    void mirror_y()
+    {
+        x0() = -x0();
+        x1() = -x1();
+        x2() = -x2();
+        x3() = -x3();
+        z0() = -z0();
+        z1() = -z1();
+        z2() = -z2();
+        z3() = -z3();
+    }
+
+    void mirror_z()
+    {
+        x0() = -x0();
+        x1() = -x1();
+        x2() = -x2();
+        x3() = -x3();
+        y0() = -y0();
+        y1() = -y1();
+        y2() = -y2();
+        y3() = -y3();
     }
 
     void mirror(Axis axis)

--- a/modmesh/pilot/_svg_gui.py
+++ b/modmesh/pilot/_svg_gui.py
@@ -99,17 +99,11 @@ class SVGFileDialog(PilotFeature):
         world = core.WorldFp64()
 
         for spad in spads:
-            # mirror with respect to x-axis: (x, y) -> (x, -y)
-            spad.y0.ndarray[:] = -spad.y0.ndarray
-            spad.y1.ndarray[:] = -spad.y1.ndarray
+            spad.mirror(axis='y')  # Flip Y axis for GUI coordinate system
             world.add_segments(pad=spad)
 
         for cpad in cpads:
-            # mirror with respect to x-axis: (x, y) -> (x, -y)
-            cpad.y0.ndarray[:] = -cpad.y0.ndarray
-            cpad.y1.ndarray[:] = -cpad.y1.ndarray
-            cpad.y2.ndarray[:] = -cpad.y2.ndarray
-            cpad.y3.ndarray[:] = -cpad.y3.ndarray
+            cpad.mirror(axis='y')  # Flip Y axis for GUI coordinate system
             world.add_beziers(pad=cpad)
 
         wid = self._mgr.add3DWidget()

--- a/modmesh/pilot/_svg_gui.py
+++ b/modmesh/pilot/_svg_gui.py
@@ -99,11 +99,13 @@ class SVGFileDialog(PilotFeature):
         world = core.WorldFp64()
 
         for spad in spads:
-            spad.mirror(axis='y')  # Flip Y axis for GUI coordinate system
+            # Flip against the X axis for GUI coordinate system
+            spad.mirror(axis='x')
             world.add_segments(pad=spad)
 
         for cpad in cpads:
-            cpad.mirror(axis='y')  # Flip Y axis for GUI coordinate system
+            # Flip against the X axis for GUI coordinate system
+            cpad.mirror(axis='x')
             world.add_beziers(pad=cpad)
 
         wid = self._mgr.add3DWidget()

--- a/modmesh/plot/svg.py
+++ b/modmesh/plot/svg.py
@@ -43,7 +43,8 @@ __all__ = [  # noqa: F822
 
 
 class SvgParser(object):
-    """The SVG parser to extract SegmentPad and CurvePad from SVG file.
+    """
+    The SVG parser to extract SegmentPad and CurvePad from SVG file.
 
     Internally uses PathParser and ShapeParser to parse <path> and
     shape elements respectively.
@@ -464,7 +465,8 @@ class EPath(object):
 
 
 class PathParser(object):
-    """The SVG <path> element parser to extract SegmentPad and CurvePad.
+    """
+    The SVG <path> element parser to extract SegmentPad and CurvePad.
 
     Parse <path> elements from the SVG file and convert them into
     SegmentPad and CurvePad objects.
@@ -700,7 +702,8 @@ class EPolygon(EShapeBase):
 
 
 class ShapeParser(object):
-    """Parse basic shapes from an SVG file to extract SegmentPad and CurvePad.
+    """
+    Parse basic shapes from an SVG file to extract SegmentPad and CurvePad.
 
     Parses the basic shapes, including <circle>, <rect>, <ellipse>,
     <line>, <polyline>, and <polygon>, but excludes <path>.

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -220,19 +220,19 @@ class Point3dTB(ModMeshTB):
 
         p1 = Point(1, 2, 3)
         p1.mirror(axis='x')
-        self.assertEqual(list(p1), [-1, 2, 3])
+        self.assertEqual(list(p1), [1, -2, -3])
 
         p2 = Point(1, 2, 3)
         p2.mirror('y')
-        self.assertEqual(list(p2), [1, -2, 3])
+        self.assertEqual(list(p2), [-1, 2, -3])
 
         p3 = Point(1, 2, 3)
         p3.mirror('z')
-        self.assertEqual(list(p3), [1, 2, -3])
+        self.assertEqual(list(p3), [-1, -2, 3])
 
         p4 = Point(1, 2, 3)
         p4.mirror('X')
-        self.assertEqual(list(p4), [-1, 2, 3])
+        self.assertEqual(list(p4), [1, -2, -3])
 
         with self.assertRaisesRegex(
                 ValueError, "Point3d::mirror: axis must be 'x', 'y', or 'z'"):
@@ -319,23 +319,23 @@ class Segment3dTB(ModMeshTB):
 
         s1 = Segment(Point(1, 2, 3), Point(4, 5, 6))
         s1.mirror('x')
-        self.assertEqual(list(s1.p0), [-1, 2, 3])
-        self.assertEqual(list(s1.p1), [-4, 5, 6])
+        self.assertEqual(list(s1.p0), [1, -2, -3])
+        self.assertEqual(list(s1.p1), [4, -5, -6])
 
         s2 = Segment(Point(1, 2, 3), Point(4, 5, 6))
         s2.mirror('y')
-        self.assertEqual(list(s2.p0), [1, -2, 3])
-        self.assertEqual(list(s2.p1), [4, -5, 6])
+        self.assertEqual(list(s2.p0), [-1, 2, -3])
+        self.assertEqual(list(s2.p1), [-4, 5, -6])
 
         s3 = Segment(Point(1, 2, 3), Point(4, 5, 6))
         s3.mirror('z')
-        self.assertEqual(list(s3.p0), [1, 2, -3])
-        self.assertEqual(list(s3.p1), [4, 5, -6])
+        self.assertEqual(list(s3.p0), [-1, -2, 3])
+        self.assertEqual(list(s3.p1), [-4, -5, 6])
 
         s4 = Segment(Point(1, 2, 3), Point(4, 5, 6))
         s4.mirror('Y')
-        self.assertEqual(list(s4.p0), [1, -2, 3])
-        self.assertEqual(list(s4.p1), [4, -5, 6])
+        self.assertEqual(list(s4.p0), [-1, 2, -3])
+        self.assertEqual(list(s4.p1), [-4, 5, -6])
 
         with self.assertRaisesRegex(
                 ValueError,
@@ -463,30 +463,30 @@ class Bezier3dTB(ModMeshTB):
                     Point(3, 1, 0), Point(4, 0, 0))
         b1.mirror('x')
         self.assertEqual(list(b1[0]), [0, 0, 0])
-        self.assertEqual(list(b1[1]), [-1, 1, 0])
-        self.assertEqual(list(b1[2]), [-3, 1, 0])
-        self.assertEqual(list(b1[3]), [-4, 0, 0])
+        self.assertEqual(list(b1[1]), [1, -1, 0])
+        self.assertEqual(list(b1[2]), [3, -1, 0])
+        self.assertEqual(list(b1[3]), [4, 0, 0])
 
         b2 = Bezier(Point(0, 0, 0), Point(1, 1, 0),
                     Point(3, 1, 0), Point(4, 0, 0))
         b2.mirror('y')
         self.assertEqual(list(b2[0]), [0, 0, 0])
-        self.assertEqual(list(b2[1]), [1, -1, 0])
-        self.assertEqual(list(b2[2]), [3, -1, 0])
-        self.assertEqual(list(b2[3]), [4, 0, 0])
+        self.assertEqual(list(b2[1]), [-1, 1, 0])
+        self.assertEqual(list(b2[2]), [-3, 1, 0])
+        self.assertEqual(list(b2[3]), [-4, 0, 0])
 
         b3 = Bezier(Point(1, 2, 3), Point(4, 5, 6),
                     Point(7, 8, 9), Point(10, 11, 12))
         b3.mirror('z')
-        self.assertEqual(list(b3[0]), [1, 2, -3])
-        self.assertEqual(list(b3[1]), [4, 5, -6])
-        self.assertEqual(list(b3[2]), [7, 8, -9])
-        self.assertEqual(list(b3[3]), [10, 11, -12])
+        self.assertEqual(list(b3[0]), [-1, -2, 3])
+        self.assertEqual(list(b3[1]), [-4, -5, 6])
+        self.assertEqual(list(b3[2]), [-7, -8, 9])
+        self.assertEqual(list(b3[3]), [-10, -11, 12])
 
         b4 = Bezier(Point(1, 2, 3), Point(4, 5, 6),
                     Point(7, 8, 9), Point(10, 11, 12))
         b4.mirror('Z')
-        self.assertEqual(list(b4[0]), [1, 2, -3])
+        self.assertEqual(list(b4[0]), [-1, -2, 3])
 
         with self.assertRaisesRegex(
                 ValueError,
@@ -762,10 +762,10 @@ class PointPadTB(ModMeshTB):
         pp.append(5.0, 6.0)
 
         pp.mirror('x')
-        self.assert_allclose(pp.x_at(0), -1.0)
-        self.assert_allclose(pp.y_at(0), 2.0)
-        self.assert_allclose(pp.x_at(1), -3.0)
-        self.assert_allclose(pp.y_at(1), 4.0)
+        self.assert_allclose(pp.x_at(0), 1.0)
+        self.assert_allclose(pp.y_at(0), -2.0)
+        self.assert_allclose(pp.x_at(1), 3.0)
+        self.assert_allclose(pp.y_at(1), -4.0)
 
         pp.mirror('y')
         self.assert_allclose(pp.x_at(0), -1.0)
@@ -781,12 +781,20 @@ class PointPadTB(ModMeshTB):
         pp.append(4.0, 5.0, 6.0)
 
         pp.mirror('z')
-        self.assert_allclose(pp.z_at(0), -3.0)
-        self.assert_allclose(pp.z_at(1), -6.0)
+        self.assert_allclose(pp.x_at(0), -1.0)
+        self.assert_allclose(pp.y_at(0), -2.0)
+        self.assert_allclose(pp.z_at(0), 3.0)
+        self.assert_allclose(pp.x_at(1), -4.0)
+        self.assert_allclose(pp.y_at(1), -5.0)
+        self.assert_allclose(pp.z_at(1), 6.0)
 
         pp.mirror('X')
         self.assert_allclose(pp.x_at(0), -1.0)
+        self.assert_allclose(pp.y_at(0), 2.0)
+        self.assert_allclose(pp.z_at(0), -3.0)
         self.assert_allclose(pp.x_at(1), -4.0)
+        self.assert_allclose(pp.y_at(1), 5.0)
+        self.assert_allclose(pp.z_at(1), -6.0)
 
         with self.assertRaisesRegex(
                 ValueError, "PointPad::mirror: axis must be 'x', 'y', or 'z'"):
@@ -1128,15 +1136,23 @@ class SegmentPadTB(ModMeshTB):
         sp.append(5.0, 6.0, 7.0, 8.0)
 
         sp.mirror('x')
-        self.assert_allclose(sp.x0_at(0), -1.0)
-        self.assert_allclose(sp.x1_at(0), -3.0)
-        self.assert_allclose(sp.x0_at(1), -5.0)
-        self.assert_allclose(sp.x1_at(1), -7.0)
+        self.assert_allclose(sp.x0_at(0), 1.0)
+        self.assert_allclose(sp.y0_at(0), -2.0)
+        self.assert_allclose(sp.x1_at(0), 3.0)
+        self.assert_allclose(sp.y1_at(0), -4.0)
+        self.assert_allclose(sp.x0_at(1), 5.0)
+        self.assert_allclose(sp.y0_at(1), -6.0)
+        self.assert_allclose(sp.x1_at(1), 7.0)
+        self.assert_allclose(sp.y1_at(1), -8.0)
 
         sp.mirror('y')
+        self.assert_allclose(sp.x0_at(0), -1.0)
         self.assert_allclose(sp.y0_at(0), -2.0)
+        self.assert_allclose(sp.x1_at(0), -3.0)
         self.assert_allclose(sp.y1_at(0), -4.0)
+        self.assert_allclose(sp.x0_at(1), -5.0)
         self.assert_allclose(sp.y0_at(1), -6.0)
+        self.assert_allclose(sp.x1_at(1), -7.0)
         self.assert_allclose(sp.y1_at(1), -8.0)
 
     def test_mirror_3d(self):
@@ -1147,14 +1163,26 @@ class SegmentPadTB(ModMeshTB):
         sp.append(7.0, 8.0, 9.0, 10.0, 11.0, 12.0)
 
         sp.mirror('z')
-        self.assert_allclose(sp.z0_at(0), -3.0)
-        self.assert_allclose(sp.z1_at(0), -6.0)
-        self.assert_allclose(sp.z0_at(1), -9.0)
-        self.assert_allclose(sp.z1_at(1), -12.0)
+        self.assert_allclose(sp.x0_at(0), -1.0)
+        self.assert_allclose(sp.y0_at(0), -2.0)
+        self.assert_allclose(sp.z0_at(0), 3.0)
+        self.assert_allclose(sp.x1_at(0), -4.0)
+        self.assert_allclose(sp.y1_at(0), -5.0)
+        self.assert_allclose(sp.z1_at(0), 6.0)
+        self.assert_allclose(sp.x0_at(1), -7.0)
+        self.assert_allclose(sp.y0_at(1), -8.0)
+        self.assert_allclose(sp.z0_at(1), 9.0)
+        self.assert_allclose(sp.x1_at(1), -10.0)
+        self.assert_allclose(sp.y1_at(1), -11.0)
+        self.assert_allclose(sp.z1_at(1), 12.0)
 
         sp.mirror('X')
         self.assert_allclose(sp.x0_at(0), -1.0)
+        self.assert_allclose(sp.y0_at(0), 2.0)
+        self.assert_allclose(sp.z0_at(0), -3.0)
         self.assert_allclose(sp.x1_at(0), -4.0)
+        self.assert_allclose(sp.y1_at(0), 5.0)
+        self.assert_allclose(sp.z1_at(0), -6.0)
 
         with self.assertRaisesRegex(
                 ValueError,
@@ -1442,24 +1470,46 @@ class CurvePadTB(ModMeshTB):
                   Point(-7, -8, -9), Point(-10, -11, -12))
 
         cp.mirror('x')
-        self.assert_allclose(list(cp.x0), [-1, 1])
-        self.assert_allclose(list(cp.x1), [-4, 4])
-        self.assert_allclose(list(cp.x2), [-7, 7])
-        self.assert_allclose(list(cp.x3), [-10, 10])
-        self.assert_allclose(list(cp.y0), [2, -2])
-        self.assert_allclose(list(cp.z0), [3, -3])
+        self.assert_allclose(list(cp.x0), [1, -1])
+        self.assert_allclose(list(cp.y0), [-2, 2])
+        self.assert_allclose(list(cp.z0), [-3, 3])
+        self.assert_allclose(list(cp.x1), [4, -4])
+        self.assert_allclose(list(cp.y1), [-5, 5])
+        self.assert_allclose(list(cp.z1), [-6, 6])
+        self.assert_allclose(list(cp.x2), [7, -7])
+        self.assert_allclose(list(cp.y2), [-8, 8])
+        self.assert_allclose(list(cp.z2), [-9, 9])
+        self.assert_allclose(list(cp.x3), [10, -10])
+        self.assert_allclose(list(cp.y3), [-11, 11])
+        self.assert_allclose(list(cp.z3), [-12, 12])
 
         cp.mirror('y')
+        self.assert_allclose(list(cp.x0), [-1, 1])
         self.assert_allclose(list(cp.y0), [-2, 2])
+        self.assert_allclose(list(cp.z0), [3, -3])
+        self.assert_allclose(list(cp.x1), [-4, 4])
         self.assert_allclose(list(cp.y1), [-5, 5])
+        self.assert_allclose(list(cp.z1), [6, -6])
+        self.assert_allclose(list(cp.x2), [-7, 7])
         self.assert_allclose(list(cp.y2), [-8, 8])
+        self.assert_allclose(list(cp.z2), [9, -9])
+        self.assert_allclose(list(cp.x3), [-10, 10])
         self.assert_allclose(list(cp.y3), [-11, 11])
+        self.assert_allclose(list(cp.z3), [12, -12])
 
         cp.mirror('Z')
-        self.assert_allclose(list(cp.z0), [-3, 3])
-        self.assert_allclose(list(cp.z1), [-6, 6])
-        self.assert_allclose(list(cp.z2), [-9, 9])
-        self.assert_allclose(list(cp.z3), [-12, 12])
+        self.assert_allclose(list(cp.x0), [1, -1])
+        self.assert_allclose(list(cp.y0), [2, -2])
+        self.assert_allclose(list(cp.z0), [3, -3])
+        self.assert_allclose(list(cp.x1), [4, -4])
+        self.assert_allclose(list(cp.y1), [5, -5])
+        self.assert_allclose(list(cp.z1), [6, -6])
+        self.assert_allclose(list(cp.x2), [7, -7])
+        self.assert_allclose(list(cp.y2), [8, -8])
+        self.assert_allclose(list(cp.z2), [9, -9])
+        self.assert_allclose(list(cp.x3), [10, -10])
+        self.assert_allclose(list(cp.y3), [11, -11])
+        self.assert_allclose(list(cp.z3), [12, -12])
 
         with self.assertRaisesRegex(
                 ValueError, "CurvePad::mirror: axis must be 'x', 'y', or 'z'"):


### PR DESCRIPTION
This is a follow-up PR for #611 and #613.

- Use `mirror` fuction in SVG GUI
- Fix SVG classes docstrings format
- Fix wrong logic of `mirror`, `mirror_x`, `mirror_y`, and `mirror_z`