### PR TITLE
Support more than one line in the Python Console & Refactor

### DIFF
--- a/cpp/modmesh/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/modmesh/pilot/RPythonConsoleDockWidget.hpp
@@ -37,6 +37,7 @@
 
 #include <Qt>
 #include <QDockWidget>
+#include <QScrollArea>
 #include <QTextEdit>
 
 namespace modmesh
@@ -63,12 +64,7 @@ class RPythonHistoryTextEdit
 {
     Q_OBJECT
 
-    void doubleClickHistoryEdit();
-
-    void mouseDoubleClickEvent(QMouseEvent *) override
-    {
-        doubleClickHistoryEdit();
-    }
+    void mouseDoubleClickEvent(QMouseEvent *) override;
 }; /* end class RPythonHistoryTextEdit */
 
 class RPythonConsoleDockWidget
@@ -84,6 +80,7 @@ public:
         Qt::WindowFlags flags = Qt::WindowFlags());
 
     QString command() const;
+    void setCommand(QString const & value);
 
     bool hasPythonRedirect() const { return m_python_redirect.is_enabled(); }
 
@@ -93,28 +90,27 @@ public:
         return *this;
     }
 
-    void writeToHistory(std::string const & data);
+    void writeToHistory(std::string const & data) const;
 
 public slots:
-
-    void setCommand(QString const & value);
     void executeCommand();
     void navigateCommand(int offset);
 
 private:
+    static int calcHeightToFitContents(const QTextEdit * edit);
 
-    void appendPastCommand(std::string const & code);
-    void printCommandOutput();
-    void printCommandHistory();
-    void printCommandStdout(const std::string & stdout_message);
-    void printCommandStderr(const std::string & stderr_message);
+    void commitCommand(std::string const & command);
+    void printCommandStdout(const std::string & stdout_message) const;
+    void printCommandStderr(const std::string & stderr_message) const;
 
+    QScrollArea * m_scroll_area = nullptr;
+    QWidget * m_container = nullptr;
     RPythonHistoryTextEdit * m_history_edit = nullptr;
     RPythonCommandTextEdit * m_command_edit = nullptr;
-    std::string m_command_string;
-    std::deque<std::string> m_past_command_strings;
+    std::string m_draft_command;
+    std::deque<std::string> m_committed_commands;
+    size_t m_committed_commands_size_limit = 1024;
     int m_current_command_index = 0;
-    size_t m_past_limit = 1024;
     int m_last_command_serial = 0;
 
     python::PythonStreamRedirect m_python_redirect;


### PR DESCRIPTION
This PR changes to the layout of Python Console in pilot.

How it looked before:
<img width="1001" height="213" alt="image" src="https://github.com/user-attachments/assets/8b5872b2-71a9-44b3-af1e-f2c6a4a65508" />

How it looks now:
<img width="940" height="265" alt="image" src="https://github.com/user-attachments/assets/06c380db-d1b7-4306-9248-1c28d2c79c3d" />

Multiline commands support:
<img width="943" height="259" alt="image" src="https://github.com/user-attachments/assets/92d58a74-822f-4578-96ca-bfde7493740c" />
