### PR TITLE
add memory alignment for PointPad

### DIFF
--- a/cpp/modmesh/base.hpp
+++ b/cpp/modmesh/base.hpp
@@ -35,6 +35,7 @@
 #include <cassert>
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <iostream>
 #include <sstream>
 #include <map>

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -33,6 +33,31 @@
 namespace modmesh
 {
 
+/// Validate that alignment is one of the supported values (0, 16, 32, 64).
+inline std::size_t validate_alignment(std::size_t alignment, const char * prefix = nullptr)
+{
+    if (alignment != 0 && alignment != 16 && alignment != 32 && alignment != 64)
+    {
+        throw std::invalid_argument(
+            Formatter()
+            << (prefix ? prefix : "") << (prefix ? ": " : "")
+            << "alignment must be 0, 16, 32, or 64, but got " << alignment);
+    }
+    return alignment;
+}
+
+/// Validate that size is a multiple of alignment (when alignment > 0).
+inline void validate_size_alignment(std::size_t size, std::size_t alignment, const char * prefix = nullptr)
+{
+    if (alignment > 0 && size % alignment != 0)
+    {
+        throw std::invalid_argument(
+            Formatter()
+            << (prefix ? prefix : "") << (prefix ? ": " : "")
+            << "size " << size << " must be a multiple of alignment " << alignment);
+    }
+}
+
 /// Base class for buffer-like objects.
 template <typename Derived>
 class BufferBase

--- a/cpp/modmesh/buffer/BufferExpander.cpp
+++ b/cpp/modmesh/buffer/BufferExpander.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<ConcreteBuffer> const & BufferExpander::as_concrete(size_type ca
     size_type const old_size = size();
     if (cap > 0 && m_alignment > 0)
     {
-        validate_size_alignment(cap, m_alignment);
+        validate_size_alignment(cap, m_alignment, "BufferExpander::as_concrete");
     }
     if (!m_concrete_buffer)
     {

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -187,11 +187,26 @@ WrapPointPad<T>::WrapPointPad(pybind11::module & mod, const char * pyname, const
             py::arg("nelem"))
         .def(
             py::init(
+                [](uint8_t ndim, size_t nelem, size_t alignment)
+                { return wrapped_type::construct(ndim, nelem, alignment); }),
+            py::arg("ndim"),
+            py::arg("nelem"),
+            py::arg("alignment"))
+        .def(
+            py::init(
                 [](SimpleArray<T> & x, SimpleArray<T> & y, bool clone)
                 { return wrapped_type::construct(x, y, clone); }),
             py::arg("x"),
             py::arg("y"),
             py::arg("clone"))
+        .def(
+            py::init(
+                [](SimpleArray<T> & x, SimpleArray<T> & y, bool clone, size_t alignment)
+                { return wrapped_type::construct(x, y, clone, alignment); }),
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("clone"),
+            py::arg("alignment"))
         .def(
             py::init(
                 [](SimpleArray<T> & x, SimpleArray<T> & y, SimpleArray<T> & z, bool clone)
@@ -200,11 +215,21 @@ WrapPointPad<T>::WrapPointPad(pybind11::module & mod, const char * pyname, const
             py::arg("y"),
             py::arg("z"),
             py::arg("clone"))
+        .def(
+            py::init(
+                [](SimpleArray<T> & x, SimpleArray<T> & y, SimpleArray<T> & z, bool clone, size_t alignment)
+                { return wrapped_type::construct(x, y, z, clone, alignment); }),
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"),
+            py::arg("clone"),
+            py::arg("alignment"))
         //
         ;
 
     (*this)
         .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def_property_readonly("alignment", &wrapped_type::alignment)
         .def(
             "append",
             [](wrapped_type & self, value_type x, value_type y)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -118,38 +118,38 @@ class ConcreteBufferAlignmentTC(unittest.TestCase):
     def test_alignment_validation_invalid_values(self):
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 17"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 17"  # noqa E501
         ):
             modmesh.ConcreteBuffer(256, 17)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 100"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 100"  # noqa E501
         ):
             modmesh.ConcreteBuffer(256, 100)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 128"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 128"  # noqa E501
         ):
             modmesh.ConcreteBuffer(1024, 128)
 
     def test_alignment_size_validation(self):
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: size .* must be a multiple of alignment 64"
+                "ConcreteBuffer::allocate: size .* must be a multiple of alignment 64"  # noqa E501
         ):
             modmesh.ConcreteBuffer(5, 64)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: size .* must be a multiple of alignment 16"
+                "ConcreteBuffer::allocate: size .* must be a multiple of alignment 16"  # noqa E501
         ):
             modmesh.ConcreteBuffer(100, 16)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: size .* must be a multiple of alignment 32"
+                "ConcreteBuffer::allocate: size .* must be a multiple of alignment 32"  # noqa E501
         ):
             modmesh.ConcreteBuffer(200, 32)
 
@@ -1116,19 +1116,19 @@ class SimpleArrayAlignmentTC(unittest.TestCase):
     def test_alignment_validation_invalid_values(self):
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 17"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 17"  # noqa E501
         ):
             modmesh.SimpleArrayFloat64((4, 4), 17)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 100"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 100"  # noqa E501
         ):
             modmesh.SimpleArrayFloat64((4, 4), 100)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 128"  # noqa: E501
+                "ConcreteBuffer::ConcreteBuffer: alignment must be 0, 16, 32, or 64, but got 128"  # noqa E501
         ):
             modmesh.SimpleArrayFloat64((16, 16), 128)
 
@@ -1138,13 +1138,13 @@ class SimpleArrayAlignmentTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: size .* must be a multiple of alignment 16"
+                "ConcreteBuffer::allocate: size .* must be a multiple of alignment 16"  # noqa E501
         ):
             modmesh.SimpleArrayFloat64((5, 1), 16)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "ConcreteBuffer: size .* must be a multiple of alignment 32"
+                "ConcreteBuffer::allocate: size .* must be a multiple of alignment 32"  # noqa E501
         ):
             modmesh.SimpleArrayFloat64((3, 5), 32)
 
@@ -3077,13 +3077,13 @@ class SimpleCollectorTC(unittest.TestCase):
         # Invalid alignments
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: alignment must be 0, 16, 32, or 64, but got 8"
+                "BufferExpander::BufferExpander: alignment must be 0, 16, 32, or 64, but got 8"  # noqa E501
         ):
             modmesh.SimpleCollectorFloat64(16, 8)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: alignment must be 0, 16, 32, or 64, but got 128"  # noqa E501
+                "BufferExpander::BufferExpander: alignment must be 0, 16, 32, or 64, but got 128"  # noqa E501
         ):
             modmesh.SimpleCollectorFloat64(128, 128)
 
@@ -3104,13 +3104,13 @@ class SimpleCollectorTC(unittest.TestCase):
         # Invalid sizes (not multiple of alignment)
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: size .* must be a multiple of alignment 16"
+                "BufferExpander::allocate: size .* must be a multiple of alignment 16"  # noqa E501
         ):
             modmesh.SimpleCollectorFloat64(17, 16)
 
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: size .* must be a multiple of alignment 32"
+                "BufferExpander::allocate: size .* must be a multiple of alignment 32"  # noqa E501
         ):
             modmesh.SimpleCollectorFloat64(31, 32)
 
@@ -3129,7 +3129,7 @@ class SimpleCollectorTC(unittest.TestCase):
         # Reserve with non-aligned size should fail
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: size .* must be a multiple of alignment 16"
+                "BufferExpander::allocate: size .* must be a multiple of alignment 16"  # noqa E501
         ):
             ct.reserve(33)
 
@@ -3211,7 +3211,7 @@ class SimpleCollectorTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 ValueError,
-                "BufferExpander: size .* must be a multiple of alignment 32"
+                "BufferExpander::as_concrete: size .* must be a multiple of alignment 32"  # noqa E501
         ):
             ep.as_concrete(100)
 


### PR DESCRIPTION
Part of #620. Add the memory alignment for `PointPad` with test cases.

## AI Usage

GitHub Copilot + Claude 4.5

1. Ask AI to add memory alignment for `PointPad`
2. Ask AI to add test cases (with more prompt for minor adjustment)
3. Manual check all implementation and test cases