### PR TITLE
fix `make pyprof` hang issue

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -404,11 +404,9 @@ jobs:
           fi
           make pytest ${JOB_MAKE_ARGS}
 
-      # FIXME: Temporarily turns off profiling run on macos-15
-      # because it takes 6 hours to fail
-      #- name: make pyprof
-      #  run: |
-      #    make pyprof
+      - name: make pyprof
+        run: |
+          make pyprof
 
       - name: make buildext BUILD_QT=ON USE_PYTEST_HELPER_BINDING=OFF
         run: |

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -1874,6 +1874,11 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const 
                                              << " but the array is " << athis->ndim() << " dimension");
     }
 
+    if (indices.size() == 0)
+    {
+        return A(indices.shape());
+    }
+
     size_t max_idx = athis->shape()[0];
 
     I const * oor_ptr = check_index_range(indices, max_idx);

--- a/cpp/modmesh/simd/neon/neon.hpp
+++ b/cpp/modmesh/simd/neon/neon.hpp
@@ -115,6 +115,13 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
     T const * ret = NULL;
 
     T const * ptr = start;
+
+    // Check if array is large enough for SIMD processing
+    if (end - start < N_lane)
+    {
+        return generic::check_between<T>(start, end, min_val, max_val);
+    }
+
     for (; ptr <= end - N_lane; ptr += N_lane)
     {
         data_vec = vld1q(ptr);

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(
     ${MODMESH_BUFFER_SOURCES}
     ${MODMESH_SERIALIZATION_SOURCES}
     ${MODMESH_TRANSFORM_SOURCES}
+    ${MODMESH_SIMD_SOURCES}
 )
 
 target_link_libraries(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1017,7 +1017,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
         _check(test_data[3])
         _check(test_data[4], True)
 
-    def test_talk_along_axis(self):
+    def test_take_along_axis(self):
         data = [1, 5, 10, 2, 6, 9, 7, 8, 4, 3]
         narr = np.array(data, dtype='int32')
         data_arr = modmesh.SimpleArrayInt32(array=narr)


### PR DESCRIPTION
## Relates to & fixes Issue
https://github.com/solvcon/modmesh/issues/635

## Overview
This PR contains safe guards for:
- passing empty list [] to SimpleArray
- array large enough for simd in `check_between` function in `neon.hpp` <- (array size can be incompatible with neon simd lane size causing a segfault)

# How I discovered a solution
Out of curiosity I just created the gtest to test the `take_along_axis_simd` function directly and found segfaults. I just fixed the segfaults and ran `make pyprof` again just to see what happens and I observed that `make pyprof` no longer hanged.

# I tried to reproduce the hang
Then I got curious and tried to reproduce the bug so I:
- removed the segfault safeguards (reverted my changes)
- Then I created a new python script to reproduce the hanging issue and called the simd function, but it still did not hang (gave the same segfault as gtest does)
- Then I added the `modmesh.call_profiler` similar to the actual profiling script and viola it hanged.

So to reproduce you need:
- a segfault
- python script with profiler

# More info
It seems passing the array smaller than N_lane size causes infinite recursion (because the first for loop is skipped but there is a recursive call right below that loop which calls the function again with the same array). That infinite recursion leads to stack corruption which causes the segfault. I still have not confirmed why running under profiler makes any difference.
