### PR TITLE
Add memory alignment support for ConcreteBuffer and SimpleArray

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -1116,7 +1116,6 @@ public:
 struct with_alignment_t
 {
 };
-inline constexpr with_alignment_t with_alignment{};
 
 /**
  * Simple array type for contiguous memory storage. Size does not change. The
@@ -1178,7 +1177,7 @@ public:
     }
 
     // NOLINTNEXTLINE(modernize-pass-by-value)
-    SimpleArray(small_vector<size_t> const & shape, size_t alignment, with_alignment_t)
+    SimpleArray(small_vector<size_t> const & shape, size_t alignment, with_alignment_t const & /* unnamed argument for tagging */)
         : m_shape(shape)
         , m_stride(calc_stride(m_shape))
     {
@@ -1190,7 +1189,7 @@ public:
     }
 
     SimpleArray(small_vector<size_t> const & shape, value_type const & value, size_t alignment)
-        : SimpleArray(shape, alignment, with_alignment)
+        : SimpleArray(shape, alignment, with_alignment_t{})
     {
         std::fill(begin(), end(), value);
     }
@@ -1224,7 +1223,7 @@ public:
     }
 
     SimpleArray(std::vector<size_t> const & shape, value_type const & value, size_t alignment)
-        : SimpleArray(shape, alignment, with_alignment)
+        : SimpleArray(shape, alignment, with_alignment_t{})
     {
         std::fill(begin(), end(), value);
     }

--- a/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
@@ -53,19 +53,22 @@ WrapConcreteBuffer::WrapConcreteBuffer(pybind11::module & mod, char const * pyna
     (*this)
         .def_timed(
             py::init(
-                [](size_t nbytes)
-                { return wrapped_type::construct(nbytes); }),
-            py::arg("nbytes"))
+                [](size_t nbytes, size_t alignment)
+                { return wrapped_type::construct(nbytes, alignment); }),
+            py::arg("nbytes"),
+            py::arg("alignment") = 0)
         .def(
             py::init(
-                [](py::array & arr_in)
+                [](py::array & arr_in, size_t alignment)
                 {
                     return wrapped_type::construct(
-                        arr_in.nbytes(), arr_in.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(arr_in));
+                        arr_in.nbytes(), arr_in.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(arr_in), alignment);
                 }),
-            py::arg("array"))
+            py::arg("array"),
+            py::arg("alignment") = 0)
         .def_timed("clone", &wrapped_type::clone)
         .def_property_readonly("nbytes", &wrapped_type::nbytes)
+        .def_property_readonly("alignment", &wrapped_type::alignment)
         .def("__len__", &wrapped_type::size)
         .def(
             "__getitem__",
@@ -128,16 +131,20 @@ WrapBufferExpander::WrapBufferExpander(pybind11::module & mod, char const * pyna
     (*this)
         .def_timed(
             py::init(
-                [](size_t length)
-                { return wrapped_type::construct(length); }),
-            py::arg("length"))
+                [](size_t length, size_t alignment)
+                { return wrapped_type::construct(length, alignment); }),
+            py::arg("length"),
+            py::arg("alignment") = 0)
         .def_timed(py::init([]()
                             { return wrapped_type::construct(); }))
-        .def_timed(py::init([](std::shared_ptr<ConcreteBuffer> const & buf)
-                            { return wrapped_type::construct(buf, /*clone*/ true); }))
+        .def_timed(py::init([](std::shared_ptr<ConcreteBuffer> const & buf, size_t alignment)
+                            { return wrapped_type::construct(buf, /*clone*/ true, alignment); }),
+                   py::arg("buffer"),
+                   py::arg("alignment") = 0)
         .def_timed("reserve", &wrapped_type::reserve, py::arg("cap"))
         .def_timed("expand", &wrapped_type::expand, py::arg("length"))
         .def_property_readonly("capacity", &wrapped_type::capacity)
+        .def_property_readonly("alignment", &wrapped_type::alignment)
         .def("__len__", &wrapped_type::size)
         .def(
             "__getitem__",

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -62,10 +62,23 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 py::arg("shape"))
             .def_timed(
                 py::init(
+                    [](py::object const & shape, size_t alignment)
+                    { return wrapped_type(make_shape(shape), alignment, with_alignment); }),
+                py::arg("shape"),
+                py::arg("alignment"))
+            .def_timed(
+                py::init(
                     [](py::object const & shape, value_type const & value)
                     { return wrapped_type(make_shape(shape), value); }),
                 py::arg("shape"),
                 py::arg("value"))
+            .def_timed(
+                py::init(
+                    [](py::object const & shape, value_type const & value, size_t alignment)
+                    { return wrapped_type(make_shape(shape), value, alignment); }),
+                py::arg("shape"),
+                py::arg("value"),
+                py::arg("alignment"))
             .def(
                 py::init(
                     [](py::array & arr_in)
@@ -151,6 +164,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def_property_readonly("nbytes", &wrapped_type::nbytes)
             .def_property_readonly("size", &wrapped_type::size)
             .def_property_readonly("itemsize", &wrapped_type::itemsize)
+            .def_property_readonly("alignment", &wrapped_type::alignment)
             .def_property_readonly(
                 "shape",
                 [](wrapped_type const & self)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -63,7 +63,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def_timed(
                 py::init(
                     [](py::object const & shape, size_t alignment)
-                    { return wrapped_type(make_shape(shape), alignment, with_alignment); }),
+                    { return wrapped_type(make_shape(shape), alignment, with_alignment_t{}); }),
                 py::arg("shape"),
                 py::arg("alignment"))
             .def_timed(

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -179,7 +179,7 @@ ConcreteBufferNdarrayRemover : ConcreteBuffer::remover_type
     }
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
-    void operator()(int8_t *) const override {}
+    void operator()(int8_t *, size_t) const override {}
 
     pybind11::array ndarray;
 


### PR DESCRIPTION
Part of #620.

Following the same approach as `BufferExpander` and `SimpleCollector`, and the memory alignment for `ConcreteBuffer` and `SimpleArray`.

## AI Usage

Env: GitHub Copilot + Claude 4.5

1. Asked AI to follow the same memory alignment approach from `BufferExpander` and `SimpleCollector` for `ConcreteBuffer` and `SimpleArray`.
2. Asked AI also add tests, which follows the privious PR as well.

Most of the code are correct, I added some comments and check over the test cases.