### PR TITLE
 Add Polygon3d and PolygonPad support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,14 +78,15 @@ jobs:
 
     - name: dependency by apt
       run: |
-        VERSION_ID=$(bash -c 'source /etc/os-release ; echo $VERSION_ID')
-        if [ "20.04" == "$VERSION_ID" ] ; then CLANG_TIDY_VERSION=10 ; else CLANG_TIDY_VERSION=18 ; fi
+        # Install clang-tidy-21 from LLVM repository for full C++23 support
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get -qqy update
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ silversearcher-ag \
-            clang-tidy-${CLANG_TIDY_VERSION} \
+            clang-tidy-21 \
             python3 python3-dev python3-venv
-        sudo ln -fs "$(which clang-tidy-${CLANG_TIDY_VERSION})" "$(dirname $(which clang-tidy-${CLANG_TIDY_VERSION}))/clang-tidy"
+        sudo ln -fs "$(which clang-tidy-21)" "/usr/local/bin/clang-tidy"
         # Install qt6 only with ubuntu-24.04
         # This page explains why we need libgl1-mesa-dev
         # https://doc-snapshots.qt.io/qt6-dev/linux.html

--- a/cpp/modmesh/universe/CMakeLists.txt
+++ b/cpp/modmesh/universe/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MODMESH_UNIVERSE_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/universe_pymod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_bernstein.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_World.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_polygon.cpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_UNIVERSE_FILES

--- a/cpp/modmesh/universe/pymod/universe_pymod.cpp
+++ b/cpp/modmesh/universe/pymod/universe_pymod.cpp
@@ -49,6 +49,7 @@ void initialize_universe(pybind11::module & mod)
     {
         wrap_bernstein(mod);
         wrap_World(mod);
+        wrap_polygon(mod);
     };
 
     OneTimeInitializer<bernstein_pymod_tag>::me()(mod, initialize_impl);

--- a/cpp/modmesh/universe/pymod/universe_pymod.hpp
+++ b/cpp/modmesh/universe/pymod/universe_pymod.hpp
@@ -43,6 +43,7 @@ namespace python
 void initialize_universe(pybind11::module & mod);
 void wrap_bernstein(pybind11::module & mod);
 void wrap_World(pybind11::module & mod);
+void wrap_polygon(pybind11::module & mod);
 
 } /* end namespace python */
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -1342,6 +1342,49 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
 }
 
 template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapBoundBox3d
+    : public WrapBase<WrapBoundBox3d<T>, BoundBox3d<T>>
+{
+public:
+    using base_type = WrapBase<WrapBoundBox3d<T>, BoundBox3d<T>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using value_type = T;
+
+    friend typename base_type::root_base_type;
+
+protected:
+    WrapBoundBox3d(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+template <typename T>
+WrapBoundBox3d<T>::WrapBoundBox3d(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
+             py::arg("min_x"),
+             py::arg("min_y"),
+             py::arg("min_z"),
+             py::arg("max_x"),
+             py::arg("max_y"),
+             py::arg("max_z"))
+        .def_property_readonly("min_x", &wrapped_type::min_x)
+        .def_property_readonly("min_y", &wrapped_type::min_y)
+        .def_property_readonly("min_z", &wrapped_type::min_z)
+        .def_property_readonly("max_x", &wrapped_type::max_x)
+        .def_property_readonly("max_y", &wrapped_type::max_y)
+        .def_property_readonly("max_z", &wrapped_type::max_z)
+        .def("overlap", &wrapped_type::overlap, py::arg("other"))
+        .def("contain", &wrapped_type::contain, py::arg("other"))
+        .def("calc_area", &wrapped_type::calc_area)
+        .def("expand", &wrapped_type::expand, py::arg("other"))
+        //
+        ;
+}
+
+template <typename T>
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapWorld
     : public WrapBase<WrapWorld<T>, World<T>, std::shared_ptr<World<T>>>
 {
@@ -1476,6 +1519,8 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
 
 void wrap_World(pybind11::module & mod)
 {
+    WrapBoundBox3d<float>::commit(mod, "BoundBox3dFp32", "BoundBox3dFp32");
+    WrapBoundBox3d<double>::commit(mod, "BoundBox3dFp64", "BoundBox3dFp64");
     WrapPoint3d<float>::commit(mod, "Point3dFp32", "Point3dFp32");
     WrapPoint3d<double>::commit(mod, "Point3dFp64", "Point3dFp64");
     WrapPointPad<float>::commit(mod, "PointPadFp32", "PointPadFp32");

--- a/cpp/modmesh/universe/pymod/wrap_polygon.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_polygon.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, An-Chi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/universe/pymod/universe_pymod.hpp>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapPolygon
+    : public WrapBase<WrapPolygon<T>, Polygon3d<T>>
+{
+public:
+    using base_type = WrapBase<WrapPolygon<T>, Polygon3d<T>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using value_type = typename wrapped_type::value_type;
+    using point_type = typename wrapped_type::point_type;
+    using segment_type = typename wrapped_type::segment_type;
+    using polygon_pad_type = typename wrapped_type::polygon_pad_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+    WrapPolygon(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+template <typename T>
+WrapPolygon<T>::WrapPolygon(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def_property_readonly("polygon_id", &wrapped_type::polygon_id)
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def_property_readonly("nnode", &wrapped_type::nnode)
+        .def("get_node", &wrapped_type::node, py::arg("index"))
+        .def("get_edge", &wrapped_type::edge, py::arg("index"))
+        .def("compute_signed_area", &wrapped_type::compute_signed_area)
+        .def("is_counter_clockwise", &wrapped_type::is_counter_clockwise)
+        .def("calc_bound_box", &wrapped_type::calc_bound_box)
+        .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+        .def(py::self != py::self) // NOLINT(misc-redundant-expression)
+        .def("is_same", &wrapped_type::is, py::arg("other"))
+        .def("is_not_same", &wrapped_type::is_not, py::arg("other"));
+}
+
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapPolygonPad
+    : public WrapBase<WrapPolygonPad<T>, PolygonPad<T>, std::shared_ptr<PolygonPad<T>>>
+{
+public:
+    using base_type = WrapBase<WrapPolygonPad<T>, PolygonPad<T>, std::shared_ptr<PolygonPad<T>>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using value_type = typename wrapped_type::value_type;
+    using point_type = typename wrapped_type::point_type;
+    using segment_pad_type = typename wrapped_type::segment_pad_type;
+    using curve_pad_type = typename wrapped_type::curve_pad_type;
+    using polygon_type = typename wrapped_type::polygon_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+    WrapPolygonPad(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+template <typename T>
+WrapPolygonPad<T>::WrapPolygonPad(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            py::init(
+                [](uint8_t ndim)
+                {
+                    return wrapped_type::construct(ndim);
+                }),
+            py::arg("ndim"))
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def_property_readonly("num_polygons", &wrapped_type::num_polygons)
+        .def_property_readonly("num_points", &wrapped_type::num_points)
+        .def(
+            "add_polygon",
+            [](wrapped_type & self, std::vector<point_type> const & nodes)
+            {
+                return self.add_polygon(nodes);
+            },
+            py::arg("nodes"))
+        .def(
+            "add_polygon_from_segments",
+            &wrapped_type::add_polygon_from_segments,
+            py::arg("segments"))
+        .def(
+            "add_polygon_from_curves",
+            &wrapped_type::add_polygon_from_curves,
+            py::arg("curves"),
+            py::arg("sample_length"))
+        .def(
+            "add_polygon_from_segments_and_curves",
+            &wrapped_type::add_polygon_from_segments_and_curves,
+            py::arg("segments"),
+            py::arg("curves"),
+            py::arg("sample_length"))
+        .def("get_polygon", &wrapped_type::get_polygon, py::arg("polygon_id"))
+        .def(
+            "search_segments",
+            [](wrapped_type const & self, BoundBox3d<T> const & box)
+            {
+                std::vector<Segment3d<T>> results;
+                self.search_segments(box, results);
+                return results;
+            },
+            py::arg("box"))
+        .def("rebuild_rtree", &wrapped_type::rebuild_rtree);
+}
+
+void wrap_polygon(pybind11::module & mod)
+{
+    WrapPolygon<float>::commit(mod, "Polygon3dFp32", "Polygon3dFp32");
+    WrapPolygon<double>::commit(mod, "Polygon3dFp64", "Polygon3dFp64");
+
+    WrapPolygonPad<float>::commit(mod, "PolygonPadFp32", "PolygonPadFp32");
+    WrapPolygonPad<double>::commit(mod, "PolygonPadFp64", "PolygonPadFp64");
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -139,6 +139,8 @@ list_of_linalg = [
 list_of_universe = [
     'calc_bernstein_polynomial',
     'interpolate_bernstein',
+    'BoundBox3dFp32',
+    'BoundBox3dFp64',
     'Point3dFp32',
     'Point3dFp64',
     'Segment3dFp32',
@@ -157,6 +159,10 @@ list_of_universe = [
     'CurvePadFp64',
     'WorldFp32',
     'WorldFp64',
+    'PolygonPadFp32',
+    'PolygonPadFp64',
+    'Polygon3dFp32',
+    'Polygon3dFp64',
 ]
 
 __all__ = (  # noqa: F822

--- a/tests/test_polygon3d.py
+++ b/tests/test_polygon3d.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2025, An-Chi Liu <phy.tiger@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import modmesh as mm
+from modmesh.testing import TestBase as ModMeshTB
+
+
+class Polygon3dTB(ModMeshTB):
+
+    def test_polygon_pad_basic(self):
+        """Test PolygonPad with basic operations."""
+        pad = self.PolygonPad(ndim=2)
+        self.assertEqual(pad.ndim, 2)
+        self.assertEqual(pad.num_polygons, 0)
+        self.assertEqual(pad.num_points, 0)
+
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        polygon = pad.add_polygon(nodes)
+
+        self.assertEqual(pad.num_polygons, 1)
+        self.assertEqual(pad.num_points, 4)
+        self.assertEqual(polygon.nnode, 4)
+
+        node0 = polygon.get_node(0)
+        self.assert_allclose([node0.x, node0.y], [0.0, 0.0])
+
+        node1 = polygon.get_node(1)
+        self.assert_allclose([node1.x, node1.y], [1.0, 0.0])
+
+    def test_polygon_handle_operations(self):
+        """Test Polygon3d handle operations."""
+        pad = self.PolygonPad(ndim=2)
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        polygon = pad.add_polygon(nodes)
+
+        self.assertEqual(polygon.ndim, 2)
+        self.assertEqual(polygon.polygon_id, 0)
+        self.assertEqual(polygon.nnode, 4)
+
+        node0 = polygon.get_node(0)
+        self.assert_allclose([node0.x, node0.y], [0.0, 0.0])
+
+        edge0 = polygon.get_edge(0)
+        self.assert_allclose([edge0.x0, edge0.y0], [0.0, 0.0])
+        self.assert_allclose([edge0.x1, edge0.y1], [1.0, 0.0])
+
+        edge3 = polygon.get_edge(3)
+        self.assert_allclose([edge3.x0, edge3.y0], [0.0, 1.0])
+        self.assert_allclose([edge3.x1, edge3.y1], [0.0, 0.0])
+
+    def test_right_hand_rule_counter_clockwise(self):
+        """
+        Test right-hand rule validation for counter-clockwise
+        (positive area) polygon.
+        """
+        pad = self.PolygonPad(ndim=2)
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        polygon = pad.add_polygon(nodes)
+
+        area = polygon.compute_signed_area()
+        self.assertGreater(area, 0.0)
+        self.assertTrue(polygon.is_counter_clockwise())
+
+    def test_right_hand_rule_clockwise(self):
+        """Test right-hand rule: clockwise nodes should have negative area."""
+        pad = self.PolygonPad(ndim=2)
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(0.0, 1.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(1.0, 0.0, 0.0)
+        ]
+        polygon = pad.add_polygon(nodes)
+
+        area = polygon.compute_signed_area()
+        self.assertLess(area, 0.0)
+        self.assertFalse(polygon.is_counter_clockwise())
+
+    def test_multiple_polygons_in_pad(self):
+        """Test storing multiple polygons in one PolygonPad."""
+        pad = self.PolygonPad(ndim=2)
+
+        square = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        triangle = [
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(3.0, 0.0, 0.0),
+            self.Point(2.5, 1.0, 0.0)
+        ]
+
+        poly1 = pad.add_polygon(square)
+        poly2 = pad.add_polygon(triangle)
+
+        self.assertEqual(pad.num_polygons, 2)
+        self.assertEqual(pad.num_points, 7)
+
+        self.assertEqual(poly1.nnode, 4)
+        self.assertEqual(poly2.nnode, 3)
+
+        self.assertGreater(poly1.compute_signed_area(), 0.0)
+        self.assertGreater(poly2.compute_signed_area(), 0.0)
+
+        retrieved_poly1 = pad.get_polygon(0)
+        retrieved_poly2 = pad.get_polygon(1)
+
+        self.assertEqual(retrieved_poly1.polygon_id, 0)
+        self.assertEqual(retrieved_poly2.polygon_id, 1)
+
+    def test_polygon_pad_from_segments(self):
+        """Test adding polygon from SegmentPad."""
+        segment_pad = self.SegmentPad(ndim=2)
+        segment_pad.append(0.0, 0.0, 1.0, 0.0)
+        segment_pad.append(1.0, 0.0, 1.0, 1.0)
+        segment_pad.append(1.0, 1.0, 0.0, 1.0)
+        segment_pad.append(0.0, 1.0, 0.0, 0.0)
+
+        pad = self.PolygonPad(ndim=2)
+        polygon = pad.add_polygon_from_segments(segment_pad)
+
+        self.assertEqual(pad.num_polygons, 1)
+        self.assertEqual(polygon.nnode, 4)
+
+        node0 = polygon.get_node(0)
+        self.assert_allclose([node0.x, node0.y], [0.0, 0.0])
+
+    def test_polygon_pad_rtree_search(self):
+        """Test RTree search across multiple polygons in PolygonPad."""
+        pad = self.PolygonPad(ndim=2)
+
+        square1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        square2 = [
+            self.Point(5.0, 5.0, 0.0),
+            self.Point(6.0, 5.0, 0.0),
+            self.Point(6.0, 6.0, 0.0),
+            self.Point(5.0, 6.0, 0.0)
+        ]
+
+        pad.add_polygon(square1)
+        pad.add_polygon(square2)
+
+        BoundBox = (mm.BoundBox3dFp32 if self.dtype == 'float32'
+                    else mm.BoundBox3dFp64)
+
+        search_box1 = BoundBox(-0.5, -0.5, -0.5, 1.5, 1.5, 0.5)
+        results1 = pad.search_segments(search_box1)
+        self.assertEqual(len(results1), 4)
+
+        search_box2 = BoundBox(4.5, 4.5, -0.5, 6.5, 6.5, 0.5)
+        results2 = pad.search_segments(search_box2)
+        self.assertEqual(len(results2), 4)
+
+        search_box3 = BoundBox(-1.0, -1.0, -0.5, 7.0, 7.0, 0.5)
+        results3 = pad.search_segments(search_box3)
+        self.assertEqual(len(results3), 8)
+
+    def test_polygon_equality_same_coordinates(self):
+        """Test that polygons with same coordinates are equal."""
+        pad1 = self.PolygonPad(ndim=2)
+        pad2 = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        nodes2 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+
+        polygon1 = pad1.add_polygon(nodes1)
+        polygon2 = pad2.add_polygon(nodes2)
+
+        self.assertTrue(polygon1 == polygon2)
+        self.assertFalse(polygon1 != polygon2)
+
+    def test_polygon_equality_different_coordinates(self):
+        """Test that polygons with different coordinates are not equal."""
+        pad1 = self.PolygonPad(ndim=2)
+        pad2 = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        nodes2 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 2.0, 0.0),
+            self.Point(0.0, 2.0, 0.0)
+        ]
+
+        polygon1 = pad1.add_polygon(nodes1)
+        polygon2 = pad2.add_polygon(nodes2)
+
+        self.assertFalse(polygon1 == polygon2)
+        self.assertTrue(polygon1 != polygon2)
+
+    def test_polygon_equality_different_node_count(self):
+        """Test that polygons with different node counts are not equal."""
+        pad1 = self.PolygonPad(ndim=2)
+        pad2 = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        nodes2 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(0.5, 1.0, 0.0)
+        ]
+
+        polygon1 = pad1.add_polygon(nodes1)
+        polygon2 = pad2.add_polygon(nodes2)
+
+        self.assertFalse(polygon1 == polygon2)
+        self.assertTrue(polygon1 != polygon2)
+
+    def test_polygon_identity_same_pad_same_id(self):
+        """Test identity: same pad and same polygon_id."""
+        pad = self.PolygonPad(ndim=2)
+
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+
+        polygon1 = pad.add_polygon(nodes)
+        polygon2 = pad.get_polygon(0)
+
+        self.assertTrue(polygon1.is_same(polygon2))
+        self.assertFalse(polygon1.is_not_same(polygon2))
+
+    def test_polygon_identity_different_pads(self):
+        """Test identity: different pads with same coordinates."""
+        pad1 = self.PolygonPad(ndim=2)
+        pad2 = self.PolygonPad(ndim=2)
+
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+
+        polygon1 = pad1.add_polygon(nodes)
+        polygon2 = pad2.add_polygon(nodes)
+
+        self.assertTrue(polygon1 == polygon2)
+        self.assertFalse(polygon1.is_same(polygon2))
+        self.assertTrue(polygon1.is_not_same(polygon2))
+
+    def test_polygon_identity_same_pad_different_id(self):
+        """Test identity: same pad but different polygon_id."""
+        pad = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        nodes2 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+
+        polygon1 = pad.add_polygon(nodes1)
+        polygon2 = pad.add_polygon(nodes2)
+
+        self.assertTrue(polygon1 == polygon2)
+        self.assertFalse(polygon1.is_same(polygon2))
+        self.assertTrue(polygon1.is_not_same(polygon2))
+
+
+class Polygon3dFp32TC(Polygon3dTB, unittest.TestCase):
+
+    dtype = 'float32'
+    Point = mm.Point3dFp32
+    SegmentPad = mm.SegmentPadFp32
+    CurvePad = mm.CurvePadFp32
+    PolygonPad = mm.PolygonPadFp32
+    SimpleArray = mm.SimpleArrayFloat32
+
+
+class Polygon3dFp64TC(Polygon3dTB, unittest.TestCase):
+
+    dtype = 'float64'
+    Point = mm.Point3dFp64
+    SegmentPad = mm.SegmentPadFp64
+    CurvePad = mm.CurvePadFp64
+    PolygonPad = mm.PolygonPadFp64
+    SimpleArray = mm.SimpleArrayFloat64


### PR DESCRIPTION
## Summary
- add `Polygon3d` handle and `PolygonPad` container to the universe module, including polygon construction from nodes, segments, and curves
- compute polygon properties (node/edge access, signed area, bound boxes) and index edges with an R-tree for spatial search
- expose polygon APIs to Python bindings and export types in `modmesh.core`
- add `Polygon3d` unit tests covering creation, orientation, equality/identity, and R-tree search

## AI Usage

GitHub Copilot + Cluade 4.5
1. Provided the class and API draft and asked AI to finish the implementation
2. Asked AI to generate tests
3. Asked AI to generate PR description