### PR TITLE
Fix: Support to assign the complex number to SimpleArray

### DIFF
--- a/cpp/modmesh/math/Complex.hpp
+++ b/cpp/modmesh/math/Complex.hpp
@@ -29,6 +29,7 @@
 #include <type_traits>
 #include <cmath>
 #include <stdexcept>
+#include <complex>
 
 namespace modmesh
 {
@@ -55,6 +56,12 @@ struct ComplexImpl
     ComplexImpl(T t)
         : real_v(t)
         , imag_v(0.0)
+    {
+    }
+
+    ComplexImpl(std::complex<T> const & c)
+        : real_v(c.real())
+        , imag_v(c.imag())
     {
     }
 
@@ -125,6 +132,7 @@ struct ComplexImpl
         return *this;
     }
 
+    std::complex<T> to_std_complex() const { return std::complex<T>(real_v, imag_v); }
     T real() const { return real_v; }
     T imag() const { return imag_v; }
     T norm() const { return real_v * real_v + imag_v * imag_v; }

--- a/cpp/modmesh/math/pymod/wrap_Complex.cpp
+++ b/cpp/modmesh/math/pymod/wrap_Complex.cpp
@@ -71,7 +71,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapComplex
             .def(
                 py::init(
                     [](const wrapped_type & other)
-                    { return std::make_shared<wrapped_type>(wrapped_type{other.real_v, other.imag_v}); }),
+                    { return std::make_shared<wrapped_type>(other); }),
                 py::arg("complex"))
             .def(
                 py::init(
@@ -106,6 +106,11 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapComplex
             .def_readonly("imag", &wrapped_type::imag_v)
             .def("norm", &wrapped_type::norm)
             .def("conj", &wrapped_type::conj)
+            .def("__complex__",
+                 [](const wrapped_type & self)
+                 {
+                     return self.to_std_complex();
+                 })
             .def("dtype",
                  []()
                  { return complex_dtype; });

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -620,6 +620,23 @@ class SimpleArrayBasicTC(unittest.TestCase):
         sarr.ndarray.fill(100)
         self.assertTrue((ndarr == 100).all())
 
+        ndarr = np.zeros((2, 3, 4), dtype='complex128')
+        sarr = modmesh.SimpleArrayComplex128(array=ndarr)
+        # Reassign the numpy array to ensure data is not shared.
+        ndarr = np.zeros((2, 3, 4), dtype='complex128')
+
+        for i in range(2):
+            for j in range(3):
+                for k in range(4):
+                    ndarr[i, j, k] = complex(i + j, k)
+                    sarr[i, j, k] = ndarr[i, j, k]
+        for i in range(2):
+            for j in range(3):
+                for k in range(4):
+                    complex_ndarr = complex(ndarr[i, j, k])
+                    complex_sarr = complex(sarr[i, j, k])
+                    self.assertEqual(complex_ndarr, complex_sarr)
+
     def test_SimpleArray_from_ndarray_slice(self):
         ndarr = np.arange(1000, dtype='float64').reshape((10, 10, 10))
         parr = ndarr[1:7:3, 6:2:-1, 3:9]

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -380,41 +380,6 @@ class KalmanFilterPredictTC(unittest.TestCase):
         np.testing.assert_allclose(p_pred_mm, p_pred_np, atol=1e-12, rtol=0.0)
 
 
-# The bug is reported in issue #604:
-# https://github.com/solvcon/modmesh/issues/604
-# Issue #604: SimpleArrayComplex128[i] = numpy.complex128 fails with cast error
-# This _wrap_complex function provides a workaround for the type conversion
-# issue when assigning numpy.complex128 values to SimpleArrayComplex128
-# elements
-def _wrap_complex(val, cls):
-    if not np.iscomplexobj(val):
-        return val.item() if hasattr(val, "item") else val
-    z = complex(val)
-    name = getattr(cls, "__name__", "")
-    if name.endswith("Complex128"):
-        return mm.complex128(z)
-    if name.endswith("Complex64"):
-        return mm.complex64(z)
-    return z
-
-
-class TestKnownIssues604(unittest.TestCase):
-
-    @unittest.expectedFailure
-    def test_issue_604_numpy_complex128_assignment(self):
-        sa = mm.SimpleArrayComplex128([3])
-        z = np.complex128(1.0 + 2.0j)
-        sa[0] = z
-        self.assertEqual(complex(sa[0]), complex(z))
-
-    @unittest.expectedFailure
-    def test_python_complex_assignment(self):
-        sa = mm.SimpleArrayComplex128([1])
-        z = complex(5.0, -6.0)
-        sa[0] = z
-        self.assertEqual(complex(sa[0]), z)
-
-
 # The bug is reported in issue #603:
 # https://github.com/solvcon/modmesh/issues/603
 # Issue #603: F-contiguous check in SimpleArray breaks when creating
@@ -428,14 +393,14 @@ def sa_from_np(arr: np.ndarray, cls):
     if arr.ndim == 1:
         sa = cls([arr.shape[0]])
         for i in range(arr.shape[0]):
-            sa[i] = _wrap_complex(arr[i], cls)
+            sa[i] = arr[i]
         return sa
     if arr.ndim == 2:
         m, n = arr.shape
         sa = cls([m, n])
         for i in range(m):
             for j in range(n):
-                sa[i, j] = _wrap_complex(arr[i, j], cls)
+                sa[i, j] = arr[i, j]
         return sa
     raise ValueError("sa_from_np supports only 1D or 2D arrays")
 


### PR DESCRIPTION
## Problem
In issue #604 , when we assign values from `np.complex128` or `Complex` to `SimpleArrayComplex128`, the cast of python instance fails.

```python
import modmesh as mm
import numpy as np

nc = np.array([1.0 + 0.1j])
mc = mm.SimpleArrayComplex128([1])
mc[0] = nc[0]          # <- fails

print(mc[0].real, mc[0].imag)
```

```shell
Traceback (most recent call last):
  ...
  mc[0] = nc[0]
RuntimeError: Unable to cast Python instance of type <class 'numpy.complex128'> to C++ type '?' 
(#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
```

## Solution
The function `__setitem__` in `wrap_SimpleArray.cpp` `calls &property_helper::setitem_parser`, and the fuunction `calls &property_helper::setitem_parser` checks if the value is number based on the following logic:

```c++
const bool is_number = py::isinstance<py::bool_>(py_value) || py::isinstance<py::int_>(py_value) || py::isinstance<py::float_>(py_value) || is_complex_v<T>;
```

This condition ignores whether `py_value` is `np.complex128` or `Complex`, it just check whether `py_value` is `modmesh.complex128`.