### PR TITLE
ci: use rm -f to avoid error in swapfile removal

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -196,11 +196,9 @@ jobs:
       # Prevent OOM during Qt builds: extra swap gives compiler/linker headroom so cc1plus isn't killed.
       if: runner.os == 'Linux'
       run: |
-        # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
-        if sudo swapon --show | grep -q /swapfile; then
-          sudo swapoff -a
-          sudo rm /swapfile
-        fi
+        # Remove /swapfile first to avoid "fallocate: Text file busy" error
+        sudo swapoff -a
+        sudo rm -f /swapfile
         sudo fallocate -l 8G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,11 +32,9 @@ jobs:
         # Prevent hitting runner's resource limits
         if: runner.os == 'Linux'
         run: |
-          # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
-          if sudo swapon --show | grep -q /swapfile; then
-            sudo swapoff -a
-            sudo rm /swapfile
-          fi
+          # Remove /swapfile first to avoid "fallocate: Text file busy" error
+          sudo swapoff -a
+          sudo rm -f /swapfile
           sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
@@ -85,11 +83,9 @@ jobs:
       # Prevent hitting runner's resource limits when running clang-tidy
       if: runner.os == 'Linux'
       run: |
-        # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
-        if sudo swapon --show | grep -q /swapfile; then
-          sudo swapoff -a
-          sudo rm /swapfile
-        fi
+        # Remove /swapfile first to avoid "fallocate: Text file busy" error
+        sudo swapoff -a
+        sudo rm -f /swapfile
         sudo fallocate -l 8G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -39,11 +39,9 @@ jobs:
       # Prevent hitting runner's resource limits
       if: runner.os == 'Linux'
       run: |
-        # If a swapfile exists, remove it first to avoid "fallocate: Text file busy" error
-        if sudo swapon --show | grep -q /swapfile; then
-          sudo swapoff -a
-          sudo rm /swapfile
-        fi
+        # Remove /swapfile first to avoid "fallocate: Text file busy" error
+        sudo swapoff -a
+        sudo rm -f /swapfile
         sudo fallocate -l 8G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile


### PR DESCRIPTION
This fix aims to avoid error when running `rm /swapfile`.

https://github.com/solvcon/modmesh/actions/runs/21710071242