### PR TITLE
ci: set 8G swap for Ubuntu runner in lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,21 @@ jobs:
       run: |
         echo "github.event_name: ${{ github.event_name }}"
 
+    - name: Add 8G swap (Ubuntu)
+      # Prevent hitting runner's resource limits when running clang-tidy
+      if: runner.os == 'Linux'
+      run: |
+        # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
+        if sudo swapon --show | grep -q /swapfile; then
+          sudo swapoff -a
+          sudo rm /swapfile
+        fi
+        sudo fallocate -l 8G /swapfile
+        sudo chmod 600 /swapfile
+        sudo mkswap /swapfile
+        sudo swapon /swapfile
+        free -h
+
     # Cache the downloaded/extracted Qt bits
     - name: Cache Qt download
       uses: actions/cache@v3


### PR DESCRIPTION
Current Ubuntu runner seems to keep failing in lint action. It just stuck there or terminated by Github. After asking others for help, it mentions this is possible due to our step hitting Github runner's resource limits(CPU/RAM/IOPS).

To avoid this, I just tried to set swap bigger and check whether it runs well. The result shows it can run it successfully after setting the swap.