### PR TITLE
Implement memory alignment in expander and collector

### DIFF
--- a/cpp/modmesh/buffer/BufferExpander.cpp
+++ b/cpp/modmesh/buffer/BufferExpander.cpp
@@ -37,7 +37,7 @@ void BufferExpander::reserve(size_type cap)
     {
         size_type const old_size = size();
         // Create new data holder and copy data.
-        std::unique_ptr<int8_t> new_data_holder = allocate(cap);
+        std::unique_ptr<int8_t, aligned_deleter> new_data_holder = allocate(cap, m_alignment);
         std::copy_n(m_begin, old_size, new_data_holder.get());
         // Process data holders.
         m_data_holder.swap(new_data_holder);

--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -52,25 +52,20 @@ public:
 
     static constexpr size_t ITEMSIZE = sizeof(value_type);
 
-    explicit SimpleCollector(size_t length)
-        : m_expander(BufferExpander::construct(length * ITEMSIZE))
+    explicit SimpleCollector(size_t length = 0, size_t alignment = 0)
+        : m_expander(BufferExpander::construct(length * ITEMSIZE, alignment))
     {
     }
 
     // Always (forcefully) clone the input array when it is a const reference
-    SimpleCollector(SimpleArray<T> const & arr)
-        : m_expander(BufferExpander::construct(arr.buffer().clone(), /*clone*/ false))
+    SimpleCollector(SimpleArray<T> const & arr, size_t alignment = 0)
+        : m_expander(BufferExpander::construct(arr.buffer().clone(), /*clone*/ false, alignment))
     {
     }
 
     // Allow sharing the buffer when the input array is an lvalue reference
-    SimpleCollector(SimpleArray<T> & arr, bool clone)
-        : m_expander(BufferExpander::construct(arr.buffer().shared_from_this(), clone))
-    {
-    }
-
-    SimpleCollector()
-        : m_expander(BufferExpander::construct())
+    SimpleCollector(SimpleArray<T> & arr, bool clone, size_t alignment = 0)
+        : m_expander(BufferExpander::construct(arr.buffer().shared_from_this(), clone, alignment))
     {
     }
 
@@ -104,6 +99,7 @@ public:
 
     size_t size() const { return expander().size() / ITEMSIZE; }
     size_t capacity() const { return expander().capacity() / ITEMSIZE; }
+    size_t alignment() const { return expander().alignment(); }
 
     value_type const & operator[](size_t it) const noexcept { return data(it); }
     value_type & operator[](size_t it) noexcept { return data(it); }

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -513,13 +513,15 @@ WrapSimpleCollector<T>::WrapSimpleCollector(pybind11::module & mod, char const *
     (*this)
         .def_timed(
             py::init(
-                [](size_t length)
-                { return wrapped_type(length); }),
-            py::arg("length"))
+                [](size_t length, size_t alignment)
+                { return wrapped_type(length, alignment); }),
+            py::arg("length"),
+            py::arg("alignment") = 0)
         .def_timed(py::init<>())
         .def_timed("reserve", &wrapped_type::reserve, py::arg("cap"))
         .def_timed("expand", &wrapped_type::expand, py::arg("length"))
         .def_property_readonly("capacity", &wrapped_type::capacity)
+        .def_property_readonly("alignment", &wrapped_type::alignment)
         .def("__len__", &wrapped_type::size)
         .def(
             "__getitem__",


### PR DESCRIPTION
`SimpleCollector` is the underlying container for `PointPod`, and `BufferExpander ` manages the low-level memory of `SimpleCollector` buffer. In order to allow `PointPod` for further Eigen vectorization usage, the underlying memory should be alignment. In this PR, the memory alignment is added for `SimpleCollector` and `BufferExpander`. Note that `SimpleArray` will need the same implementation, but I will keep it in the next PR.

## AI usage

I used Copilot with Claude 4.5 in the agent mode with the following flow:
1. AskedAI to use `std::aligned_alloc` for `SimpleExpander` and to add `alignment` in the argument
2. Asked AI to implement the validation which was not added in the step 1.
3. Asked AI to add test cases for the implementation.

The AI output is about 80% correct, I have checked over the implementation and test cases manually.