### PR TITLE
fix: nouse_install_macos remove installing wheel with pip to avoid conflict

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -143,7 +143,6 @@ jobs:
           echo "which python3: $(which python3)"
           ls -al $(which python3)
           python3 -m pip -v install --break-system-packages --upgrade setuptools
-          python3 -m pip -v install --break-system-packages --upgrade wheel
           # TODO:
           # This issue was linked to #213
           # temporary remove pip upgrade, due to latest pip will let cmake


### PR DESCRIPTION
Current nouse_install_macos github action seems to fail continually. 

I compared [the log with the action succeeded before](https://github.com/solvcon/modmesh/actions/runs/21220501168/job/61053639109), finding that when installing wheel, pip will say requirement satisfied (0.45.1) and doing nothing. 

However, in today's scheduled action, it will try to download a newer one (0.46.3) and uninstall old one (0.45.1). When uninstalling the old one, pip can't find old wheel package and fails. I think it's because homebrew install wheel package when installing pybind and python pip can't find it.

Although I don't know why pip acts differently (try to install new one and remove old one) currently, to avoid the github action keeping failing, I just removed the line that install wheel because [setuptools depends on wheel](https://github.com/pypa/setuptools/blob/main/pyproject.toml#L103). I think when installing setuptools, wheel package will be handled properly.

After removing and running [the github action in my fork](https://github.com/ExplorerRay/modmesh/actions/runs/21270708438/job/61220087128), it shows that this operation works fine.