### PR TITLE
ci: reallocate swap if swapfile exists in devbuild on Ubuntu

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -162,6 +162,11 @@ jobs:
       # Prevent OOM during Qt builds: extra swap gives compiler/linker headroom so cc1plus isn't killed.
       if: runner.os == 'Linux'
       run: |
+        # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
+        if sudo swapon --show | grep -q /swapfile; then
+          sudo swapoff -a
+          sudo rm /swapfile
+        fi
         sudo fallocate -l 8G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -256,7 +256,6 @@ jobs:
           ls -al $(which python3)
           # suppress the warning of pip because brew forces PEP668 since python3.12
           python3 -m pip -v install --upgrade setuptools --break-system-packages
-          python3 -m pip -v install --upgrade pip --break-system-packages
           python3 -m pip -v install --upgrade numpy matplotlib pytest flake8 jsonschema
           # For now (2024/10/22), pyside6 6.6.3 does not support Python 3.13.
           # Use --ignore-requires-python to force installation.


### PR DESCRIPTION
Current devbuild GitHub Action on Ubuntu sometimes fails when adding swap. (`fallocate: fallocate failed: Text file busy`)

I found that Github runner has 3G swap on `/swapfile` by default at least in Ubuntu runner ([ref](https://github.com/ExplorerRay/modmesh/actions/runs/21535926503/job/62061521554)). Our old action makes swap increase from 3G to 11G. I guess it sometimes fails because the old one might be used when running `fallocate`. 
To avoid this error, I just removed default swap set by Github runner if it exists. And then add an 8G swap by the Github action step (Just reconfigure the swap). This step refers to [this article](https://askubuntu.com/questions/920595/fallocate-fallocate-failed-text-file-busy-in-ubuntu-17-04).

After running this revised devbuild action in my local fork, I found 8G is enough for the subsequent compiling. Therefore, I just make it 8G instead of original 11G.