### PR TITLE
Move NEON SIMD helpers from `simd.hpp` to `neon.hpp`

### DIFF
--- a/cpp/modmesh/simd/neon/neon.hpp
+++ b/cpp/modmesh/simd/neon/neon.hpp
@@ -75,6 +75,7 @@ inline constexpr size_t get_recommended_alignment()
 {
 #if defined(__aarch64__) || defined(__arm__)
     return 16;
+// TODO: The non-NEON conditional should be factored out elsewhere in the future.
 #elif defined(__AVX512F__)
     return 64;
 #elif defined(__AVX__) || defined(__AVX2__)

--- a/cpp/modmesh/simd/neon/neon.hpp
+++ b/cpp/modmesh/simd/neon/neon.hpp
@@ -45,6 +45,49 @@ namespace simd
 namespace neon
 {
 
+namespace detail
+{
+
+#ifndef NDEBUG
+template <typename T>
+bool is_aligned(T const * pointer, size_t alignment)
+{
+    return (reinterpret_cast<std::uintptr_t>(pointer) % alignment) == 0;
+}
+
+template <typename T>
+void check_alignment(T const * pointer, size_t required_alignment, const char * name)
+{
+    if (!is_aligned(pointer, required_alignment))
+    {
+        std::fprintf(stderr,
+                     "Warning: %s pointer %p is not aligned to %zu bytes. "
+                     "SIMD performance may be degraded.\n",
+                     name,
+                     static_cast<const void *>(pointer),
+                     required_alignment);
+    }
+}
+#endif // NDEBUG
+
+// Get the recommended memory alignment for SIMD operations based on the detected SIMD instruction set.
+inline constexpr size_t get_recommended_alignment()
+{
+#if defined(__aarch64__) || defined(__arm__)
+    return 16;
+#elif defined(__AVX512F__)
+    return 64;
+#elif defined(__AVX__) || defined(__AVX2__)
+    return 32;
+#elif defined(__SSE__) || defined(__SSE2__) || defined(__SSE3__) || defined(__SSSE3__) || defined(__SSE4_1__) || defined(__SSE4_2__)
+    return 16;
+#else
+    return 0;
+#endif
+}
+
+} /* end namespace detail */
+
 #if defined(__aarch64__)
 template <typename T, typename std::enable_if_t<!type::has_vectype<T>> * = nullptr>
 const T * check_between(T const * start, T const * end, T const & min_val, T const & max_val)
@@ -60,7 +103,7 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
     constexpr size_t N_lane = type::vector_lane<T>;
 
 #ifndef NDEBUG
-    constexpr size_t alignment = get_recommended_alignment();
+    constexpr size_t alignment = detail::get_recommended_alignment();
     detail::check_alignment(start, alignment, "check_between start");
 #endif
 
@@ -91,7 +134,7 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
 
     if (ptr != end)
     {
-        ret = generic::check_between<T>(ptr, end, min_val, max_val);
+        ret = check_between<T>(ptr, end, min_val, max_val);
     }
 
     return ret;
@@ -124,7 +167,7 @@ void add(T * dest, T const * dest_end, T const * src1, T const * src2)
         constexpr size_t N_lane = type::vector_lane<T>;
 
 #ifndef NDEBUG
-        constexpr size_t alignment = get_recommended_alignment();
+        constexpr size_t alignment = detail::get_recommended_alignment();
         detail::check_alignment(dest, alignment, "add dest");
         detail::check_alignment(src1, alignment, "add src1");
         detail::check_alignment(src2, alignment, "add src2");
@@ -161,7 +204,7 @@ void sub(T * dest, T const * dest_end, T const * src1, T const * src2)
         constexpr size_t N_lane = type::vector_lane<T>;
 
 #ifndef NDEBUG
-        constexpr size_t alignment = get_recommended_alignment();
+        constexpr size_t alignment = detail::get_recommended_alignment();
         detail::check_alignment(dest, alignment, "sub dest");
         detail::check_alignment(src1, alignment, "sub src1");
         detail::check_alignment(src2, alignment, "sub src2");
@@ -198,7 +241,7 @@ void mul(T * dest, T const * dest_end, T const * src1, T const * src2)
         constexpr size_t N_lane = type::vector_lane<T>;
 
 #ifndef NDEBUG
-        constexpr size_t alignment = get_recommended_alignment();
+        constexpr size_t alignment = detail::get_recommended_alignment();
         detail::check_alignment(dest, alignment, "mul dest");
         detail::check_alignment(src1, alignment, "mul src1");
         detail::check_alignment(src2, alignment, "mul src2");
@@ -235,7 +278,7 @@ void div(T * dest, T const * dest_end, T const * src1, T const * src2)
         constexpr size_t N_lane = type::vector_lane<T>;
 
 #ifndef NDEBUG
-        constexpr size_t alignment = get_recommended_alignment();
+        constexpr size_t alignment = detail::get_recommended_alignment();
         detail::check_alignment(dest, alignment, "div dest");
         detail::check_alignment(src1, alignment, "div src1");
         detail::check_alignment(src2, alignment, "div src2");

--- a/cpp/modmesh/simd/simd.hpp
+++ b/cpp/modmesh/simd/simd.hpp
@@ -39,56 +39,13 @@ namespace modmesh
 namespace simd
 {
 
-namespace detail
-{
-#ifndef NDEBUG
-template <typename T>
-bool is_aligned(T const * pointer, size_t alignment)
-{
-    return (reinterpret_cast<std::uintptr_t>(pointer) % alignment) == 0;
-}
-
-template <typename T>
-void check_alignment(T const * pointer, size_t required_alignment, const char * name)
-{
-    if (!is_aligned(pointer, required_alignment))
-    {
-        std::fprintf(stderr,
-                     "Warning: %s pointer %p is not aligned to %zu bytes. "
-                     "SIMD performance may be degraded.\n",
-                     name,
-                     static_cast<const void *>(pointer),
-                     required_alignment);
-    }
-}
-#endif
-
-// Get the recommended memory alignment for SIMD operations based on the detected SIMD instruction set.
-inline constexpr size_t get_recommended_alignment()
-{
-#if defined(__aarch64__) || defined(__arm__)
-    return 16;
-#elif defined(__AVX512F__)
-    return 64;
-#elif defined(__AVX__) || defined(__AVX2__)
-    return 32;
-#elif defined(__SSE__) || defined(__SSE2__) || defined(__SSE3__) || defined(__SSSE3__) || defined(__SSE4_1__) || defined(__SSE4_2__)
-    return 16;
-#else
-    return 0;
-#endif
-}
-
-} // namespace detail
-
 // Check if each element from start to end (excluded end) is within the range [min_val, max_val)
 template <typename T>
 const T * check_between(T const * start, T const * end, T const & min_val, T const & max_val)
 {
-    using namespace detail;
-    switch (detect_simd())
+    switch (detail::detect_simd())
     {
-    case SIMD_NEON:
+    case detail::SIMD_NEON:
         return neon::check_between<T>(start, end, min_val, max_val);
         break;
 


### PR DESCRIPTION
Without the patch, I got build error on my local macos 26:

```
cd /Users/yungyuc/work/modmesh/build/clion/restdebug/cpp/modmesh && /usr/bin/c++ cpp/modmesh/CMakeFiles/modmesh_primary.dir/toggle/pymod/toggle_pymod.cpp.o -MF CMakeFiles/modmesh_primary.dir/toggle/pymod/toggle_pymod.cpp.o.d -o CMakeFiles/modmesh_primary.dir/toggle/pymod/toggle_pymod.cpp.o -c /Users/yungyuc/work/modmesh/cpp/modmesh/toggle/pymod/toggle_pymod.cpp
In file included from /Users/yungyuc/work/modmesh/cpp/modmesh/buffer/SimpleArray.cpp:29:
In file included from /Users/yungyuc/work/modmesh/cpp/modmesh/buffer/SimpleArray.hpp:33:
In file included from /Users/yungyuc/work/modmesh/cpp/modmesh/simd/simd.hpp:34:
/Users/yungyuc/work/modmesh/cpp/modmesh/simd/neon/neon.hpp:63:34: error: use of undeclared identifier 'get_recommended_alignment'
   63 |     constexpr size_t alignment = get_recommended_alignment();
      |                                  ^
/Users/yungyuc/work/modmesh/cpp/modmesh/simd/neon/neon.hpp:64:13: error: no member named 'check_alignment' in namespace 'modmesh::simd::detail'
   64 |     detail::check_alignment(start, alignment, "check_between start");
      |     ~~~~~~~~^
/Users/yungyuc/work/modmesh/cpp/modmesh/simd/neon/neon.hpp:127:38: error: use of undeclared identifier 'get_recommended_alignment'
  127 |         constexpr size_t alignment = get_recommended_alignment();
      |                                      ^
/Users/yungyuc/work/modmesh/cpp/modmesh/simd/neon/neon.hpp:128:17: error: no member named 'check_alignment' in namespace 'modmesh::simd::detail'
  128 |         detail::check_alignment(dest, alignment, "add dest");
      |         ~~~~~~~~^
```

It seems to come from PR #628 , but I do not know why CI did not catch it.

@KHLee529 is `simd_generic.hpp` a good location for the helpers?  I am not sure about it.