### PR TITLE
ci: send email to mailing list when CI fails on master branch

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -641,3 +641,33 @@ jobs:
         with:
           name: modmesh-pilot-win64
           path: modmesh-pilot-win64/
+
+  send_email_on_failure:
+    name: send_emails_when_fails
+    needs: [standalone_buffer, build_ubuntu, build_macos, build_windows]
+    runs-on: ubuntu-latest
+    # Run if any of the dependencies failed in master branch
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    steps:
+      - name: Send mail to mailing list
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          # Subject: Uses the Repository name
+          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          # Body: Lists the result of every job
+          body: |
+            The workflow ${{ github.workflow }} has failed.
+            Job Status Report:
+            ------------------
+            - standalone_buffer: ${{ needs.standalone_buffer.result }}
+            - build_ubuntu: ${{ needs.build_ubuntu.result }}
+            - build_macos: ${{ needs.build_macos.result }}
+            - build_windows: ${{ needs.build_windows.result }}
+
+            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          to: solvcon@googlegroups.com
+          from: solvcon_notification

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -320,3 +320,32 @@ jobs:
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+
+  send_email_on_failure:
+    name: send_emails_when_fails
+    needs: [clang_format_check, tidy_flake8_ubuntu, tidy_flake8_macos]
+    runs-on: ubuntu-latest
+    # Run if any of the dependencies failed in master branch
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    steps:
+      - name: Send mail to mailing list
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          # Subject: Uses the Repository name
+          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          # Body: Lists the result of every job
+          body: |
+            The workflow ${{ github.workflow }} has failed.
+            Job Status Report:
+            ------------------
+            - clang_format_check: ${{ needs.clang_format_check.result }}
+            - tidy_flake8_ubuntu: ${{ needs.tidy_flake8_ubuntu.result }}
+            - tidy_flake8_macos: ${{ needs.tidy_flake8_macos.result }}
+
+            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          to: solvcon@googlegroups.com
+          from: solvcon_notification

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -183,7 +183,35 @@ jobs:
           python3 -c "import _modmesh; print(_modmesh.__file__)"
           # The following command is the original commend, and it will fail on pytest == 8.0.0 .
           # pytest --rootdir=/tmp -v
-          # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781  
+          # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781
           # The alternative command to solve the issue is ```pytest --rootdir=. -v``` .
           pytest --rootdir=. -v
           cd ..
+
+  send_email_on_failure:
+    name: send_emails_when_fails
+    needs: [nouse_install_ubuntu, nouse_install_macos]
+    runs-on: ubuntu-latest
+    # Run if any of the dependencies failed in master branch
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    steps:
+      - name: Send mail to mailing list
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          # Subject: Uses the Repository name
+          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          # Body: Lists the result of every job
+          body: |
+            The workflow ${{ github.workflow }} has failed.
+            Job Status Report:
+            ------------------
+            - nouse_install_ubuntu: ${{ needs.nouse_install_ubuntu.result }}
+            - nouse_install_macos: ${{ needs.nouse_install_macos.result }}
+
+            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          to: solvcon@googlegroups.com
+          from: solvcon_notification


### PR DESCRIPTION
This PR sends an email to the SOLVCON Google Group per workflow when CI fails on the `master` branch.

I only check the `master` branch to prevent unnecessary email noise in the Google Group from PR CI failures.

The CI I ran on my local fork to trigger the following mail sending:
https://github.com/ExplorerRay/modmesh/actions/runs/19896588063

The email sent out will be something looks like this:
<img width="596" height="245" alt="image" src="https://github.com/user-attachments/assets/464d6a20-2ed0-4731-b83a-b0a40222c5f6" />