### PR TITLE
ci: add date to email subject when CI fails

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -669,6 +669,9 @@ jobs:
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
+      - name: Get current date and set to env
+        run: |
+          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6
         with:
@@ -677,7 +680,7 @@ jobs:
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
           # Subject: Uses the Repository name
-          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
           # Body: Lists the result of every job
           body: |
             The workflow ${{ github.workflow }} has failed.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -341,6 +341,9 @@ jobs:
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
+      - name: Get current date and set to env
+        run: |
+          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6
         with:
@@ -349,7 +352,7 @@ jobs:
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
           # Subject: Uses the Repository name
-          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
           # Body: Lists the result of every job
           body: |
             The workflow ${{ github.workflow }} has failed.

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -205,6 +205,9 @@ jobs:
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     steps:
+      - name: Get current date and set to env
+        run: |
+          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6
         with:
@@ -213,7 +216,7 @@ jobs:
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
           # Subject: Uses the Repository name
-          subject: CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
           # Body: Lists the result of every job
           body: |
             The workflow ${{ github.workflow }} has failed.


### PR DESCRIPTION
- Prepend date (format is like `12/19`) to email subject when CI fails
- Solves https://github.com/solvcon/modmesh/issues/656

The following test shows that setting command output to env is available.
https://github.com/ExplorerRay/modmesh/actions/runs/20363563177/job/58513478643