### PR TITLE
Check no trailing whitespace (TWS) in CI & remove exist TWS for current source files

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -158,7 +158,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 100
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100
 
-    - name: Add 8G swap (Ubuntu) 
+    - name: Add 8G swap (Ubuntu)
       # Prevent OOM during Qt builds: extra swap gives compiler/linker headroom so cc1plus isn't killed.
       if: runner.os == 'Linux'
       run: |
@@ -265,7 +265,7 @@ jobs:
       run: |
         python3 -c "import modmesh; assert modmesh.HAS_PILOT == True"
         make pytest VERBOSE=1
-        
+
     - name: make pyprof
       run: |
         make pyprof
@@ -287,7 +287,7 @@ jobs:
     # FIXME: turn off until all issues resolved
     - name: make cmake USE_SANITIZER=ON & make pytest
       run: |
-        export ASAN_OPTIONS=verify_asan_link_order=0 
+        export ASAN_OPTIONS=verify_asan_link_order=0
         rm -f build/*/Makefile
         make cmake \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
@@ -483,7 +483,7 @@ jobs:
       # FIXME: turn off until all issues resolved
       - name: make cmake USE_SANITIZER=ON & make pytest
         run: |
-          export ASAN_OPTIONS=verify_asan_link_order=0 
+          export ASAN_OPTIONS=verify_asan_link_order=0
           rm -f build/*/Makefile
           make cmake \
             VERBOSE=1 USE_CLANG_TIDY=OFF \
@@ -539,7 +539,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12' 
+          python-version: '3.12'
 
       - name: dependency by pip
         run: |
@@ -637,7 +637,7 @@ jobs:
           & $py_exec -m pip install numpy matplotlib PySide6==$qt_ver shiboken6-generator==$qt_ver
 
           # Copy pyside6 and shiboken6 DLLs alongside the pilot executable
-          $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))") 
+          $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
           $shiboken6_path=$(& $py_exec -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
           copy "$pyside6_path\pyside6.abi3.dll" $destination
           copy "$shiboken6_path\shiboken6.abi3.dll" $destination
@@ -691,4 +691,3 @@ jobs:
             Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           to: solvcon@googlegroups.com
           from: solvcon_notification
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -167,6 +167,9 @@ jobs:
     - name: make checkascii (check ASCII-only characters)
       run: make checkascii
 
+    - name: make checktws (check trailing whitespace)
+      run: make checktws
+
     - name: make pilot
       run: |
         make pilot \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
     - name: event name
       run: |
         echo "github.event_name: ${{ github.event_name }}"
-    
+
     # Cache the downloaded/extracted Qt bits
     - name: Cache Qt download
       uses: actions/cache@v3
@@ -78,7 +78,7 @@ jobs:
 
     - name: dependency by apt
       run: |
-        VERSION_ID=$(bash -c 'source /etc/os-release ; echo $VERSION_ID')        
+        VERSION_ID=$(bash -c 'source /etc/os-release ; echo $VERSION_ID')
         if [ "20.04" == "$VERSION_ID" ] ; then CLANG_TIDY_VERSION=10 ; else CLANG_TIDY_VERSION=18 ; fi
         sudo apt-get -qqy update
         sudo apt-get -qy install \
@@ -359,4 +359,3 @@ jobs:
             Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           to: solvcon@googlegroups.com
           from: solvcon_notification
-

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -101,7 +101,7 @@ jobs:
         python3 -c "import _modmesh; print(_modmesh.__file__)"
         # The following command is the original commend, and it will fail on pytest == 8.0.0 .
         # pytest --rootdir=/tmp -v
-        # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781  
+        # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781
         # The alternative command to solve the issue is ```pytest --rootdir=. -v```.
         pytest --rootdir=. -v
         cd ..
@@ -193,7 +193,7 @@ jobs:
           python3 -c "import _modmesh; print(_modmesh.__file__)"
           # The following command is the original commend, and it will fail on pytest == 8.0.0 .
           # pytest --rootdir=/tmp -v
-          # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781  
+          # Here is the issue and temporary solution: https://github.com/pytest-dev/pytest/issues/11781
           # The alternative command to solve the issue is ```pytest --rootdir=. -v``` .
           pytest --rootdir=. -v
           cd ..
@@ -225,4 +225,3 @@ jobs:
             Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           to: solvcon@googlegroups.com
           from: solvcon_notification
-

--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,12 @@ flake8:
 checkascii:
 	$(WHICH_PYTHON) contrib/lint/check_ascii.py
 
+.PHONY: checktws
+checktws:
+	$(WHICH_PYTHON) contrib/lint/check_ascii.py --check-tws
+
 .PHONY: lint
-lint: cformat cinclude flake8 checkascii
+lint: cformat cinclude flake8 checkascii checktws
 
 .PHONY: clean
 clean:

--- a/contrib/lint/check_ascii.py
+++ b/contrib/lint/check_ascii.py
@@ -25,9 +25,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-ASCII-only character checker for modmesh source code files.
+ASCII-only character and trailing whitespace checker for modmesh source code files.
 
-This script checks that all source files contain only ASCII characters,
+This script checks that all source files contain only ASCII characters and no trailing whitespace,
 as required by the project coding standards.
 """
 
@@ -52,6 +52,22 @@ def check_ascii_file(filepath):
         return False
 
 
+def check_no_trailing_whitespace(filepath):
+    """Check if a single file contains no trailing whitespace."""
+    try:
+        no_tws = True
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+            for lineno, line in enumerate(lines, start=1):
+                if line.rstrip('\n').rstrip('\r').endswith(' ') or line.rstrip('\n').rstrip('\r').endswith('\t'):
+                    print(f"Trailing whitespace found in {filepath} at line {lineno}")
+                    no_tws = False
+            return no_tws
+    except Exception as e:
+        print(f"Error checking {filepath}: {e}")
+        return False
+
+
 def find_source_files():
     """Find all source code files in the project."""
     patterns = [
@@ -71,7 +87,12 @@ def find_source_files():
 def parse_arguments():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Check that source files contain only ASCII characters'
+        description='Check that source files contain only ASCII characters or no trailing whitespace'
+    )
+    parser.add_argument(
+        '--check-tws',
+        action='store_true',
+        help='Check for trailing whitespace instead of non-ASCII characters'
     )
     parser.add_argument(
         '--verbose', '-v',
@@ -94,38 +115,58 @@ def get_files_to_check(args):
         return find_source_files()
 
 
-def check_files(files_to_check, verbose=False):
-    """Check all files for ASCII-only characters."""
-    print(f"Checking {len(files_to_check)} source files for ASCII-only "
-          f"characters...")
-
+def check_files(files_to_check, check_tws=False, verbose=False):
+    """Check all files for ASCII-only characters or no trailing whitespace."""
     failed_files = []
     checked_count = 0
+
+    if check_tws:
+        print(f"Checking {len(files_to_check)} source files for no trailing whitespace...")
+    else:
+        print(f"Checking {len(files_to_check)} source files for ASCII-only "
+            f"characters...")
 
     for filepath in files_to_check:
         if verbose:
             print(f"Checking: {filepath}")
 
-        if not check_ascii_file(filepath):
-            failed_files.append(filepath)
-        checked_count += 1
+        if check_tws:
+            if not check_no_trailing_whitespace(filepath):
+                failed_files.append(filepath)
+            checked_count += 1
+        else:
+            if not check_ascii_file(filepath):
+                failed_files.append(filepath)
+            checked_count += 1
 
     return failed_files, checked_count
 
 
-def report_results(failed_files, checked_count):
+def report_results(failed_files, checked_count, check_tws=False):
     """Report the check results and return exit code."""
-    if failed_files:
-        print(f"\nFAILED: {len(failed_files)} files contain non-ASCII "
-              f"characters:")
-        for f in failed_files:
-            print(f"  - {f}")
-        print(f"\nChecked {checked_count} files total.")
-        return 1
+    if check_tws:
+        if failed_files:
+            print(f"\nFAILED: {len(failed_files)} files contain trailing "
+                  f"whitespace:")
+            for f in failed_files:
+                print(f"  - {f}")
+            print(f"\nChecked {checked_count} files total.")
+            return 1
+        else:
+            print(f"SUCCESS: All {checked_count} source files contain no "
+                  f"trailing whitespace.")
     else:
-        print(f"SUCCESS: All {checked_count} source files contain only "
-              f"ASCII characters.")
-        return 0
+        if failed_files:
+            print(f"\nFAILED: {len(failed_files)} files contain non-ASCII "
+                f"characters:")
+            for f in failed_files:
+                print(f"  - {f}")
+            print(f"\nChecked {checked_count} files total.")
+            return 1
+        else:
+            print(f"SUCCESS: All {checked_count} source files contain only "
+                f"ASCII characters.")
+    return 0
 
 
 def main():
@@ -136,8 +177,8 @@ def main():
         print("No files found to check")
         return 0
 
-    failed_files, checked_count = check_files(files_to_check, args.verbose)
-    return report_results(failed_files, checked_count)
+    failed_files, checked_count = check_files(files_to_check, args.check_tws, args.verbose)
+    return report_results(failed_files, checked_count, args.check_tws)
 
 
 if __name__ == '__main__':

--- a/contrib/lint/check_ascii.py
+++ b/contrib/lint/check_ascii.py
@@ -73,7 +73,8 @@ def find_source_files():
     patterns = [
         '**/*.py', '**/*.cpp', '**/*.hpp', '**/*.c', '**/*.h',
         '**/*.cxx', '**/*.hxx', '**/*.sh',
-        '**/Makefile', '**/makefile', '**/CMakeLists.txt'
+        '**/Makefile', '**/makefile', '**/CMakeLists.txt',
+        '.github/workflows/*.yml'
     ]
 
     all_files = []

--- a/contrib/lint/check_ascii.py
+++ b/contrib/lint/check_ascii.py
@@ -25,9 +25,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-ASCII-only character and trailing whitespace checker for modmesh source code files.
+ASCII-only character and
+no trailing whitespace checker
+for modmesh source code files.
 
-This script checks that all source files contain only ASCII characters and no trailing whitespace,
+This script checks that all source files contain
+only ASCII characters and no trailing whitespace,
 as required by the project coding standards.
 """
 
@@ -59,8 +62,12 @@ def check_no_trailing_whitespace(filepath):
         with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
             lines = f.readlines()
             for lineno, line in enumerate(lines, start=1):
-                if line.rstrip('\n').rstrip('\r').endswith(' ') or line.rstrip('\n').rstrip('\r').endswith('\t'):
-                    print(f"Trailing whitespace found in {filepath} at line {lineno}")
+                if line.rstrip('\n').rstrip('\r').endswith(' ') or \
+                  line.rstrip('\n').rstrip('\r').endswith('\t'):
+                    print(
+                        f"Trailing whitespace found in {filepath} "
+                        f"at line {lineno}"
+                    )
                     no_tws = False
             return no_tws
     except Exception as e:
@@ -88,7 +95,8 @@ def find_source_files():
 def parse_arguments():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Check that source files contain only ASCII characters or no trailing whitespace'
+        description='Check that source files '
+        'contain only ASCII characters or no trailing whitespace'
     )
     parser.add_argument(
         '--check-tws',
@@ -122,10 +130,15 @@ def check_files(files_to_check, check_tws=False, verbose=False):
     checked_count = 0
 
     if check_tws:
-        print(f"Checking {len(files_to_check)} source files for no trailing whitespace...")
+        print(
+            f"Checking {len(files_to_check)} source files for "
+            f"no trailing whitespace..."
+        )
     else:
-        print(f"Checking {len(files_to_check)} source files for ASCII-only "
-            f"characters...")
+        print(
+            f"Checking {len(files_to_check)} source files for ASCII-only "
+            f"characters..."
+        )
 
     for filepath in files_to_check:
         if verbose:
@@ -158,15 +171,19 @@ def report_results(failed_files, checked_count, check_tws=False):
                   f"trailing whitespace.")
     else:
         if failed_files:
-            print(f"\nFAILED: {len(failed_files)} files contain non-ASCII "
-                f"characters:")
+            print(
+                f"\nFAILED: {len(failed_files)} files contain non-ASCII "
+                f"characters:"
+            )
             for f in failed_files:
                 print(f"  - {f}")
             print(f"\nChecked {checked_count} files total.")
             return 1
         else:
-            print(f"SUCCESS: All {checked_count} source files contain only "
-                f"ASCII characters.")
+            print(
+                f"SUCCESS: All {checked_count} source files contain only "
+                f"ASCII characters."
+            )
     return 0
 
 
@@ -178,7 +195,9 @@ def main():
         print("No files found to check")
         return 0
 
-    failed_files, checked_count = check_files(files_to_check, args.check_tws, args.verbose)
+    failed_files, checked_count = check_files(
+        files_to_check, args.check_tws, args.verbose
+    )
     return report_results(failed_files, checked_count, args.check_tws)
 
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -335,7 +335,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                        self,
                        // NOLINTNEXTLINE(fuchsia-trailing-return)
                        [&](const auto & array) -> wrapped_type // need the return type to get correct deduced type
-                       { 
+                       {
                         const auto shape = make_shape(py_shape);
                         return array.reshape(shape); }); })
             .def_property_readonly("has_ghost", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(has_ghost))
@@ -415,7 +415,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
         auto datatype = array_plex.data_type();
         execute_callback_with_typed_array(
             array_plex, [&py_value, datatype](auto & array)
-            { 
+            {
                 using value_type = typename std::remove_reference_t<decltype(array[0])>;
                 verify_python_value_datatype(py_value, datatype);
                 const auto value = py_value.cast<value_type>();
@@ -437,7 +437,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
         auto datatype = array_plex.data_type();
         execute_callback_with_typed_array(
             array_plex, [&py_value, datatype](auto & array)
-            { 
+            {
                 using value_type = typename std::remove_reference_t<decltype(array[0])>;
                 verify_python_value_datatype(py_value, datatype);
                 const auto value = py_value.cast<value_type>();

--- a/cpp/modmesh/mesh/StaticMesh_interior.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_interior.cpp
@@ -365,7 +365,7 @@ struct FaceBuilder
         // clang-format off
         return std::accumulate
         (
-            tcltpn.body(), tcltpn.body()+tcltpn.nbody(), size_t(0) 
+            tcltpn.body(), tcltpn.body()+tcltpn.nbody(), size_t(0)
           , [](size_t a, uint8_t b){ return a + static_cast<size_t>(CellType::by_id(b).nface()); }
         );
         // clang-format on


### PR DESCRIPTION
This PR does the following things to fix https://github.com/solvcon/modmesh/issues/645.

- Revise `contrib/lint/check_ascii.py` for checking trailing whitespace option `--check-tws`
- Revise Makefile to add `make checktws`, then add this to github action (`lint.yml`)
- Finding some TWS exist and remove them