### PR TITLE
Implement `TrapezoidalDecomposer::decompose` using sweep-line algorithm

### DIFF
--- a/cpp/modmesh/universe/pymod/wrap_polygon.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_polygon.cpp
@@ -168,6 +168,90 @@ WrapPolygonPad<T>::WrapPolygonPad(pybind11::module & mod, const char * pyname, c
             py::arg("p2"));
 }
 
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapTrapezoidPad
+    : public WrapBase<WrapTrapezoidPad<T>, TrapezoidPad<T>, std::shared_ptr<TrapezoidPad<T>>>
+{
+public:
+    using base_type = WrapBase<WrapTrapezoidPad<T>, TrapezoidPad<T>, std::shared_ptr<TrapezoidPad<T>>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using value_type = typename wrapped_type::value_type;
+    using point_type = typename wrapped_type::point_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+    WrapTrapezoidPad(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+template <typename T>
+WrapTrapezoidPad<T>::WrapTrapezoidPad(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            py::init(
+                [](uint8_t ndim)
+                {
+                    return wrapped_type::construct(ndim);
+                }),
+            py::arg("ndim"))
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def_property_readonly("size", &wrapped_type::size)
+        .def("x0", py::overload_cast<size_t>(&wrapped_type::x0, py::const_), py::arg("index"))
+        .def("y0", py::overload_cast<size_t>(&wrapped_type::y0, py::const_), py::arg("index"))
+        .def("z0", py::overload_cast<size_t>(&wrapped_type::z0, py::const_), py::arg("index"))
+        .def("x1", py::overload_cast<size_t>(&wrapped_type::x1, py::const_), py::arg("index"))
+        .def("y1", py::overload_cast<size_t>(&wrapped_type::y1, py::const_), py::arg("index"))
+        .def("z1", py::overload_cast<size_t>(&wrapped_type::z1, py::const_), py::arg("index"))
+        .def("x2", py::overload_cast<size_t>(&wrapped_type::x2, py::const_), py::arg("index"))
+        .def("y2", py::overload_cast<size_t>(&wrapped_type::y2, py::const_), py::arg("index"))
+        .def("z2", py::overload_cast<size_t>(&wrapped_type::z2, py::const_), py::arg("index"))
+        .def("x3", py::overload_cast<size_t>(&wrapped_type::x3, py::const_), py::arg("index"))
+        .def("y3", py::overload_cast<size_t>(&wrapped_type::y3, py::const_), py::arg("index"))
+        .def("z3", py::overload_cast<size_t>(&wrapped_type::z3, py::const_), py::arg("index"));
+}
+
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapTrapezoidalDecomposer
+    : public WrapBase<WrapTrapezoidalDecomposer<T>, TrapezoidalDecomposer<T>>
+{
+public:
+    using base_type = WrapBase<WrapTrapezoidalDecomposer<T>, TrapezoidalDecomposer<T>>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using value_type = typename wrapped_type::value_type;
+    using point_type = typename wrapped_type::point_type;
+    using trapezoid_pad_type = typename wrapped_type::trapezoid_pad_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+    WrapTrapezoidalDecomposer(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+template <typename T>
+WrapTrapezoidalDecomposer<T>::WrapTrapezoidalDecomposer(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(py::init<uint8_t>(), py::arg("ndim"))
+        .def(
+            "decompose",
+            [](wrapped_type & self, size_t polygon_id, std::vector<point_type> const & points)
+            {
+                return self.decompose(polygon_id, points);
+            },
+            py::arg("polygon_id"),
+            py::arg("points"))
+        .def("num_trapezoids", &wrapped_type::num_trapezoids, py::arg("polygon_id"))
+        .def("trapezoids", py::overload_cast<>(&wrapped_type::trapezoids))
+        .def("clear", &wrapped_type::clear);
+}
+
 void wrap_polygon(pybind11::module & mod)
 {
     WrapPolygon<float>::commit(mod, "Polygon3dFp32", "Polygon3dFp32");
@@ -175,6 +259,12 @@ void wrap_polygon(pybind11::module & mod)
 
     WrapPolygonPad<float>::commit(mod, "PolygonPadFp32", "PolygonPadFp32");
     WrapPolygonPad<double>::commit(mod, "PolygonPadFp64", "PolygonPadFp64");
+
+    WrapTrapezoidPad<float>::commit(mod, "TrapezoidPadFp32", "TrapezoidPadFp32");
+    WrapTrapezoidPad<double>::commit(mod, "TrapezoidPadFp64", "TrapezoidPadFp64");
+
+    WrapTrapezoidalDecomposer<float>::commit(mod, "TrapezoidalDecomposerFp32", "TrapezoidalDecomposerFp32");
+    WrapTrapezoidalDecomposer<double>::commit(mod, "TrapezoidalDecomposerFp64", "TrapezoidalDecomposerFp64");
 }
 
 } /* end namespace python */

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -163,6 +163,10 @@ list_of_universe = [
     'PolygonPadFp64',
     'Polygon3dFp32',
     'Polygon3dFp64',
+    'TrapezoidPadFp32',
+    'TrapezoidPadFp64',
+    'TrapezoidalDecomposerFp32',
+    'TrapezoidalDecomposerFp64',
 ]
 
 __all__ = (  # noqa: F822

--- a/tests/test_universe_trap.py
+++ b/tests/test_universe_trap.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2026, An-Chi Liu <phy.tiger@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import modmesh as mm
+from modmesh.testing import TestBase as ModMeshTB
+
+
+class TrapezoidalDecomposerTB(ModMeshTB):
+
+    def _make_2d_points(self, *coords):
+        """Helper to create Point objects from 2D coordinates.
+
+        Args:
+            *coords: Variable number of (x, y) tuples
+
+        Returns:
+            List of Point objects with z=0.0
+        """
+        return [self.Point(x, y, 0.0) for x, y in coords]
+
+    def test_simple_rectangle(self):
+        """Test decomposition of a simple rectangle."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        rectangle = self._make_2d_points(
+            (0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0))
+
+        begin_index, end_index = decomposer.decompose(0, rectangle)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 1)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+        self.assert_allclose(trapezoids.x0(0), 0.0)
+        self.assert_allclose(trapezoids.y0(0), 0.0)
+        self.assert_allclose(trapezoids.x1(0), 2.0)
+        self.assert_allclose(trapezoids.y1(0), 0.0)
+        self.assert_allclose(trapezoids.x2(0), 2.0)
+        self.assert_allclose(trapezoids.y2(0), 1.0)
+        self.assert_allclose(trapezoids.x3(0), 0.0)
+        self.assert_allclose(trapezoids.y3(0), 1.0)
+
+    def test_simple_triangle(self):
+        """Test decomposition of a simple triangle."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        triangle = self._make_2d_points((0.0, 0.0), (2.0, 0.0), (1.0, 2.0))
+
+        begin_index, end_index = decomposer.decompose(0, triangle)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 1)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+        self.assert_allclose(trapezoids.y0(0), 0.0)
+        self.assert_allclose(trapezoids.y1(0), 0.0)
+        self.assert_allclose(trapezoids.x0(0), 0.0)
+        self.assert_allclose(trapezoids.x1(0), 2.0)
+
+        self.assert_allclose(trapezoids.y2(0), 2.0)
+        self.assert_allclose(trapezoids.y3(0), 2.0)
+        self.assert_allclose(trapezoids.x2(0), 1.0)
+        self.assert_allclose(trapezoids.x3(0), 1.0)
+
+    def test_trapezoid_shape(self):
+        """Test decomposition of a trapezoid shape."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        trapezoid = self._make_2d_points(
+            (0.0, 0.0), (4.0, 0.0), (3.0, 2.0), (1.0, 2.0))
+
+        begin_index, end_index = decomposer.decompose(0, trapezoid)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 1)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+        self.assert_allclose(trapezoids.y0(0), 0.0)
+        self.assert_allclose(trapezoids.y1(0), 0.0)
+        self.assert_allclose(trapezoids.y2(0), 2.0)
+        self.assert_allclose(trapezoids.y3(0), 2.0)
+
+        self.assert_allclose(trapezoids.x0(0), 0.0)
+        self.assert_allclose(trapezoids.x1(0), 4.0)
+        self.assert_allclose(trapezoids.x2(0), 3.0)
+        self.assert_allclose(trapezoids.x3(0), 1.0)
+
+    def test_pentagon(self):
+        """Test decomposition of a pentagon."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        pentagon = self._make_2d_points(
+            (0.0, 0.0), (3.0, 0.0), (4.0, 2.0), (1.5, 3.0), (-1.0, 2.0))
+
+        begin_index, end_index = decomposer.decompose(0, pentagon)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 2)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 2)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 2)
+
+    def test_concave_polygon(self):
+        """Test decomposition of a concave polygon."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        concave = self._make_2d_points(
+            (0.0, 0.0), (4.0, 0.0), (4.0, 3.0), (2.0, 1.5), (0.0, 3.0))
+
+        begin_index, end_index = decomposer.decompose(0, concave)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 3)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 3)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 3)
+
+    def test_multiple_polygons(self):
+        """Test decomposition of multiple polygons."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        square1 = self._make_2d_points(
+            (0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+
+        square2 = self._make_2d_points(
+            (2.0, 0.0), (3.0, 0.0), (3.0, 1.0), (2.0, 1.0))
+
+        begin1, end1 = decomposer.decompose(0, square1)
+        begin2, end2 = decomposer.decompose(1, square2)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+        self.assertEqual(decomposer.num_trapezoids(1), 1)
+
+        self.assertEqual(begin1, 0)
+        self.assertEqual(end1, 1)
+        self.assertEqual(begin2, 1)
+        self.assertEqual(end2, 2)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 2)
+
+    def test_cached_decomposition(self):
+        """Test that decomposition results are cached."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        square = self._make_2d_points(
+            (0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+
+        begin1, end1 = decomposer.decompose(0, square)
+        begin2, end2 = decomposer.decompose(0, square)
+
+        self.assertEqual(begin1, begin2)
+        self.assertEqual(end1, end2)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+    def test_clear(self):
+        """Test clearing decomposition results."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        square = self._make_2d_points(
+            (0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+
+        decomposer.decompose(0, square)
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+
+        decomposer.clear()
+
+        self.assertEqual(decomposer.num_trapezoids(0), 0)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 0)
+
+    def test_horizontal_edges_ignored(self):
+        """Test that horizontal edges are ignored during decomposition."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        shape_with_horizontal = self._make_2d_points(
+            (0.0, 0.0), (2.0, 0.0), (3.0, 1.0), (2.0, 1.0), (0.0, 1.0))
+
+        begin_index, end_index = decomposer.decompose(0, shape_with_horizontal)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+    def test_floating_point_precision(self):
+        """Test decomposition with different floating point precisions."""
+        decomposer_fp32 = mm.TrapezoidalDecomposerFp32(2)
+        decomposer_fp64 = self.TrapezoidalDecomposer(2)
+
+        triangle_fp32 = [
+            mm.Point3dFp32(0.0, 0.0, 0.0),
+            mm.Point3dFp32(1.0, 0.0, 0.0),
+            mm.Point3dFp32(0.5, 1.0, 0.0)
+        ]
+
+        triangle_fp64 = self._make_2d_points(
+            (0.0, 0.0), (1.0, 0.0), (0.5, 1.0))
+
+        begin32, end32 = decomposer_fp32.decompose(0, triangle_fp32)
+        begin64, end64 = decomposer_fp64.decompose(0, triangle_fp64)
+
+        self.assertEqual(decomposer_fp32.num_trapezoids(0),
+                         decomposer_fp64.num_trapezoids(0))
+
+    def test_complex_polygon_with_many_vertices(self):
+        """Test decomposition of a complex polygon with many vertices."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        octagon = self._make_2d_points(
+            (1.0, 0.0), (2.0, 0.0), (3.0, 1.0), (3.0, 2.0),
+            (2.0, 3.0), (1.0, 3.0), (0.0, 2.0), (0.0, 1.0))
+
+        begin_index, end_index = decomposer.decompose(0, octagon)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 3)
+        self.assertEqual(begin_index, 0)
+        self.assertEqual(end_index, 3)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 3)
+
+    def test_l_shaped_polygon(self):
+        """Test decomposition of an L-shaped polygon."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        l_shape = self._make_2d_points(
+            (0.0, 0.0), (2.0, 0.0), (2.0, 1.0),
+            (1.0, 1.0), (1.0, 3.0), (0.0, 3.0))
+
+        begin_index, end_index = decomposer.decompose(0, l_shape)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 2)
+        self.assertEqual(begin_index, 0)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 2)
+
+    def test_narrow_spike(self):
+        """Test decomposition of a narrow spike."""
+        decomposer = self.TrapezoidalDecomposer(2)
+
+        spike = self._make_2d_points((0.0, 0.0), (1.0, 0.0), (0.5, 10.0))
+
+        begin_index, end_index = decomposer.decompose(0, spike)
+
+        self.assertEqual(decomposer.num_trapezoids(0), 1)
+
+        trapezoids = decomposer.trapezoids()
+        self.assertEqual(trapezoids.size, 1)
+
+
+class TrapezoidalDecomposerFp32TC(TrapezoidalDecomposerTB, unittest.TestCase):
+
+    def setUp(self):
+        self.Point = mm.Point3dFp32
+        self.TrapezoidalDecomposer = mm.TrapezoidalDecomposerFp32
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-7
+        return super().assert_allclose(*args, **kw)
+
+
+class TrapezoidalDecomposerFp64TC(TrapezoidalDecomposerTB, unittest.TestCase):
+
+    def setUp(self):
+        self.Point = mm.Point3dFp64
+        self.TrapezoidalDecomposer = mm.TrapezoidalDecomposerFp64
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-15
+        return super().assert_allclose(*args, **kw)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Implement decompose using a sweep-line algorithm. The algorithm processes all unique y-values of the polygon as events. Active edges define the boundaries of trapezoids, which are collected into the trapezoid set. Corresponding test cases are added using pytest.

AI usage: Copilot + Claude 4.5 generating the test cases, VSCode IntelliSense for auto-completion, ChatGPT 5.2 for discussing the algorithm.

## Visualization of the test cases

Original:
<img width="1915" height="598" alt="Screenshot 2026-02-04 at 9 55 42 PM" src="https://github.com/user-attachments/assets/5f53763b-d479-43cd-a6b2-97beb6eb0c1e" />

Fractured:
<img width="1916" height="599" alt="Screenshot 2026-02-04 at 9 57 18 PM" src="https://github.com/user-attachments/assets/6d44264b-e6d3-42b7-b5b3-d97a68d4e0e9" />