### PR TITLE
ci: ensure email sending when repo is upstream

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -667,7 +667,7 @@ jobs:
     needs: [standalone_buffer, build_ubuntu, build_macos, build_windows]
     runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -336,7 +336,7 @@ jobs:
     needs: [clang_format_check, tidy_flake8_ubuntu, tidy_flake8_macos]
     runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -203,7 +203,7 @@ jobs:
     needs: [nouse_install_ubuntu, nouse_install_macos]
     runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6


### PR DESCRIPTION
I search online and find that `github.event.repository.fork` is able to fix https://github.com/solvcon/modmesh/issues/653.

ref:
- [online web info](https://beckysweger.com/2025/01/02/skip-a-job-in-a.html)
- [fork repo skip because of this setting](https://github.com/Chipdelmal/variant-nowcast-hub/actions/workflows/hubverse-aws-upload.yaml)