### PR TITLE
Remove old Formatter, use std::format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
     - name: dependency by apt
       run: |
         VERSION_ID=$(bash -c 'source /etc/os-release ; echo $VERSION_ID')        
-        if [ "20.04" == "$VERSION_ID" ] ; then CLANG_TIDY_VERSION=10 ; else CLANG_TIDY_VERSION=14 ; fi
+        if [ "20.04" == "$VERSION_ID" ] ; then CLANG_TIDY_VERSION=10 ; else CLANG_TIDY_VERSION=18 ; fi
         sudo apt-get -qqy update
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ silversearcher-ag \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ find_program(
 )
 if(USE_CLANG_TIDY)
     if(CLANG_TIDY_EXE)
-        set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-header-filter=/cpp/.\*/modmesh/.\*")
+        set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-header-filter=/cpp/.\*/modmesh/.\*" "--extra-arg=-std=c++2b")
         if(LINT_AS_ERRORS)
             set(DO_CLANG_TIDY "${DO_CLANG_TIDY}" "-warnings-as-errors=*")
         endif()
@@ -88,7 +88,7 @@ endif()
 
 include(Flake8)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/contrib/dependency/apt.ubuntu-2204.sh
+++ b/contrib/dependency/apt.ubuntu-2204.sh
@@ -1,7 +1,7 @@
 # Install system tools.
 apt-get -qy install sudo curl git
 # Install compiler and build tools.
-apt-get -qy install build-essential make cmake libc6-dev gcc g++ clang-tidy-14
+apt-get -qy install build-essential make cmake libc6-dev gcc g++ clang-tidy-18
 # Install Python.
 apt-get -qy install python3 python3-dev python3-env python3-setuptools python3.10-dev
 apt-get -qy install python3-numpy python3-pytest python3-flake8

--- a/contrib/standalone_buffer/modbuf.cpp
+++ b/contrib/standalone_buffer/modbuf.cpp
@@ -25,9 +25,9 @@ void import_numpy()
     }
 }
 
-}
+} // namespace python
 
-}
+} // namespace modmesh
 
 PYBIND11_MODULE(modbuf, mod)
 {

--- a/cpp/modmesh/base.hpp
+++ b/cpp/modmesh/base.hpp
@@ -32,13 +32,14 @@
 #include <cstdint>
 
 // Shared by all code.
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <format>
+#include <iostream>
+#include <map>
 #include <memory>
 #include <optional>
-#include <iostream>
 #include <sstream>
-#include <map>
 
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
@@ -132,7 +133,7 @@ public:
 }; /* end class SpaceBase */
 
 // Taken from https://stackoverflow.com/a/12262626
-class Formatter
+class [[deprecated("Use std::format instead")]] Formatter
 {
 
 public:

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -38,10 +38,11 @@ inline std::size_t validate_alignment(std::size_t alignment, const char * prefix
 {
     if (alignment != 0 && alignment != 16 && alignment != 32 && alignment != 64)
     {
+        const std::string prefix_str = prefix ? std::string(prefix) + ": " : "";
         throw std::invalid_argument(
-            Formatter()
-            << (prefix ? prefix : "") << (prefix ? ": " : "")
-            << "alignment must be 0, 16, 32, or 64, but got " << alignment);
+            std::format("{}alignment must be 0, 16, 32, or 64, but got {}",
+                        prefix_str,
+                        alignment));
     }
     return alignment;
 }
@@ -51,10 +52,12 @@ inline void validate_size_alignment(std::size_t size, std::size_t alignment, con
 {
     if (alignment > 0 && size % alignment != 0)
     {
+        const std::string prefix_str = prefix ? std::string(prefix) + ": " : "";
         throw std::invalid_argument(
-            Formatter()
-            << (prefix ? prefix : "") << (prefix ? ": " : "")
-            << "size " << size << " must be a multiple of alignment " << alignment);
+            std::format("{}size {} must be a multiple of alignment {}",
+                        prefix_str,
+                        size,
+                        alignment));
     }
 }
 
@@ -135,7 +138,7 @@ protected:
     {
         if (it >= size())
         {
-            throw std::out_of_range(Formatter() << name() << ": index " << it << " is out of bounds with size " << size());
+            throw std::out_of_range(std::format("{}: index {} is out of bounds with size {}", name(), it, size()));
         }
     }
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -138,11 +138,11 @@ public:
         if (size() + amount > capacity())
         {
             throw std::out_of_range(
-                Formatter()
-                << name() << ": "
-                << "size() " << size() << " + "
-                << "amount " << amount << " > "
-                << "capacity() " << capacity());
+                std::format("{}: size() {} + amount {} > capacity() {}",
+                            name(),
+                            size(),
+                            amount,
+                            capacity()));
         }
         m_end += amount;
     }

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -81,8 +81,7 @@ inline size_t buffer_offset(small_vector<size_t> const & stride, small_vector<si
 {
     if (stride.size() != idx.size())
     {
-        throw std::out_of_range(Formatter() << "stride size " << stride.size() << " != "
-                                            << "index size " << idx.size());
+        throw std::out_of_range(std::format("stride size {} != index size {}", stride.size(), idx.size()));
     }
     size_t offset = 0;
     for (size_t it = 0; it < stride.size(); ++it)
@@ -614,7 +613,8 @@ public:
         }
         else
         {
-            throw std::runtime_error(Formatter() << "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+            throw std::runtime_error(
+                "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
         }
         return *athis;
     }
@@ -635,7 +635,8 @@ public:
         }
         else
         {
-            throw std::runtime_error(Formatter() << "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+            throw std::runtime_error(
+                "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
         }
         return *athis;
     }
@@ -713,7 +714,8 @@ public:
         }
         else
         {
-            throw std::runtime_error(Formatter() << "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
+            throw std::runtime_error(
+                "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
         }
         return *athis;
     }
@@ -923,30 +925,33 @@ A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
 
     auto format_shape = [](A const * arr) -> std::string
     {
-        Formatter shape_formatter;
         if (arr->ndim() == 0)
         {
-            shape_formatter << "()";
+            return "()";
         }
         else
         {
-            shape_formatter << "(";
+            std::string result = "(";
             for (size_t i = 0; i < arr->ndim(); ++i)
             {
                 if (i > 0)
-                    shape_formatter << ",";
-                shape_formatter << arr->shape(i);
+                {
+                    result += ",";
+                }
+                result += std::to_string(arr->shape(i));
             }
-            shape_formatter << ")";
+            result += ")";
+            return result;
         }
-        return shape_formatter.str();
     };
 
     if (this_ndim != 2 || other_ndim != 2)
     {
-        throw std::out_of_range(Formatter() << "SimpleArray::matmul(): unsupported dimensions: this="
-                                            << format_shape(athis) << " other=" << format_shape(&other)
-                                            << ". Only 2D x 2D matrix multiplication is supported");
+        const std::string err = std::format("SimpleArray::matmul(): unsupported dimensions: "
+                                            "this={} other={}. Only 2D x 2D matrix multiplication is supported",
+                                            format_shape(athis),
+                                            format_shape(&other));
+        throw std::out_of_range(err);
     }
 
     const size_t m = athis->shape(0);
@@ -955,8 +960,10 @@ A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
 
     if (k != other.shape(0))
     {
-        throw std::out_of_range(Formatter() << "SimpleArray::matmul(): shape mismatch: this="
-                                            << format_shape(athis) << " other=" << format_shape(&other));
+        throw std::out_of_range(
+            std::format("SimpleArray::matmul(): shape mismatch: this={} other={}",
+                        format_shape(athis),
+                        format_shape(&other)));
     }
 
     typename detail::SimpleArrayInternalTypes<T>::shape_type result_shape{m, n};
@@ -1052,8 +1059,9 @@ void SimpleArrayMixinSort<A, T>::sort(void)
     auto athis = static_cast<A *>(this);
     if (athis->ndim() != 1)
     {
-        throw std::runtime_error(Formatter() << "SimpleArray::sort(): currently only support 1D array but the array is "
-                                             << athis->ndim() << " dimension");
+        throw std::runtime_error(
+            std::format(
+                "SimpleArray::sort(): currently only support 1D array but the array is {} dimension", athis->ndim()));
     }
 
     std::sort(athis->begin(), athis->end());
@@ -1264,8 +1272,10 @@ public:
             const size_t nbytes = m_shape[0] * m_stride[0] * ITEMSIZE;
             if (nbytes != buffer->nbytes())
             {
-                throw std::runtime_error(Formatter() << "SimpleArray: shape byte count " << nbytes
-                                                     << " differs from buffer " << buffer->nbytes());
+                throw std::runtime_error(
+                    std::format("SimpleArray: shape byte count {} differs from buffer {}",
+                                nbytes,
+                                buffer->nbytes()));
             }
         }
     }
@@ -1539,12 +1549,14 @@ public:
             if (0 == ndim())
             {
                 throw std::out_of_range(
-                    Formatter() << "SimpleArray: cannot set nghost " << nghost << " > 0 to an empty array");
+                    std::format("SimpleArray: cannot set nghost {} > 0 to an empty array", nghost));
             }
             if (nghost > shape(0))
             {
                 throw std::out_of_range(
-                    Formatter() << "SimpleArray: cannot set nghost " << nghost << " > shape(0) " << shape(0));
+                    std::format("SimpleArray: cannot set nghost {} > shape(0) {}",
+                                nghost,
+                                shape(0)));
             }
         }
         m_nghost = nghost;
@@ -1673,37 +1685,48 @@ private:
         if (m_nghost != 0 && ndim() != 1)
         {
             throw std::out_of_range(
-                Formatter() << "SimpleArray::validate_range(): cannot handle "
-                            << ndim() << "-dimensional (more than 1) array with non-zero nghost: " << m_nghost);
+                std::format("SimpleArray::validate_range(): "
+                            "cannot handle {}-dimensional (more than 1) array with non-zero nghost: {}",
+                            ndim(),
+                            m_nghost));
         }
         if (it < -static_cast<ssize_t>(m_nghost))
         {
-            throw std::out_of_range(Formatter() << "SimpleArray: index " << it << " < -nghost: " << -static_cast<ssize_t>(m_nghost));
+            throw std::out_of_range(
+                std::format("SimpleArray: index {} < -nghost: {}",
+                            it,
+                            -static_cast<ssize_t>(m_nghost)));
         }
         if (it >= static_cast<ssize_t>((buffer().nbytes() / ITEMSIZE) - m_nghost))
         {
             throw std::out_of_range(
-                Formatter() << "SimpleArray: index " << it << " >= " << (buffer().nbytes() / ITEMSIZE) - m_nghost
-                            << " (buffer size: " << (buffer().nbytes() / ITEMSIZE) << " - nghost: " << m_nghost << ")");
+                std::format("SimpleArray: index {} >= {} (buffer size: {} - nghost: {})",
+                            it,
+                            (buffer().nbytes() / ITEMSIZE) - m_nghost,
+                            (buffer().nbytes() / ITEMSIZE),
+                            m_nghost));
         }
     }
 
     void validate_shape(small_vector<ssize_t> const & idx) const
     {
-        auto index2string = [&idx]()
+        auto index2string = [&idx]() -> std::string
         {
-            Formatter ms;
-            ms << "[";
+            if (idx.empty())
+            {
+                return "[]";
+            }
+            std::string result = "[";
             for (size_t it = 0; it < idx.size(); ++it)
             {
-                ms << idx[it];
-                if (it != idx.size() - 1)
+                if (it > 0)
                 {
-                    ms << ", ";
+                    result += ", ";
                 }
+                result += std::to_string(idx[it]);
             }
-            ms << "]";
-            return ms.str();
+            result += "]";
+            return result;
         };
 
         // Test for the "index shape".
@@ -1713,20 +1736,28 @@ private:
         }
         if (idx.size() != m_shape.size())
         {
-            throw std::out_of_range(Formatter() << "SimpleArray: dimension of input indices " << index2string()
-                                                << " != array dimension " << m_shape.size());
+            throw std::out_of_range(
+                std::format("SimpleArray: dimension of input indices {} != array dimension {}",
+                            index2string(),
+                            m_shape.size()));
         }
 
         // Test the first dimension.
         if (idx[0] < -static_cast<ssize_t>(m_nghost))
         {
-            throw std::out_of_range(Formatter() << "SimpleArray: dim 0 in " << index2string()
-                                                << " < -nghost: " << -static_cast<ssize_t>(m_nghost));
+            throw std::out_of_range(
+                std::format("SimpleArray: dim 0 in {} < -nghost: {}",
+                            index2string(),
+                            -static_cast<ssize_t>(m_nghost)));
         }
         if (idx[0] >= static_cast<ssize_t>(nbody()))
         {
-            throw std::out_of_range(Formatter() << "SimpleArray: dim 0 in " << index2string() << " >= nbody: " << nbody()
-                                                << " (shape[0]: " << m_shape[0] << " - nghost: " << nghost() << ")");
+            throw std::out_of_range(
+                std::format("SimpleArray: dim 0 in {} >= nbody: {} (shape[0]: {} - nghost: {})",
+                            index2string(),
+                            nbody(),
+                            m_shape[0],
+                            nghost()));
         }
 
         // Test the rest of the dimensions.
@@ -1734,12 +1765,18 @@ private:
         {
             if (idx[it] < 0)
             {
-                throw std::out_of_range(Formatter() << "SimpleArray: dim " << it << " in " << index2string() << " < 0");
+                throw std::out_of_range(std::format("SimpleArray: dim {} in {} < 0",
+                                                    it,
+                                                    index2string()));
             }
             if (idx[it] >= static_cast<ssize_t>(m_shape[it]))
             {
-                throw std::out_of_range(Formatter() << "SimpleArray: dim " << it << " in " << index2string()
-                                                    << " >= shape[" << it << "]: " << m_shape[it]);
+                throw std::out_of_range(
+                    std::format("SimpleArray: dim {} in {} >= shape[{}]: {}",
+                                it,
+                                index2string(),
+                                it,
+                                m_shape[it]));
             }
         }
     }
@@ -1763,8 +1800,10 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort(void)
     auto athis = static_cast<A *>(this);
     if (athis->ndim() != 1)
     {
-        throw std::runtime_error(Formatter() << "SimpleArray::argsort(): currently only support 1D array"
-                                             << " but the array is " << athis->ndim() << " dimension");
+        throw std::runtime_error(
+            std::format("SimpleArray::argsort(): "
+                        "currently only support 1D array but the array is {} dimension",
+                        athis->ndim()));
     }
 
     SimpleArray<uint64_t> ret(athis->shape());
@@ -1792,8 +1831,10 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     auto athis = static_cast<A *>(this);
     if (athis->ndim() != 1)
     {
-        throw std::runtime_error(Formatter() << "SimpleArray::take_along_axis(): currently only support 1D array"
-                                             << " but the array is " << athis->ndim() << " dimension");
+        throw std::runtime_error(
+            std::format("SimpleArray::take_along_axis(): "
+                        "currently only support 1D array but the array is {} dimension",
+                        athis->ndim()));
     }
 
     size_t max_idx = athis->shape()[0];
@@ -1805,18 +1846,21 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
         {
             size_t offset = src - indices.begin();
             shape_type const & stride = indices.stride();
-            Formatter err_msg;
-            err_msg << "SimpleArray::take_along_axis(): indices[" << offset / stride[0];
+            std::string indices_str = "[" + std::to_string(offset / stride[0]);
             offset %= stride[0];
             for (size_t dim = 1; dim < stride.size(); ++dim)
             {
-                err_msg << ", " << offset / stride[dim];
+                indices_str += ", " + std::to_string(offset / stride[dim]);
                 offset %= stride[dim];
             }
-            err_msg << "] is " << *src << ", which is out of range of the array size "
-                    << max_idx;
+            indices_str += "]";
 
-            throw std::out_of_range(err_msg);
+            throw std::out_of_range(
+                std::format("SimpleArray::take_along_axis(): "
+                            "indices{} is {}, which is out of range of the array size {}",
+                            indices_str,
+                            *src,
+                            max_idx));
         }
         src++;
     }
@@ -1870,8 +1914,10 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const 
     auto athis = static_cast<A *>(this);
     if (athis->ndim() != 1)
     {
-        throw std::runtime_error(Formatter() << "SimpleArray::take_along_axis(): currently only support 1D array"
-                                             << " but the array is " << athis->ndim() << " dimension");
+        const auto err = std::format("SimpleArray::take_along_axis(): "
+                                     "currently only support 1D array but the array is {} dimension",
+                                     athis->ndim());
+        throw std::runtime_error(err);
     }
 
     size_t max_idx = athis->shape()[0];
@@ -1882,18 +1928,21 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const 
         size_t offset = oor_ptr - indices.begin();
         shape_type const & stride = indices.stride();
         const size_t ndim = stride.size();
-        Formatter err_msg;
-        err_msg << "SimpleArray::take_along_axis_simd(): indices[" << offset / stride[0];
+        std::string indices_str = "[" + std::to_string(offset / stride[0]);
         offset %= stride[0];
         for (size_t dim = 1; dim < ndim; ++dim)
         {
-            err_msg << ", " << offset / stride[dim];
+            indices_str += ", " + std::to_string(offset / stride[dim]);
             offset %= stride[dim];
         }
-        err_msg << "] is " << *oor_ptr << ", which is out of range of the array size "
-                << max_idx;
+        indices_str += "]";
 
-        throw std::out_of_range(err_msg);
+        const auto err = std::format("SimpleArray::take_along_axis_simd(): "
+                                     "indices{} is {}, which is out of range of the array size {}",
+                                     indices_str,
+                                     *oor_ptr,
+                                     max_idx);
+        throw std::out_of_range(err);
     }
 
     I const * src = indices.begin();

--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -152,7 +152,10 @@ private:
     {
         if (it >= size())
         {
-            throw std::out_of_range(Formatter() << "SimpleCollector: index " << it << " is out of bounds with size " << size());
+            throw std::out_of_range(
+                std::format("SimpleCollector: index {} is out of bounds with size {}",
+                            it,
+                            size()));
         }
     }
 

--- a/cpp/modmesh/inout/gmsh.hpp
+++ b/cpp/modmesh/inout/gmsh.hpp
@@ -109,7 +109,7 @@ private:
             // The parse only support ver 2.2 msh file.
             if (msh_ver != 2.2)
             {
-                throw std::invalid_argument(Formatter() << "modmesh does not support msh file ver " << msh_ver << ".");
+                throw std::invalid_argument(std::format("modmesh does not support msh file ver {}.", msh_ver));
             }
 
             msh_file_type = std::stoi(tokens[1]);

--- a/cpp/modmesh/linalg/factorization.hpp
+++ b/cpp/modmesh/linalg/factorization.hpp
@@ -68,7 +68,7 @@ auto Llt<T>::forward_substitution(array_type const & l, array_type const & b) ->
 {
     if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::forward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
         for (ssize_t i = 0; i < l.ndim(); ++i)
         {
@@ -83,7 +83,7 @@ auto Llt<T>::forward_substitution(array_type const & l, array_type const & b) ->
     }
     if (b.ndim() != 2 || b.shape(0) != l.shape(0))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::forward_substitution: The second argument b must be a 2D SimpleArray with first dimension matching l, but got shape (";
         for (ssize_t i = 0; i < b.ndim(); ++i)
         {
@@ -121,7 +121,7 @@ auto Llt<T>::backward_substitution(array_type const & l, array_type const & y) -
 {
     if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::backward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
         for (ssize_t i = 0; i < l.ndim(); ++i)
         {
@@ -136,7 +136,7 @@ auto Llt<T>::backward_substitution(array_type const & l, array_type const & y) -
     }
     if (y.ndim() != 2 || y.shape(0) != l.shape(0))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::backward_substitution: The second argument y must be a 2D SimpleArray with first dimension matching l, but got shape (";
         for (ssize_t i = 0; i < y.ndim(); ++i)
         {
@@ -174,7 +174,7 @@ auto Llt<T>::factorize(array_type const & a) -> array_type
 {
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::factorize: The first argument a must be a square 2D SimpleArray, but got shape (";
         for (ssize_t i = 0; i < a.ndim(); ++i)
         {
@@ -225,7 +225,7 @@ auto Llt<T>::solve(array_type const & a, array_type const & b) -> array_type
 {
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::solve: The first argument a must be a square 2D SimpleArray, but got shape (";
         for (ssize_t i = 0; i < a.ndim(); ++i)
         {
@@ -240,13 +240,13 @@ auto Llt<T>::solve(array_type const & a, array_type const & b) -> array_type
     }
     if (a.shape(0) != b.shape(0))
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::solve: The first argument a and the second argument b dimension mismatch: a.shape[0]=" << a.shape(0) << ", b.shape[0]=" << b.shape(0);
         throw std::invalid_argument(oss.str());
     }
     if (b.ndim() != 1 && b.ndim() != 2)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "Llt::solve: The second argument b must be 1D or 2D, but got " << b.ndim() << "D";
         throw std::invalid_argument(oss.str());
     }

--- a/cpp/modmesh/linalg/kalman_filter.hpp
+++ b/cpp/modmesh/linalg/kalman_filter.hpp
@@ -236,7 +236,7 @@ void KalmanFilter<T>::check_dimensions()
 {
     if (m_f.ndim() != 2 || m_f.shape(0) != m_state_size || m_f.shape(1) != m_state_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The state transition SimpleArray f must be state_sizexstate_size, but got shape (";
         for (ssize_t i = 0; i < m_f.ndim(); ++i)
         {
@@ -251,7 +251,7 @@ void KalmanFilter<T>::check_dimensions()
     }
     if (m_h.ndim() != 2 || m_h.shape(0) != m_measurement_size || m_h.shape(1) != m_state_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The measurement SimpleArray h must be measurement_sizexstate_size, but got shape (";
         for (ssize_t i = 0; i < m_h.ndim(); ++i)
         {
@@ -266,7 +266,7 @@ void KalmanFilter<T>::check_dimensions()
     }
     if (m_q.ndim() != 2 || m_q.shape(0) != m_state_size || m_q.shape(1) != m_state_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The process noise covariance SimpleArray q must be state_sizexstate_size, but got shape (";
         for (ssize_t i = 0; i < m_q.ndim(); ++i)
         {
@@ -281,7 +281,7 @@ void KalmanFilter<T>::check_dimensions()
     }
     if (m_r.ndim() != 2 || m_r.shape(0) != m_measurement_size || m_r.shape(1) != m_measurement_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The measurement noise covariance SimpleArray r must be measurement_sizexmeasurement_size, but got shape (";
         for (ssize_t i = 0; i < m_r.ndim(); ++i)
         {
@@ -296,7 +296,7 @@ void KalmanFilter<T>::check_dimensions()
     }
     if (m_p.ndim() != 2 || m_p.shape(0) != m_state_size || m_p.shape(1) != m_state_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The state covariance SimpleArray p must be state_sizexstate_size, but got shape (";
         for (ssize_t i = 0; i < m_p.ndim(); ++i)
         {
@@ -311,7 +311,7 @@ void KalmanFilter<T>::check_dimensions()
     }
     if (m_x.ndim() != 1 || m_x.shape(0) != m_state_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_dimensions: The state SimpleArray x must be 1D of length state_size, but got shape (";
         for (ssize_t i = 0; i < m_x.ndim(); ++i)
         {
@@ -329,13 +329,13 @@ void KalmanFilter<T>::check_dimensions()
     {
         if (m_b.ndim() != 2)
         {
-            Formatter oss;
+            std::ostringstream oss;
             oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be 2D when control_size > 0, but got " << m_b.ndim() << "D";
             throw std::invalid_argument(oss.str());
         }
         if (m_b.shape(0) != m_state_size || m_b.shape(1) != m_control_size)
         {
-            Formatter oss;
+            std::ostringstream oss;
             oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizexcontrol_size, but got shape (";
             for (ssize_t i = 0; i < m_b.ndim(); ++i)
             {
@@ -353,7 +353,7 @@ void KalmanFilter<T>::check_dimensions()
     {
         if (m_b.ndim() != 2 || m_b.shape(1) != 0)
         {
-            Formatter oss;
+            std::ostringstream oss;
             oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizex0 when control_size = 0, but got shape (";
             for (ssize_t i = 0; i < m_b.ndim(); ++i)
             {
@@ -410,7 +410,7 @@ void KalmanFilter<T>::check_measurement(array_type const & z)
 {
     if (z.ndim() != 1 || z.shape(0) != m_measurement_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_measurement: The measurement SimpleArray z must be 1D of length measurement_size (" << m_measurement_size << "), but got shape (";
         for (ssize_t i = 0; i < z.ndim(); ++i)
         {
@@ -430,13 +430,13 @@ void KalmanFilter<T>::check_control(array_type const & u)
 {
     if (m_control_size == 0)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_control: Control input not supported: control_size is 0";
         throw std::invalid_argument(oss.str());
     }
     if (u.ndim() != 1 || u.shape(0) != m_control_size)
     {
-        Formatter oss;
+        std::ostringstream oss;
         oss << "KalmanFilter::check_control: The control SimpleArray u must be 1D of length control_size (" << m_control_size << "), but got shape (";
         for (ssize_t i = 0; i < u.ndim(); ++i)
         {

--- a/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
+++ b/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
@@ -146,26 +146,26 @@ protected:
 
         (*this)
             .def_timed(
-                (Formatter() << "march_half_so1_alpha" << ALPHA).str().c_str(),
+                std::format("march_half_so1_alpha{}", ALPHA).c_str(),
                 [](wrapped_type & self, bool odd_plane)
                 {
                     return self.template march_half_so1_alpha<ALPHA>(odd_plane);
                 },
                 py::arg("odd_plane"))
             .def_timed(
-                (Formatter() << "march_half1_alpha" << ALPHA).str().c_str(),
+                std::format("march_half1_alpha{}", ALPHA).c_str(),
                 [](wrapped_type & self)
                 {
                     self.template march_half1_alpha<ALPHA>();
                 })
             .def_timed(
-                (Formatter() << "march_half2_alpha" << ALPHA).str().c_str(),
+                std::format("march_half2_alpha{}", ALPHA).c_str(),
                 [](wrapped_type & self)
                 {
                     self.template march_half2_alpha<ALPHA>();
                 })
             .def_timed(
-                (Formatter() << "march_alpha" << ALPHA).str().c_str(),
+                std::format("march_alpha{}", ALPHA).c_str(),
                 [](wrapped_type & self, size_t steps)
                 {
                     self.template march_alpha<ALPHA>(steps);

--- a/cpp/modmesh/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/pilot/RPythonConsoleDockWidget.cpp
@@ -158,15 +158,14 @@ void RPythonConsoleDockWidget::printCommandHistory()
     std::string lead;
     if (m_past_command_strings.size() > 1)
     {
-        lead = Formatter() << "\n[";
+        lead = "\n[";
     }
     else
     {
-        lead = Formatter() << "[";
+        lead = "[";
     }
     m_history_edit->insertPlainText(QString::fromStdString(
-        Formatter() << lead << m_last_command_serial << "] "
-                    << m_command_edit->toPlainText().toStdString() << "\n"));
+        std::format("{}{}] {}\n", lead, m_last_command_serial, m_command_edit->toPlainText().toStdString())));
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
 }

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -53,7 +53,12 @@ namespace detail
 {
 
 template <class T>
-std::string to_str(T const & self) { return Formatter() << self >> Formatter::to_str; }
+std::string to_str(T const & self)
+{
+    std::ostringstream oss;
+    oss << self;
+    return oss.str();
+}
 
 } /* end namespace detail */
 

--- a/cpp/modmesh/spacetime/core.cpp
+++ b/cpp/modmesh/spacetime/core.cpp
@@ -18,15 +18,19 @@ Grid::Grid(real_type xmin, real_type xmax, size_t ncelm, ctor_passkey const &)
 {
     if (ncelm < 1)
     {
-        throw std::invalid_argument(modmesh::Formatter()
-                                    << "Grid::Grid(xmin=" << xmin << ", xmax=" << xmax
-                                    << ", ncelm=" << ncelm << ") invalid argument: ncelm smaller than 1");
+        throw std::invalid_argument(
+            std::format("Grid::Grid(xmin={}, xmax={}, ncelm={}) invalid argument: ncelm smaller than 1",
+                        xmin,
+                        xmax,
+                        ncelm));
     }
     if (xmin >= xmax)
     {
-        throw std::invalid_argument(modmesh::Formatter()
-                                    << "Grid::Grid(xmin=" << xmin << ", xmax=" << xmax
-                                    << ", ncelm=" << ncelm << ") invalid arguments: xmin >= xmax");
+        throw std::invalid_argument(
+            std::format("Grid::Grid(xmin={}, xmax={}, ncelm={}) invalid arguments: xmin >= xmax",
+                        xmin,
+                        xmax,
+                        ncelm));
     }
     // Fill the array for CCE boundary.
     const real_type xspace = (xmax - xmin) / ncelm;
@@ -45,18 +49,20 @@ void Grid::init_from_array(array_type const & xloc)
 {
     if (xloc.size() < 2)
     {
-        throw std::invalid_argument(modmesh::Formatter()
-                                    << "Grid::init_from_array(xloc) invalid arguments: "
-                                    << "xloc.size()=" << xloc.size() << " smaller than 2");
+        throw std::invalid_argument(
+            std::format("Grid::init_from_array(xloc) invalid arguments: xloc.size()={} smaller than 2",
+                        xloc.size()));
     }
     for (size_t it = 0; it < xloc.size() - 1; ++it)
     {
         if (xloc[it] >= xloc[it + 1])
         {
-            throw std::invalid_argument(modmesh::Formatter()
-                                        << "Grid::init_from_array(xloc) invalid arguments: "
-                                        << "xloc[" << it << "]=" << xloc[it]
-                                        << " >= xloc[" << it + 1 << "]=" << xloc[it + 1]);
+            throw std::invalid_argument(
+                std::format("Grid::init_from_array(xloc) invalid arguments: xloc[{}]={} >= xloc[{}]={}",
+                            it,
+                            xloc[it],
+                            it + 1,
+                            xloc[it + 1]));
         }
     }
     m_ncelm = xloc.size() - 1;
@@ -114,10 +120,12 @@ void Celm::move_at(int_type offset)
     const size_t xindex = this->xindex() + offset;
     if (xindex < 2 || xindex >= grid().xsize() - 2)
     {
-        throw std::out_of_range(modmesh::Formatter()
-                                << "Celm(xindex=" << this->xindex() << ")::move_at(offset=" << offset
-                                << "): xindex = " << xindex
-                                << " outside the interval [2, " << grid().xsize() - 2 << ")");
+        throw std::out_of_range(
+            std::format("Celm(xindex={})::move_at(offset={}): xindex = {} outside the interval [2, {})",
+                        this->xindex(),
+                        offset,
+                        xindex,
+                        grid().xsize() - 2));
     }
     move(offset);
 }
@@ -127,10 +135,12 @@ void Selm::move_at(int_type offset)
     const size_t xindex = this->xindex() + offset;
     if (xindex < 1 || xindex >= grid().xsize() - 1)
     {
-        throw std::out_of_range(modmesh::Formatter()
-                                << "Selm(xindex=" << this->xindex() << ")::move_at(offset=" << offset
-                                << "): xindex = " << xindex
-                                << " outside the interval [1, " << grid().xsize() - 1 << ")");
+        throw std::out_of_range(
+            std::format("Selm(xindex={})::move_at(offset={}): xindex = {} outside the interval [1, {})",
+                        this->xindex(),
+                        offset,
+                        xindex,
+                        grid().xsize() - 1));
     }
     move(offset);
 }

--- a/cpp/modmesh/spacetime/core.hpp
+++ b/cpp/modmesh/spacetime/core.hpp
@@ -5,9 +5,9 @@
  * BSD 3-Clause License, see COPYING
  */
 
+#include <functional>
 #include <memory>
 #include <vector>
-#include <functional>
 
 #include <modmesh/modmesh.hpp>
 
@@ -381,10 +381,12 @@ inline CE const Field::celm_at(int_type ielm, bool odd_plane) const
     const CE elm = celm<CE>(ielm, odd_plane);
     if (elm.xindex() < 2 || elm.xindex() >= grid().xsize() - 2)
     {
-        throw std::out_of_range(Formatter()
-                                << "Field::celm_at(ielm=" << ielm << ", odd_plane=" << odd_plane
-                                << "): xindex = " << elm.xindex()
-                                << " outside the interval [2, " << grid().xsize() - 2 << ")");
+        throw std::out_of_range(
+            std::format("Field::celm_at(ielm={}, odd_plane={}): xindex = {} outside the interval [2, {})",
+                        ielm,
+                        static_cast<int>(odd_plane),
+                        elm.xindex(),
+                        grid().xsize() - 2));
     }
     return elm;
 }
@@ -395,10 +397,12 @@ inline CE Field::celm_at(int_type ielm, bool odd_plane)
     const CE elm = celm<CE>(ielm, odd_plane);
     if (elm.xindex() < 2 || elm.xindex() >= grid().xsize() - 2)
     {
-        throw std::out_of_range(Formatter()
-                                << "Field::celm_at(ielm=" << ielm << ", odd_plane=" << odd_plane
-                                << "): xindex = " << elm.xindex()
-                                << " outside the interval [2, " << grid().xsize() - 2 << ")");
+        throw std::out_of_range(
+            std::format("Field::celm_at(ielm={}, odd_plane={}): xindex = {} outside the interval [2, {})",
+                        ielm,
+                        static_cast<int>(odd_plane),
+                        elm.xindex(),
+                        grid().xsize() - 2));
     }
     return elm;
 }
@@ -410,10 +414,12 @@ inline SE const Field::selm_at(int_type ielm, bool odd_plane) const
     const SE elm = selm<SE>(ielm, odd_plane);
     if (elm.xindex() < 1 || elm.xindex() >= grid().xsize() - 1)
     {
-        throw std::out_of_range(Formatter()
-                                << "Field::selm_at(ielm=" << ielm << ", odd_plane=" << odd_plane
-                                << "): xindex = " << elm.xindex()
-                                << " outside the interval [1, " << grid().xsize() - 1 << ")");
+        throw std::out_of_range(
+            std::format("Field::selm_at(ielm={}, odd_plane={}): xindex = {} outside the interval [1, {})",
+                        ielm,
+                        static_cast<int>(odd_plane),
+                        elm.xindex(),
+                        grid().xsize() - 1));
     }
     return elm;
 }
@@ -424,10 +430,7 @@ inline SE Field::selm_at(int_type ielm, bool odd_plane)
     const SE elm = selm<SE>(ielm, odd_plane);
     if (elm.xindex() < 1 || elm.xindex() >= grid().xsize() - 1)
     {
-        throw std::out_of_range(Formatter()
-                                << "Field::selm_at(ielm=" << ielm << ", odd_plane=" << odd_plane
-                                << "): xindex = " << elm.xindex()
-                                << " outside the interval [1, " << grid().xsize() - 1 << ")");
+        throw std::out_of_range(std::format("Field::selm_at(ielm={}, odd_plane={}): xindex = {} outside the interval [1, {})", ielm, static_cast<int>(odd_plane), elm.xindex(), grid().xsize() - 1));
     }
     return elm;
 }
@@ -880,7 +883,7 @@ SolverBase<ST, CE, SE>::set_so0(size_t iv, typename SolverBase<ST, CE, SE>::arra
 {
     if (iv >= m_field.nvar())
     {
-        throw std::out_of_range(Formatter() << "set_so0(): iv " << iv << " >= nvar " << m_field.nvar());
+        throw std::out_of_range(std::format("set_so0(): iv {} >= nvar {}", iv, m_field.nvar()));
     }
     if (1 != arr.shape().size())
     {
@@ -889,7 +892,7 @@ SolverBase<ST, CE, SE>::set_so0(size_t iv, typename SolverBase<ST, CE, SE>::arra
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
     if (nselm != arr.size())
     {
-        throw std::out_of_range(Formatter() << "set_so0(): arr size " << arr.size() << " != nselm " << nselm);
+        throw std::out_of_range(std::format("set_so0(): arr size {} != nselm {}", arr.size(), nselm));
     }
     for (uint_type it = 0; it < nselm; ++it) { selm(it, odd_plane).so0(iv) = arr[it]; }
 }

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -189,7 +189,7 @@ pybind11::object WrapHierarchicalToggleAccess::getattr(wrapped_type & self, std:
     {
     case DynamicToggleIndex::TYPE_NONE:
         throw py::attribute_error(
-            Formatter() << "Cannot get non-existing key \"" << self.rekey(key) << "\"");
+            std::format("Cannot get non-existing key \"{}\"", self.rekey(key)));
         break;
     case DynamicToggleIndex::TYPE_BOOL:
         return py::cast(self.get_bool(key));
@@ -236,8 +236,7 @@ void WrapHierarchicalToggleAccess::setattr(wrapped_type & self, std::string cons
          *
          * Do not try to "fix" the exception using RTTI. */
         throw pybind11::attribute_error(
-            Formatter() << "Cannot set non-existing key \"" << self.rekey(key) << "\"; "
-                        << "use set_TYPE() instead");
+            std::format("Cannot set non-existing key \"{}\"; use set_TYPE() instead", self.rekey(key)));
         break;
     case DynamicToggleIndex::TYPE_BOOL:
         self.set_bool(key, py::cast<bool>(value));
@@ -488,7 +487,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
                 }
                 else
                 {
-                    throw py::attribute_error(Formatter() << "Cannot get by key \"" << key << "\"");
+                    throw py::attribute_error(std::format("Cannot get by key \"{}\"", key));
                 }
                 return ret;
             })
@@ -509,7 +508,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
                 /* solid toggle is not settable */
                 else
                 {
-                    throw py::attribute_error(Formatter() << "Cannot set by key \"" << key << "\"");
+                    throw py::attribute_error(std::format("Cannot set by key \"{}\"", key));
                 }
             })
         .def("dynamic_keys", &wrapped_type::dynamic_keys)
@@ -568,7 +567,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
 
 std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
 {
-    return Formatter() << "Toggle: USE_PYSIDE=" << self.solid().use_pyside();
+    return std::format("Toggle: USE_PYSIDE={}", self.solid().use_pyside());
 }
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCommandLineInfo

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -30,12 +30,12 @@
 
 #include <modmesh/base.hpp>
 #include <modmesh/buffer/buffer.hpp>
-#include <modmesh/toggle/profile.hpp>
 #include <modmesh/toggle/RadixTree.hpp>
+#include <modmesh/toggle/profile.hpp>
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace modmesh
 {
@@ -115,7 +115,7 @@ public:
 
     std::string rekey(std::string const & key) const
     {
-        return m_base.empty() ? key : (Formatter() << m_base << "." << key);
+        return m_base.empty() ? key : std::format("{}.{}", m_base, key);
     }
 
 private:

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -142,7 +142,7 @@ private:
     {
         if (i >= s)
         {
-            throw std::out_of_range(Formatter() << "World: (" << msg << ") i " << i << " >= size " << s);
+            throw std::out_of_range(std::format("World: ({}) i {} >= size {}", msg, i, s));
         }
     }
 

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -192,7 +192,7 @@ private:
     {
         if (i >= s)
         {
-            throw std::out_of_range(Formatter() << "Bezier3d: (" << msg << ") i " << i << " >= size " << s);
+            throw std::out_of_range(std::format("Bezier3d: ({}) i {} >= size {}", msg, i, s));
         }
     }
 

--- a/cpp/modmesh/universe/coord.hpp
+++ b/cpp/modmesh/universe/coord.hpp
@@ -72,7 +72,7 @@ public:
      */
     std::string value_string() const
     {
-        return (Formatter() << this->x() << ", " << this->y() << ", " << this->z()).str();
+        return std::format("{}, {}, {}", this->x(), this->y(), this->z());
     }
 
     using value_type = T;
@@ -238,7 +238,7 @@ private:
     {
         if (i >= s)
         {
-            throw std::out_of_range(Formatter() << "Point3d: i " << i << " >= size " << s);
+            throw std::out_of_range(std::format("Point3d: i {} >= size {}", i, s));
         }
     }
 
@@ -313,16 +313,12 @@ public:
         if (ndim > 3)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " > 3");
+                std::format("PointPad::PointPad: ndim = {} > 3", int(ndim)));
         }
         else if (ndim < 2)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " < 2");
+                std::format("PointPad::PointPad: ndim = {} < 2", int(ndim)));
         }
     }
 
@@ -340,16 +336,12 @@ public:
         else if (ndim > 3)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " > 3");
+                std::format("PointPad::PointPad: ndim = {} > 3", int(ndim)));
         }
         else if (ndim < 2)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " < 2");
+                std::format("PointPad::PointPad: ndim = {} < 2", int(ndim)));
         }
     }
 
@@ -367,16 +359,12 @@ public:
         else if (ndim > 3)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " > 3");
+                std::format("PointPad::PointPad: ndim = {} > 3", int(ndim)));
         }
         else if (ndim < 2)
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "ndim = " << int(ndim) << " < 2");
+                std::format("PointPad::PointPad: ndim = {} < 2", int(ndim)));
         }
     }
 
@@ -391,10 +379,7 @@ public:
         if (x.size() != y.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} are not the same", x.size(), y.size()));
         }
     }
 
@@ -408,10 +393,7 @@ public:
         if (x.size() != y.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} are not the same", x.size(), y.size()));
         }
     }
 
@@ -426,10 +408,10 @@ public:
         if (x.size() != y.size() || x.size() != z.size() || y.size() != z.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size() << " z.size() " << z.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} z.size() {} are not the same",
+                            x.size(),
+                            y.size(),
+                            z.size()));
         }
     }
 
@@ -443,10 +425,10 @@ public:
         if (x.size() != y.size() || x.size() != z.size() || y.size() != z.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size() << " z.size() " << z.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} z.size() {} are not the same",
+                            x.size(),
+                            y.size(),
+                            z.size()));
         }
     }
 
@@ -460,10 +442,7 @@ public:
         if (x.size() != y.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} are not the same", x.size(), y.size()));
         }
     }
 
@@ -477,10 +456,7 @@ public:
         if (x.size() != y.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} are not the same", x.size(), y.size()));
         }
     }
 
@@ -494,10 +470,10 @@ public:
         if (x.size() != y.size() || x.size() != z.size() || y.size() != z.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size() << " z.size() " << z.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} z.size() {} are not the same",
+                            x.size(),
+                            y.size(),
+                            z.size()));
         }
     }
 
@@ -511,10 +487,10 @@ public:
         if (x.size() != y.size() || x.size() != z.size() || y.size() != z.size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "PointPad::PointPad: "
-                << "x.size() " << x.size() << " y.size() " << y.size() << " z.size() " << z.size()
-                << " are not the same");
+                std::format("PointPad::PointPad: x.size() {} y.size() {} z.size() {} are not the same",
+                            x.size(),
+                            y.size(),
+                            z.size()));
         }
     }
 
@@ -540,7 +516,7 @@ public:
     {
         if (m_ndim != 2)
         {
-            throw std::out_of_range(Formatter() << "PointPad::append: ndim must be 2 but is " << int(m_ndim));
+            throw std::out_of_range(std::format("PointPad::append: ndim must be 2 but is {}", int(m_ndim)));
         }
         m_x.push_back(x);
         m_y.push_back(y);
@@ -550,7 +526,7 @@ public:
     {
         if (m_ndim != 3)
         {
-            throw std::out_of_range(Formatter() << "PointPad::append: ndim must be 3 but is " << int(m_ndim));
+            throw std::out_of_range(std::format("PointPad::append: ndim must be 3 but is {}", int(m_ndim)));
         }
         m_x.push_back(x);
         m_y.push_back(y);
@@ -720,7 +696,7 @@ public:
     {
         if (m_ndim != 3)
         {
-            throw std::out_of_range(Formatter() << "PointPad::mirror_z: ndim must be 3 but is " << int(m_ndim));
+            throw std::out_of_range(std::format("PointPad::mirror_z: ndim must be 3 but is {}", int(m_ndim)));
         }
         for (size_t i = 0; i < m_x.size(); ++i)
         {
@@ -914,7 +890,7 @@ private:
     {
         if (i >= s)
         {
-            throw std::out_of_range(Formatter() << "Segment3d: i " << i << " >= size " << s);
+            throw std::out_of_range(std::format("Segment3d: i {} >= size {}", i, s));
         }
     }
 
@@ -1335,7 +1311,7 @@ public:
         if (ndim() != 3)
         {
             throw std::out_of_range(
-                Formatter() << "SegmentPad::mirror_z: cannot mirror Z axis for ndim " << int(ndim()));
+                std::format("SegmentPad::mirror_z: cannot mirror Z axis for ndim {}", int(ndim())));
         }
         size_t const nseg = size();
         for (size_t i = 0; i < nseg; ++i)
@@ -1365,10 +1341,9 @@ private:
         if (m_p0->size() != m_p1->size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "SegmentPad::SegmentPad: "
-                << "p0.size() " << p0.size() << " p1.size() " << p1.size()
-                << " are not the same");
+                std::format("SegmentPad::SegmentPad: p0.size() {} p1.size() {} are not the same",
+                            p0.size(),
+                            p1.size()));
         }
     }
 

--- a/cpp/modmesh/universe/polygon.hpp
+++ b/cpp/modmesh/universe/polygon.hpp
@@ -239,7 +239,7 @@ private:
     {
         if (i >= s)
         {
-            throw std::out_of_range(Formatter() << "Triangle3d: i " << i << " >= size " << s);
+            throw std::out_of_range(std::format("Triangle3d: i {} >= size {}", i, s));
         }
     }
 
@@ -733,7 +733,7 @@ public:
         if (ndim() != 3)
         {
             throw std::out_of_range(
-                Formatter() << "TrianglePad::mirror_z: cannot mirror Z axis for ndim " << int(ndim()));
+                std::format("TrianglePad::mirror_z: cannot mirror Z axis for ndim {}", int(ndim())));
         }
         size_t const ntri = size();
         for (size_t i = 0; i < ntri; ++i)
@@ -765,10 +765,10 @@ private:
         if (m_p0->size() != m_p1->size() || m_p0->size() != m_p2->size())
         {
             throw std::invalid_argument(
-                Formatter()
-                << "TrianglePad::TrianglePad: "
-                << "p0.size() " << p0.size() << " p1.size() " << p1.size() << " p2.size() " << p2.size()
-                << " are not the same");
+                std::format("TrianglePad::TrianglePad: p0.size() {} p1.size() {} p2.size() {} are not the same",
+                            p0.size(),
+                            p1.size(),
+                            p2.size()));
         }
     }
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -70,7 +70,7 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
             {
                 // Hard-code the Python type names in the static variable before finding a systematic way.
                 static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
-                return (Formatter() << ptypename << "(" << self.value_string() << ")").str();
+                return std::format("{}({})", ptypename, self.value_string());
             })
         .def_alias("__repr__", "__str__")
         .def(
@@ -373,11 +373,12 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
                 // Hard-code the Python type names in the static variables before finding a systematic way.
                 static char const * stypename = std::is_same_v<T, double> ? "Segment3dFp64" : "Segment3dFp32";
                 static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
-                return (Formatter()
-                        << stypename << "("
-                        << ptypename << "(" << self.p0().value_string() << "), "
-                        << ptypename << "(" << self.p1().value_string() << "))")
-                    .str();
+                return std::format("{}({}({}), {}({}))",
+                                   stypename,
+                                   ptypename,
+                                   self.p0().value_string(),
+                                   ptypename,
+                                   self.p1().value_string());
             })
         .def_alias("__repr__", "__str__")
         .def(
@@ -728,12 +729,14 @@ WrapTriangle3d<T>::WrapTriangle3d(pybind11::module & mod, const char * pyname, c
             {
                 static char const * ttypename = std::is_same_v<T, double> ? "Triangle3dFp64" : "Triangle3dFp32";
                 static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
-                return (Formatter()
-                        << ttypename << "("
-                        << ptypename << "(" << self.p0().value_string() << "), "
-                        << ptypename << "(" << self.p1().value_string() << "), "
-                        << ptypename << "(" << self.p2().value_string() << "))")
-                    .str();
+                return std::format("{}({}({}), {}({}), {}({}))",
+                                   ttypename,
+                                   ptypename,
+                                   self.p0().value_string(),
+                                   ptypename,
+                                   self.p1().value_string(),
+                                   ptypename,
+                                   self.p2().value_string());
             })
         .def_alias("__repr__", "__str__")
         .def(
@@ -1102,13 +1105,16 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
                 // Hard-code the Python type names in the static variables before finding a systematic way.
                 static char const * btypename = std::is_same_v<T, double> ? "Bezier3dFp64" : "Bezier3dFp32";
                 static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
-                return (Formatter()
-                        << btypename << "("
-                        << ptypename << "(" << self.p0().value_string() << "), "
-                        << ptypename << "(" << self.p1().value_string() << "), "
-                        << ptypename << "(" << self.p2().value_string() << "), "
-                        << ptypename << "(" << self.p3().value_string() << "))")
-                    .str();
+                return std::format("{}({}({}), {}({}), {}({}), {}({}))",
+                                   btypename,
+                                   ptypename,
+                                   self.p0().value_string(),
+                                   ptypename,
+                                   self.p1().value_string(),
+                                   ptypename,
+                                   self.p2().value_string(),
+                                   ptypename,
+                                   self.p3().value_string());
             })
         .def_alias("__repr__", "__str__")
         .def("__len__",

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
     test_nopython_serializable.cpp
     test_nopython_transform.cpp
     test_nopython_rtree.cpp
+    test_nopython_formatter.cpp
     ${MODMESH_TOGGLE_SOURCES}
     ${MODMESH_BUFFER_SOURCES}
     ${MODMESH_SERIALIZATION_SOURCES}

--- a/gtests/test_nopython_formatter.cpp
+++ b/gtests/test_nopython_formatter.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025, Liu, An-Chi <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Intended to use deprecated Formatter as the demo of comparison with std::format
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#include <modmesh/base.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <format>
+#include <string>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+TEST(Formatter, basic_usage)
+{
+    modmesh::Formatter formatter;
+    formatter << "Hello, "
+              << "World!"
+              << " " << 42;
+    std::string formatter_result = formatter.str();
+
+    std::string format_result = std::format("Hello, {}! {}", "World", 42);
+
+    EXPECT_EQ(formatter_result, "Hello, World! 42");
+    EXPECT_EQ(format_result, "Hello, World! 42");
+    EXPECT_EQ(formatter_result, format_result);
+}
+
+TEST(Formatter, numeric_types)
+{
+    modmesh::Formatter formatter;
+    formatter << "int: " << 123 << ", double: " << 3.14159 << ", bool: " << true;
+    std::string formatter_result = formatter.str();
+
+    std::string format_result = std::format("int: {}, double: {}, bool: {}", 123, 3.14159, true);
+
+    EXPECT_EQ(formatter_result, "int: 123, double: 3.14159, bool: 1");
+    EXPECT_EQ(format_result, "int: 123, double: 3.14159, bool: true");
+}
+
+TEST(Formatter, chaining)
+{
+    std::string formatter_result = (modmesh::Formatter() << "x = " << 10 << ", y = " << 20).str();
+
+    std::string format_result = std::format("x = {}, y = {}", 10, 20);
+
+    EXPECT_EQ(formatter_result, "x = 10, y = 20");
+    EXPECT_EQ(format_result, "x = 10, y = 20");
+    EXPECT_EQ(formatter_result, format_result);
+}
+
+TEST(Formatter, conversion_operator)
+{
+    std::string formatter_result = modmesh::Formatter() << "Test " << 123;
+
+    std::string format_result = std::format("Test {}", 123);
+
+    EXPECT_EQ(formatter_result, "Test 123");
+    EXPECT_EQ(format_result, "Test 123");
+    EXPECT_EQ(formatter_result, format_result);
+}
+
+TEST(StdFormat, basic_usage)
+{
+    std::string format_result = std::format("Hello, {}! {}", "World", 42);
+
+    std::string formatter_result = (modmesh::Formatter() << "Hello, "
+                                                         << "World!"
+                                                         << " " << 42)
+                                       .str();
+
+    EXPECT_EQ(format_result, "Hello, World! 42");
+    EXPECT_EQ(formatter_result, "Hello, World! 42");
+    EXPECT_EQ(format_result, formatter_result);
+}
+
+TEST(StdFormat, numeric_types)
+{
+    std::string format_result = std::format("int: {}, double: {}, bool: {}", 123, 3.14159, true);
+
+    modmesh::Formatter formatter;
+    formatter << "int: " << 123 << ", double: " << 3.14159 << ", bool: " << true;
+    std::string formatter_result = formatter.str();
+
+    EXPECT_EQ(format_result, "int: 123, double: 3.14159, bool: true");
+    EXPECT_EQ(formatter_result, "int: 123, double: 3.14159, bool: 1");
+}
+
+TEST(StdFormat, formatting_options)
+{
+    std::string format_result = std::format("hex: {:#x}, precision: {:.2f}", 255, 3.14159);
+
+    std::string formatter_result = (modmesh::Formatter() << "hex: " << 255 << ", precision: " << 3.14159).str();
+
+    EXPECT_EQ(format_result, "hex: 0xff, precision: 3.14");
+    EXPECT_EQ(formatter_result, "hex: 255, precision: 3.14159");
+}
+
+TEST(FormatterVsStdFormat, simple_string_comparison)
+{
+    std::string formatter_result = (modmesh::Formatter() << "Value: " << 42).str();
+    std::string format_result = std::format("Value: {}", 42);
+
+    EXPECT_EQ(formatter_result, format_result);
+}
+
+TEST(FormatterVsStdFormat, multiple_values_comparison)
+{
+    std::string formatter_result = (modmesh::Formatter() << "x = " << 10 << ", y = " << 20 << ", z = " << 30).str();
+    std::string format_result = std::format("x = {}, y = {}, z = {}", 10, 20, 30);
+
+    EXPECT_EQ(formatter_result, format_result);
+}
+
+TEST(FormatterVsStdFormat, performance_formatter)
+{
+    auto start = std::chrono::high_resolution_clock::now();
+
+    std::string result;
+    for (int32_t i = 0; i < 10000; ++i)
+    {
+        result = (modmesh::Formatter() << "Iteration: " << i << ", Value: " << i * 2).str();
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << "Formatter time: " << duration.count() << " microseconds" << std::endl;
+
+    EXPECT_FALSE(result.empty());
+}
+
+TEST(FormatterVsStdFormat, performance_std_format)
+{
+    auto start = std::chrono::high_resolution_clock::now();
+
+    std::string result;
+    for (int32_t i = 0; i < 10000; ++i)
+    {
+        result = std::format("Iteration: {}, Value: {}", i, i * 2);
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << "std::format time: " << duration.count() << " microseconds" << std::endl;
+
+    EXPECT_FALSE(result.empty());
+}
+
+#pragma GCC diagnostic pop
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Since now we move to C++23. Use std::format instead of handcraft formater.

Using Copilot + Claude 4.5 with the prompt "remove Formatter in the whole project, and use std::format"