### PR TITLE
Temporarily turns off profiling run on macos-15

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -403,10 +403,12 @@ jobs:
             JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
           fi
           make pytest ${JOB_MAKE_ARGS}
-        
-      - name: make pyprof
-        run: |
-          make pyprof
+
+      # FIXME: Temporarily turns off profiling run on macos-15
+      # because it takes 6 hours to fail
+      #- name: make pyprof
+      #  run: |
+      #    make pyprof
 
       - name: make buildext BUILD_QT=ON USE_PYTEST_HELPER_BINDING=OFF
         run: |


### PR DESCRIPTION
`make pyprof` takes forever and make `build_macos-15_Release` fails after running for 6 hours:

```
Run make pyprof
  make pyprof
  shell: /bin/bash -e {0}
  env:
    QT_DEBUG_PLUGINS: 1
    PIP_BREAK_SYSTEM_PACKAGES: 1
    AQT_CONFIG: thirdparty/aqt_settings.ini
    PKG_CONFIG_PATH: /Users/runner/work/modmesh/Qt/6.8.1/macos/lib/pkgconfig
    QT_ROOT_DIR: /Users/runner/work/modmesh/Qt/6.8.1/macos
    QT_PLUGIN_PATH: /Users/runner/work/modmesh/Qt/6.8.1/macos/plugins
    QML2_IMPORT_PATH: /Users/runner/work/modmesh/Qt/6.8.1/macos/qml
cmake --build build/dev314 --target _modmesh_py VERBOSE= -j
[ 96%] Built target modmesh_primary
[100%] Built target _modmesh
[100%] Built target _modmesh_py
/opt/homebrew/bin/python3 profiling/profile_arithmetic_simd.py > profiling/results/profile_arithmetic_simd.output
/Users/runner/work/modmesh/modmesh/profiling/profile_arithmetic_simd.py:111: RuntimeWarning: divide by zero encountered in divide
  return np.divide(src1, src2)
/opt/homebrew/bin/python3 profiling/profile_arithmetic.py > profiling/results/profile_arithmetic.output
/opt/homebrew/bin/python3 profiling/profile_median.py > profiling/results/profile_median.output
/opt/homebrew/bin/python3 profiling/profile_statistic_ops.py > profiling/results/profile_statistic_ops.output
Matplotlib is building the font cache; this may take a moment.
/opt/homebrew/bin/python3 profiling/profile_take_along_axis.py > profiling/results/profile_take_along_axis.output
Error: The operation was canceled.
```

A CI run history can be found at: https://github.com/solvcon/modmesh/actions/runs/19475614444/job/55734494567