### PR TITLE
 Implement Polygon Boolean Operations (Union, Intersection, Difference)

### DIFF
--- a/cpp/modmesh/universe/polygon.hpp
+++ b/cpp/modmesh/universe/polygon.hpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <set>
 #include <vector>
 
 namespace modmesh
@@ -2378,6 +2379,13 @@ public:
     std::pair<size_t, size_t> decompose_to_trapezoid(size_t polygon_id);
 
     /**
+     * Access the trapezoid pad produced by the decomposer.
+     * Valid after calling decompose_to_trapezoid().
+     */
+    std::shared_ptr<TrapezoidPad<T>> decomposed_trapezoids() { return m_decomposer.trapezoids(); }
+    std::shared_ptr<TrapezoidPad<T> const> decomposed_trapezoids() const { return m_decomposer.trapezoids(); }
+
+    /**
      * Compute union of two polygons using trapezoidal decomposition.
      *
      * @param p1 First polygon
@@ -2779,28 +2787,413 @@ std::pair<size_t, size_t> PolygonPad<T>::decompose_to_trapezoid(size_t polygon_i
     return m_decomposer.decompose(polygon_id, points);
 }
 
+namespace detail
+{
+
+enum class BooleanOperation
+{
+    Union,
+    Intersection,
+    Difference
+}; /* end enum class BooleanOperation */
+
+/**
+ * Boolean operations on two polygons using trapezoidal decomposition.
+ *
+ * A "band" (Y-band) is a horizontal strip between two consecutive critical
+ * Y-values [y_lo, y_hi].  The set of critical Y-values comes from:
+ *   - the top/bottom edges of every trapezoid produced by decomposing both
+ *     input polygons, and
+ *   - the Y-coordinates where a trapezoid edge from one polygon crosses a
+ *     trapezoid edge from the other polygon.
+ *
+ * Within a single band no edges from different polygons cross, so the
+ * left-to-right ordering of edges is stable.  Each polygon's trapezoids
+ * that span the band contribute X-intervals (start at the left edge, end
+ * at the right edge).  Sweeping those interval events along X while
+ * tracking inside/outside counts for each polygon lets us apply the
+ * boolean predicate (union / intersection / difference) and emit result
+ * trapezoids.
+ *
+ * Illustration for two overlapping squares P1=(0,0)-(2,2) and P2=(1,1)-(3,3):
+ *
+ *  Critical Y-values: {0, 1, 2, 3}
+ *  Three y-bands: [0,1], [1,2], [2,3]
+ *
+ *   y=3 - - - - - +----------------+- - - - - - - - - -
+ *                 |          P2    |        band [2,3]
+ *   y=2 +----------------+- - - - -|- - - - - - - - - -
+ *       |   P1    |//////|         |        band [1,2]
+ *   y=1 |- - - - -+------+---------+- - - - - - - - - -
+ *       |                |                  band [0,1]
+ *   y=0 +----------------+- - - - - - - - - - - - - - -
+ *       x=0      x=1    x=2       x=3
+ *
+ *   Band [1,2]: P1 interval [0,2], P2 interval [1,3]
+ *     Events sorted by x position:  P1-start@x=0, P2-start@x=1, P1-end@x=2, P2-end@x=3
+ *     Intersection (P1 AND P2): result interval [1,2]
+ *     Union        (P1 OR  P2): result interval [0,3]
+ *     Difference   (P1-P2)    : result interval [0,1]
+ *
+ * The algorithm works by:
+ * 1. Decomposing both polygons into trapezoids via TrapezoidalDecomposer
+ * 2. Collecting all critical Y-values from both trapezoid sets, plus
+ *    Y-values where trapezoid edges from different polygons cross
+ * 3. For each Y-band, gathering X-intervals from each polygon's trapezoids
+ * 4. Applying the boolean predicate on the interval events
+ * 5. Emitting result trapezoids as polygons
+ */
+template <typename T>
+std::shared_ptr<PolygonPad<T>> compute_boolean_with_decomposition(
+    const std::shared_ptr<PolygonPad<T>> & pad,
+    size_t polygon_id1,
+    size_t polygon_id2,
+    BooleanOperation op)
+{
+    using value_type = T;
+    using point_type = Point3d<T>;
+
+    std::shared_ptr<PolygonPad<T>> result = PolygonPad<T>::construct(pad->ndim());
+
+    // Short-circuit: operating a polygon with itself
+    if (polygon_id1 == polygon_id2)
+    {
+        if (op == BooleanOperation::Difference)
+        {
+            return result; // P - P = empty
+        }
+        // Union(P, P) = P, Intersection(P, P) = P: copy the polygon
+        Polygon3d<T> poly = pad->get_polygon(polygon_id1);
+        std::vector<point_type> nodes;
+        nodes.reserve(poly.nnode());
+        for (size_t i = 0; i < poly.nnode(); ++i)
+        {
+            nodes.push_back(poly.node(i));
+        }
+        result->add_polygon(nodes);
+        return result;
+    }
+
+    // Step 1: Decompose both polygons using the pad's TrapezoidalDecomposer
+    size_t begin1, end1, begin2, end2;
+    std::tie(begin1, end1) = pad->decompose_to_trapezoid(polygon_id1);
+    std::tie(begin2, end2) = pad->decompose_to_trapezoid(polygon_id2);
+    std::shared_ptr<TrapezoidPad<T>> trap_pad = pad->decomposed_trapezoids();
+
+    if (begin1 == end1 && begin2 == end2)
+    {
+        return result;
+    }
+
+    // Step 2: Read trapezoid geometry directly from trap_pad.
+    //
+    // Each trapezoid in the TrapezoidPad has 4 corners stored as:
+    //   p0 = (x0, y0) bottom-left     p1 = (x1, y1) bottom-right
+    //   p3 = (x3, y3) top-left        p2 = (x2, y2) top-right
+    //
+    // A trapezoid forms a horizontal band [y0, y3] (bottom to top).
+    // Its left edge goes from x0 (at y0) to x3 (at y3); its right edge
+    // goes from x1 (at y0) to x2 (at y3).  Both edges are linear in Y.
+    //
+    // The source polygon is determined by the index range:
+    //   [begin1, end1) -> polygon1 (source 0)
+    //   [begin2, end2) -> polygon2 (source 1)
+    auto source_of = [begin1, end1, begin2, end2](size_t idx) -> int
+    {
+        if (idx >= begin1 && idx < end1)
+        {
+            return 0;
+        }
+        if (idx >= begin2 && idx < end2)
+        {
+            return 1;
+        }
+        throw std::logic_error("trapezoid index belongs to neither polygon");
+    };
+
+    // Helper: linearly interpolate X along a trapezoid edge at a given Y.
+    // An edge is defined by two points: bottom_point and top_point.
+    constexpr value_type eps = std::numeric_limits<value_type>::epsilon() * 100;
+
+    auto lerp_x = [eps](const point_type & bottom_point, const point_type & top_point, value_type y) -> value_type
+    {
+        value_type dy = top_point.y() - bottom_point.y();
+        value_type scale = std::max(std::abs(top_point.y()), std::abs(bottom_point.y()));
+        if (std::abs(dy) < eps * std::max(scale, value_type(1)))
+        {
+            return bottom_point.x();
+        }
+        value_type t = (y - bottom_point.y()) / dy;
+        return bottom_point.x() + t * (top_point.x() - bottom_point.x());
+    };
+
+    // TODO: potential performance issue: std container
+    // Collect all unique Y values from trapezoid boundaries
+    std::set<value_type> y_set;
+    for (size_t idx = begin1; idx < end1; ++idx)
+    {
+        y_set.insert(trap_pad->y0(idx));
+        y_set.insert(trap_pad->y3(idx));
+    }
+    for (size_t idx = begin2; idx < end2; ++idx)
+    {
+        y_set.insert(trap_pad->y0(idx));
+        y_set.insert(trap_pad->y3(idx));
+    }
+
+    // Find Y values where trapezoid edges from different polygons cross.
+    // This ensures no two cross-polygon edges swap order within a band.
+    // Only cross-polygon pairs need checking (polygon1 vs polygon2).
+    for (size_t ti = begin1; ti < end1; ++ti)
+    {
+        for (size_t tj = begin2; tj < end2; ++tj)
+        {
+            // Y-range overlap between the two trapezoids
+            value_type y_lo = std::max(trap_pad->y0(ti), trap_pad->y0(tj));
+            value_type y_hi = std::min(trap_pad->y3(ti), trap_pad->y3(tj));
+            if (y_lo >= y_hi)
+            {
+                continue;
+            }
+
+            // TODO: potential performance issue: closure in the nested loop
+            // Find the Y-value where two edges cross within the overlap range.
+            // Each edge is defined by its X-values at y_lo and y_hi.
+            // clang-format off
+            auto find_crossing = [&](value_type edge_a_x_at_bottom, value_type edge_a_x_at_top,
+                                     value_type edge_b_x_at_bottom, value_type edge_b_x_at_top,
+                                     value_type overlap_y_bottom, value_type overlap_y_top) -> void
+            {
+                // clang-format on
+
+                // Parameterize two edges as linear functions of t in [0,1]:
+                //   edge_a(t) = edge_a_x_at_bottom + dx_a * t
+                //   edge_b(t) = edge_b_x_at_bottom + dx_b * t
+                // They cross when (edge_a_x_at_bottom - edge_b_x_at_bottom) + (dx_a - dx_b)*t = 0
+                value_type dx_a = edge_a_x_at_top - edge_a_x_at_bottom;
+                value_type dx_b = edge_b_x_at_top - edge_b_x_at_bottom;
+                value_type denom = dx_a - dx_b;
+                value_type scale = std::max({std::abs(dx_a), std::abs(dx_b), value_type(1)});
+                if (std::abs(denom) < eps * scale)
+                {
+                    return; // edges are parallel, no crossing
+                }
+                value_type t = (edge_b_x_at_bottom - edge_a_x_at_bottom) / denom;
+                if (t > 0 && t < 1)
+                {
+                    value_type crossing_y = overlap_y_bottom + t * (overlap_y_top - overlap_y_bottom);
+                    y_set.insert(crossing_y);
+                }
+            };
+
+            // Trapezoid edges (each edge is a pair of points: bottom -> top):
+            //   Left edge:  p0 (bottom-left)  -> p3 (top-left)
+            //   Right edge: p1 (bottom-right) -> p2 (top-right)
+            point_type trap_i_left_bottom = trap_pad->p0(ti);
+            point_type trap_i_left_top = trap_pad->p3(ti);
+            point_type trap_i_right_bottom = trap_pad->p1(ti);
+            point_type trap_i_right_top = trap_pad->p2(ti);
+            point_type trap_j_left_bottom = trap_pad->p0(tj);
+            point_type trap_j_left_top = trap_pad->p3(tj);
+            point_type trap_j_right_bottom = trap_pad->p1(tj);
+            point_type trap_j_right_top = trap_pad->p2(tj);
+
+            // Interpolate each trapezoid's left/right edges within the Y-overlap range to get X-values at y_lo and y_hi.
+            value_type trap_i_left_at_bottom = lerp_x(trap_i_left_bottom, trap_i_left_top, y_lo);
+            value_type trap_i_left_at_top = lerp_x(trap_i_left_bottom, trap_i_left_top, y_hi);
+            value_type trap_i_right_at_bottom = lerp_x(trap_i_right_bottom, trap_i_right_top, y_lo);
+            value_type trap_i_right_at_top = lerp_x(trap_i_right_bottom, trap_i_right_top, y_hi);
+            value_type trap_j_left_at_bottom = lerp_x(trap_j_left_bottom, trap_j_left_top, y_lo);
+            value_type trap_j_left_at_top = lerp_x(trap_j_left_bottom, trap_j_left_top, y_hi);
+            value_type trap_j_right_at_bottom = lerp_x(trap_j_right_bottom, trap_j_right_top, y_lo);
+            value_type trap_j_right_at_top = lerp_x(trap_j_right_bottom, trap_j_right_top, y_hi);
+
+            // TODO: potential performance issue: closure in the nested loop
+            // Check all 4 edge-pair crossings between the two trapezoids:
+            // left_i vs left_j, left_i vs right_j, right_i vs left_j, right_i vs right_j
+            // Add any crossing Y-values to the set of critical Y-values.
+            find_crossing(trap_i_left_at_bottom, trap_i_left_at_top, trap_j_left_at_bottom, trap_j_left_at_top, y_lo, y_hi);
+            find_crossing(trap_i_left_at_bottom, trap_i_left_at_top, trap_j_right_at_bottom, trap_j_right_at_top, y_lo, y_hi);
+            find_crossing(trap_i_right_at_bottom, trap_i_right_at_top, trap_j_left_at_bottom, trap_j_left_at_top, y_lo, y_hi);
+            find_crossing(trap_i_right_at_bottom, trap_i_right_at_top, trap_j_right_at_bottom, trap_j_right_at_top, y_lo, y_hi);
+        }
+    }
+
+    // Convert to sorted vector and merge near-duplicate Y-values that
+    // differ only by floating-point rounding, avoiding degenerate
+    // near-zero-height bands.
+    std::vector<value_type> y_values(y_set.begin(), y_set.end());
+    {
+        auto merged_end = std::unique(y_values.begin(), y_values.end(), [eps](value_type a, value_type b)
+                                      {
+                                          value_type scale = std::max(std::abs(a), std::abs(b));
+                                          return std::abs(a - b) < eps * std::max(scale, value_type(1)); });
+        y_values.erase(merged_end, y_values.end());
+    }
+
+    if (y_values.size() < 2)
+    {
+        return result;
+    }
+
+    // Boolean predicate
+    auto should_include = [op](int count_p1, int count_p2) -> bool
+    {
+        switch (op)
+        {
+        case BooleanOperation::Union:
+            return (count_p1 > 0) || (count_p2 > 0); // either polygon contributes to this region
+        case BooleanOperation::Intersection:
+            return (count_p1 > 0) && (count_p2 > 0); // both polygons must contribute to this region
+        case BooleanOperation::Difference:
+            return (count_p1 > 0) && (count_p2 == 0); // only include regions where polygon 1 contributes and polygon 2 does not
+        default:
+            return false;
+        }
+    };
+
+    // Step 3: Sweep through Y-bands.
+    // Each consecutive pair [y_values[yi], y_values[yi+1]] forms one band.
+    // Within this band we collect X-interval events from every trapezoid
+    // that vertically spans it, then sweep those events left-to-right to
+    // determine which X-regions satisfy the boolean predicate.
+    struct Event
+    {
+        value_type x_lo, x_hi; // X at y_low and y_high
+        int source;
+        bool is_start; // true = entering the polygon interval, false = leaving
+    }; /* end struct Event */
+
+    // Reuse the events vector across bands to avoid repeated heap allocation
+    std::vector<Event> events;
+
+    for (size_t yi = 0; yi + 1 < y_values.size(); ++yi)
+    {
+        value_type y_low = y_values[yi];
+        value_type y_high = y_values[yi + 1];
+
+        events.clear();
+
+        // Gather interval-boundary events from trapezoids spanning this band
+        auto gather_events = [&](size_t begin, size_t end)
+        {
+            for (size_t idx = begin; idx < end; ++idx)
+            {
+                if (!(trap_pad->y0(idx) <= y_low && trap_pad->y3(idx) >= y_high))
+                {
+                    continue; // trapezoid doesn't vertically span this band
+                }
+                int source = source_of(idx);
+                // Left edge: p0 (bottom-left) -> p3 (top-left)
+                // Right edge: p1 (bottom-right) -> p2 (top-right)
+                point_type left_bottom = trap_pad->p0(idx);
+                point_type left_top = trap_pad->p3(idx);
+                point_type right_bottom = trap_pad->p1(idx);
+                point_type right_top = trap_pad->p2(idx);
+                value_type left_x_at_band_bottom = lerp_x(left_bottom, left_top, y_low);
+                value_type left_x_at_band_top = lerp_x(left_bottom, left_top, y_high);
+                value_type right_x_at_band_bottom = lerp_x(right_bottom, right_top, y_low);
+                value_type right_x_at_band_top = lerp_x(right_bottom, right_top, y_high);
+                events.push_back({left_x_at_band_bottom, left_x_at_band_top, source, true});
+                events.push_back({right_x_at_band_bottom, right_x_at_band_top, source, false});
+            }
+        };
+        gather_events(begin1, end1);
+        gather_events(begin2, end2);
+
+        if (events.empty())
+        {
+            continue;
+        }
+
+        // Sort events by X position (use average of x_lo and x_hi).
+        // Use tolerance-based comparison to avoid nondeterministic ordering
+        // from floating-point rounding at nearly-identical X positions.
+        // clang-format off
+        std::sort(events.begin(), events.end(),
+            [eps](const Event & a, const Event & b)
+            {
+                value_type xa = a.x_lo + a.x_hi;
+                value_type xb = b.x_lo + b.x_hi;
+                value_type scale = std::max({std::abs(xa), std::abs(xb), value_type(1)});
+                if (std::abs(xa - xb) > eps * scale)
+                {
+                    return xa < xb;
+                }
+                // At same X, end events before start events
+                return !a.is_start && b.is_start;
+            }
+        );
+        // clang-format on
+
+        // Sweep left to right
+        int count_p1 = 0;
+        int count_p2 = 0;
+        bool currently_included = false;
+        value_type left_x_low = 0;
+        value_type left_x_high = 0;
+
+        for (const auto & ev : events)
+        {
+            bool was_included = currently_included;
+
+            if (ev.source == 0)
+            {
+                count_p1 += ev.is_start ? 1 : -1;
+            }
+            else
+            {
+                count_p2 += ev.is_start ? 1 : -1;
+            }
+
+            currently_included = should_include(count_p1, count_p2);
+
+            if (!was_included && currently_included)
+            {
+                // Entering an included region
+                left_x_low = ev.x_lo;
+                left_x_high = ev.x_hi;
+            }
+            else if (was_included && !currently_included)
+            {
+                // Leaving an included region -- emit trapezoid as polygon (CCW)
+                value_type bottom_width = std::abs(ev.x_lo - left_x_low);
+                value_type top_width = std::abs(ev.x_hi - left_x_high);
+                // Skip degenerate zero-area trapezoids (edges touching at a point/line)
+                if (bottom_width > eps || top_width > eps)
+                {
+                    std::vector<point_type> nodes = {
+                        point_type(left_x_low, y_low, 0),
+                        point_type(ev.x_lo, y_low, 0),
+                        point_type(ev.x_hi, y_high, 0),
+                        point_type(left_x_high, y_high, 0)};
+                    result->add_polygon(nodes);
+                }
+            }
+        }
+    }
+
+    return result;
+} /* end function compute_boolean_with_decomposition */
+
+} /* end namespace detail */
+
 template <typename T>
 std::shared_ptr<PolygonPad<T>> AreaBooleanUnion<T>::compute(const std::shared_ptr<PolygonPad<T>> & pad, size_t polygon_id1, size_t polygon_id2)
 {
-    // TODO: A proper implementation would merge overlapping regions using trapezoidal decomposition
-    auto empty_pad = PolygonPad<T>::construct(pad->ndim());
-    return empty_pad;
+    return detail::compute_boolean_with_decomposition(pad, polygon_id1, polygon_id2, detail::BooleanOperation::Union);
 }
 
 template <typename T>
 std::shared_ptr<PolygonPad<T>> AreaBooleanIntersection<T>::compute(const std::shared_ptr<PolygonPad<T>> & pad, size_t polygon_id1, size_t polygon_id2)
 {
-    // TODO:  A proper implementation would find overlapping regions using trapezoidal decomposition
-    auto empty_pad = PolygonPad<T>::construct(pad->ndim());
-    return empty_pad;
+    return detail::compute_boolean_with_decomposition(pad, polygon_id1, polygon_id2, detail::BooleanOperation::Intersection);
 }
 
 template <typename T>
 std::shared_ptr<PolygonPad<T>> AreaBooleanDifference<T>::compute(const std::shared_ptr<PolygonPad<T>> & pad, size_t polygon_id1, size_t polygon_id2)
 {
-    // TODO:  A proper implementation would subtract overlapping regions using trapezoidal decomposition
-    auto empty_pad = PolygonPad<T>::construct(pad->ndim());
-    return empty_pad;
+    return detail::compute_boolean_with_decomposition(pad, polygon_id1, polygon_id2, detail::BooleanOperation::Difference);
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/universe/pymod/wrap_polygon.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_polygon.cpp
@@ -165,7 +165,13 @@ WrapPolygonPad<T>::WrapPolygonPad(pybind11::module & mod, const char * pyname, c
             "boolean_difference",
             &wrapped_type::boolean_difference,
             py::arg("p1"),
-            py::arg("p2"));
+            py::arg("p2"))
+        .def(
+            "decomposed_trapezoids",
+            [](wrapped_type & self)
+            {
+                return self.decomposed_trapezoids();
+            });
 }
 
 template <typename T>

--- a/tests/test_polygon3d.py
+++ b/tests/test_polygon3d.py
@@ -332,13 +332,26 @@ class Polygon3dTB(ModMeshTB):
         self.assertFalse(polygon1.is_same(polygon2))
         self.assertTrue(polygon1.is_not_same(polygon2))
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
+    def _compute_total_area(self, result_pad):
+        """Helper to compute total unsigned area of all polygons in a pad."""
+        total = 0.0
+        for i in range(result_pad.num_polygons):
+            total += abs(result_pad.get_polygon(i).compute_signed_area())
+        return total
+
+    def _assert_all_ccw(self, result_pad):
+        """Assert all result polygons have counter-clockwise winding."""
+        for i in range(result_pad.num_polygons):
+            area = result_pad.get_polygon(i).compute_signed_area()
+            self.assertGreaterEqual(area, 0.0,
+                                    f"Polygon {i} has negative area {area}"
+                                    " (clockwise winding)")
+
     def test_boolean_union_simple(self):
         """Test polygon boolean union with two overlapping squares."""
         pad = self.PolygonPad(ndim=2)
 
-        # First square: (0,0) to (2,2)
+        # First square: (0,0) to (2,2), area = 4
         square1_nodes = [
             self.Point(0.0, 0.0, 0.0),
             self.Point(2.0, 0.0, 0.0),
@@ -347,7 +360,9 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon1 = pad.add_polygon(square1_nodes)
 
-        # Second square: (1,1) to (3,3) - overlaps with first
+        # Second square: (1,1) to (3,3), area = 4
+        # Overlap region: (1,1) to (2,2), area = 1
+        # Union area = 4 + 4 - 1 = 7
         square2_nodes = [
             self.Point(1.0, 1.0, 0.0),
             self.Point(3.0, 1.0, 0.0),
@@ -356,17 +371,12 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(square2_nodes)
 
-        # Call boolean_union - should not crash even if implementation is TODO
-        try:
-            result = pad.boolean_union(polygon1, polygon2)
-            # Implementation is not complete yet, but should return a list
-            self.assertIsInstance(result, self.PolygonPad)
-        except NotImplementedError:
-            # Expected if method raises NotImplementedError
-            pass
+        result = pad.boolean_union(polygon1, polygon2)
+        self.assertIsInstance(result, self.PolygonPad)
+        self.assertGreater(result.num_polygons, 0)
+        total_area = self._compute_total_area(result)
+        self.assert_allclose([total_area], [7.0], rtol=1e-6)
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
     def test_boolean_intersection_simple(self):
         """Test polygon boolean intersection with two overlapping squares."""
         pad = self.PolygonPad(ndim=2)
@@ -380,8 +390,8 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon1 = pad.add_polygon(square1_nodes)
 
-        # Second square: (1,1) to (3,3) - overlaps with first
-        # Intersection should be (1,1) to (2,2)
+        # Second square: (1,1) to (3,3)
+        # Intersection should be (1,1) to (2,2), area = 1
         square2_nodes = [
             self.Point(1.0, 1.0, 0.0),
             self.Point(3.0, 1.0, 0.0),
@@ -390,23 +400,17 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(square2_nodes)
 
-        # Call boolean_intersection - should not crash even
-        # if implementation is TODO
-        try:
-            result = pad.boolean_intersection(polygon1, polygon2)
-            # Implementation is not complete yet, but should return a list
-            self.assertIsInstance(result, self.PolygonPad)
-        except NotImplementedError:
-            # Expected if method raises NotImplementedError
-            pass
+        result = pad.boolean_intersection(polygon1, polygon2)
+        self.assertIsInstance(result, self.PolygonPad)
+        self.assertGreater(result.num_polygons, 0)
+        total_area = self._compute_total_area(result)
+        self.assert_allclose([total_area], [1.0], rtol=1e-6)
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
     def test_boolean_difference_simple(self):
         """Test polygon boolean difference with two overlapping squares."""
         pad = self.PolygonPad(ndim=2)
 
-        # First square: (0,0) to (2,2)
+        # First square: (0,0) to (2,2), area = 4
         square1_nodes = [
             self.Point(0.0, 0.0, 0.0),
             self.Point(2.0, 0.0, 0.0),
@@ -415,8 +419,8 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon1 = pad.add_polygon(square1_nodes)
 
-        # Second square: (1,1) to (3,3) - overlaps with first
-        # Difference (polygon1 - polygon2) should be L-shaped region
+        # Second square: (1,1) to (3,3)
+        # Difference (polygon1 - polygon2) = L-shaped region, area = 4 - 1 = 3
         square2_nodes = [
             self.Point(1.0, 1.0, 0.0),
             self.Point(3.0, 1.0, 0.0),
@@ -425,23 +429,17 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(square2_nodes)
 
-        # Call boolean_difference - should not crash even
-        # if implementation is TODO
-        try:
-            result = pad.boolean_difference(polygon1, polygon2)
-            # Implementation is not complete yet, but should return a list
-            self.assertIsInstance(result, self.PolygonPad)
-        except NotImplementedError:
-            # Expected if method raises NotImplementedError
-            pass
+        result = pad.boolean_difference(polygon1, polygon2)
+        self.assertIsInstance(result, self.PolygonPad)
+        self.assertGreater(result.num_polygons, 0)
+        total_area = self._compute_total_area(result)
+        self.assert_allclose([total_area], [3.0], rtol=1e-6)
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
     def test_boolean_union_non_overlapping(self):
         """Test polygon boolean union with two non-overlapping squares."""
         pad = self.PolygonPad(ndim=2)
 
-        # First square: (0,0) to (1,1)
+        # First square: (0,0) to (1,1), area = 1
         square1_nodes = [
             self.Point(0.0, 0.0, 0.0),
             self.Point(1.0, 0.0, 0.0),
@@ -450,7 +448,8 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon1 = pad.add_polygon(square1_nodes)
 
-        # Second square: (2,2) to (3,3) - no overlap
+        # Second square: (2,2) to (3,3), area = 1
+        # No overlap, union area = 2
         square2_nodes = [
             self.Point(2.0, 2.0, 0.0),
             self.Point(3.0, 2.0, 0.0),
@@ -459,15 +458,11 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(square2_nodes)
 
-        # Call boolean_union - should not crash
-        try:
-            result = pad.boolean_union(polygon1, polygon2)
-            self.assertIsInstance(result, self.PolygonPad)
-        except NotImplementedError:
-            pass
+        result = pad.boolean_union(polygon1, polygon2)
+        self.assertIsInstance(result, self.PolygonPad)
+        total_area = self._compute_total_area(result)
+        self.assert_allclose([total_area], [2.0], rtol=1e-6)
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
     def test_boolean_intersection_non_overlapping(self):
         """Test polygon boolean intersection with two non-overlapping squares.
         """
@@ -492,20 +487,15 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(square2_nodes)
 
-        # Call boolean_intersection - should not crash
-        try:
-            result = pad.boolean_intersection(polygon1, polygon2)
-            self.assertIsInstance(result, self.PolygonPad)
-        except NotImplementedError:
-            pass
+        result = pad.boolean_intersection(polygon1, polygon2)
+        self.assertIsInstance(result, self.PolygonPad)
+        self.assertEqual(result.num_polygons, 0)
 
-    # TODO: Verify and implement boolean operations
-    # once the C++ side is complete.
     def test_boolean_operations_triangle(self):
         """Test polygon boolean operations with triangular polygons."""
         pad = self.PolygonPad(ndim=2)
 
-        # Triangle 1: Right triangle at origin
+        # Triangle 1: (0,0)-(2,0)-(0,2), area = 2
         triangle1_nodes = [
             self.Point(0.0, 0.0, 0.0),
             self.Point(2.0, 0.0, 0.0),
@@ -513,7 +503,7 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon1 = pad.add_polygon(triangle1_nodes)
 
-        # Triangle 2: Right triangle shifted
+        # Triangle 2: (1,1)-(3,1)-(1,3), area = 2
         triangle2_nodes = [
             self.Point(1.0, 1.0, 0.0),
             self.Point(3.0, 1.0, 0.0),
@@ -521,24 +511,281 @@ class Polygon3dTB(ModMeshTB):
         ]
         polygon2 = pad.add_polygon(triangle2_nodes)
 
-        # Test all three operations - should not crash
-        try:
-            result_union = pad.boolean_union(polygon1, polygon2)
-            self.assertIsInstance(result_union, self.PolygonPad)
-        except NotImplementedError:
-            pass
+        # Intersection: the overlap region is x>=1, y>=1, x+y<=2.
+        # Since x>=1 and y>=1 imply x+y>=2, the only solution is the single
+        # point (1,1). The two triangles touch at exactly one point, so
+        # the intersection area is 0.
+        result_intersection = pad.boolean_intersection(polygon1, polygon2)
+        self.assertIsInstance(result_intersection, self.PolygonPad)
+        intersection_area = self._compute_total_area(result_intersection)
+        self.assertAlmostEqual(intersection_area, 0.0, places=5)
 
-        try:
-            result_intersection = pad.boolean_intersection(polygon1, polygon2)
-            self.assertIsInstance(result_intersection, self.PolygonPad)
-        except NotImplementedError:
-            pass
+        # Union area = 2 + 2 - 0 = 4
+        result_union = pad.boolean_union(polygon1, polygon2)
+        self.assertIsInstance(result_union, self.PolygonPad)
+        union_area = self._compute_total_area(result_union)
+        self.assert_allclose([union_area], [4.0], rtol=1e-6)
 
-        try:
-            result_difference = pad.boolean_difference(polygon1, polygon2)
-            self.assertIsInstance(result_difference, self.PolygonPad)
-        except NotImplementedError:
-            pass
+        # Difference area = 2 - 0 = 2
+        result_difference = pad.boolean_difference(polygon1, polygon2)
+        self.assertIsInstance(result_difference, self.PolygonPad)
+        diff_area = self._compute_total_area(result_difference)
+        self.assert_allclose([diff_area], [2.0], rtol=1e-6)
+
+    def test_boolean_containment(self):
+        """Test boolean operations when one polygon contains the other."""
+        pad = self.PolygonPad(ndim=2)
+
+        # Large square: (0,0) to (4,4), area = 16
+        large_nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(4.0, 0.0, 0.0),
+            self.Point(4.0, 4.0, 0.0),
+            self.Point(0.0, 4.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(large_nodes)
+
+        # Small square: (1,1) to (3,3), area = 4
+        small_nodes = [
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(3.0, 1.0, 0.0),
+            self.Point(3.0, 3.0, 0.0),
+            self.Point(1.0, 3.0, 0.0)
+        ]
+        polygon2 = pad.add_polygon(small_nodes)
+
+        # Union = large square, area = 16
+        result_union = pad.boolean_union(polygon1, polygon2)
+        union_area = self._compute_total_area(result_union)
+        self.assert_allclose([union_area], [16.0], rtol=1e-6)
+
+        # Intersection = small square, area = 4
+        result_inter = pad.boolean_intersection(polygon1, polygon2)
+        inter_area = self._compute_total_area(result_inter)
+        self.assert_allclose([inter_area], [4.0], rtol=1e-6)
+
+        # Difference = large - small = 12
+        result_diff = pad.boolean_difference(polygon1, polygon2)
+        diff_area = self._compute_total_area(result_diff)
+        self.assert_allclose([diff_area], [12.0], rtol=1e-6)
+
+    def test_boolean_identical_polygons(self):
+        """Test boolean operations when both polygons are identical."""
+        pad = self.PolygonPad(ndim=2)
+
+        nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(3.0, 0.0, 0.0),
+            self.Point(3.0, 3.0, 0.0),
+            self.Point(0.0, 3.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(nodes)
+        polygon2 = pad.add_polygon(nodes)
+
+        # Union(P, P) = P, area = 9
+        result_union = pad.boolean_union(polygon1, polygon2)
+        self.assert_allclose(
+            [self._compute_total_area(result_union)], [9.0], rtol=1e-6)
+
+        # Intersection(P, P) = P, area = 9
+        result_inter = pad.boolean_intersection(polygon1, polygon2)
+        self.assert_allclose(
+            [self._compute_total_area(result_inter)], [9.0], rtol=1e-6)
+
+        # Difference(P, P) = empty
+        result_diff = pad.boolean_difference(polygon1, polygon2)
+        self.assertEqual(result_diff.num_polygons, 0)
+
+    def test_boolean_shared_edge(self):
+        """Test boolean operations with two squares sharing an edge."""
+        pad = self.PolygonPad(ndim=2)
+
+        # Square 1: (0,0)-(1,1)
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(0.0, 1.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(nodes1)
+
+        # Square 2: (1,0)-(2,1), shares edge at x=1
+        nodes2 = [
+            self.Point(1.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 1.0, 0.0),
+            self.Point(1.0, 1.0, 0.0)
+        ]
+        polygon2 = pad.add_polygon(nodes2)
+
+        # Union = (0,0)-(2,1), area = 2
+        result_union = pad.boolean_union(polygon1, polygon2)
+        self.assert_allclose(
+            [self._compute_total_area(result_union)], [2.0], rtol=1e-6)
+
+        # Intersection: touching at edge only, area = 0
+        result_inter = pad.boolean_intersection(polygon1, polygon2)
+        inter_area = self._compute_total_area(result_inter)
+        self.assertAlmostEqual(inter_area, 0.0, places=5)
+
+        # Difference(A, B) = square 1, area = 1
+        result_diff = pad.boolean_difference(polygon1, polygon2)
+        self.assert_allclose(
+            [self._compute_total_area(result_diff)], [1.0], rtol=1e-6)
+
+    def test_boolean_commutativity(self):
+        """Test that union and intersection are commutative,
+        and difference is non-commutative."""
+        pad = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 2.0, 0.0),
+            self.Point(0.0, 2.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(nodes1)
+
+        nodes2 = [
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(3.0, 1.0, 0.0),
+            self.Point(3.0, 3.0, 0.0),
+            self.Point(1.0, 3.0, 0.0)
+        ]
+        polygon2 = pad.add_polygon(nodes2)
+
+        # Union(A, B) == Union(B, A)
+        union_ab = self._compute_total_area(
+            pad.boolean_union(polygon1, polygon2))
+        union_ba = self._compute_total_area(
+            pad.boolean_union(polygon2, polygon1))
+        self.assert_allclose([union_ab], [union_ba], rtol=1e-6)
+
+        # Intersection(A, B) == Intersection(B, A)
+        inter_ab = self._compute_total_area(
+            pad.boolean_intersection(polygon1, polygon2))
+        inter_ba = self._compute_total_area(
+            pad.boolean_intersection(polygon2, polygon1))
+        self.assert_allclose([inter_ab], [inter_ba], rtol=1e-6)
+
+        # Difference is non-commutative: A-B=3, B-A=3 in area but
+        # they are different regions. Verify areas are as expected.
+        diff_ab = self._compute_total_area(
+            pad.boolean_difference(polygon1, polygon2))
+        diff_ba = self._compute_total_area(
+            pad.boolean_difference(polygon2, polygon1))
+        self.assert_allclose([diff_ab], [3.0], rtol=1e-6)
+        self.assert_allclose([diff_ba], [3.0], rtol=1e-6)
+
+    def test_boolean_partial_vertical_overlap(self):
+        """Test with rectangles that partially overlap in Y."""
+        pad = self.PolygonPad(ndim=2)
+
+        # Rectangle 1: (0,0)-(2,3), area = 6
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 3.0, 0.0),
+            self.Point(0.0, 3.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(nodes1)
+
+        # Rectangle 2: (1,1)-(3,2), area = 2
+        # Overlap region: (1,1)-(2,2), area = 1
+        nodes2 = [
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(3.0, 1.0, 0.0),
+            self.Point(3.0, 2.0, 0.0),
+            self.Point(1.0, 2.0, 0.0)
+        ]
+        polygon2 = pad.add_polygon(nodes2)
+
+        # Union = 6 + 2 - 1 = 7
+        result_union = pad.boolean_union(polygon1, polygon2)
+        self._assert_all_ccw(result_union)
+        self.assert_allclose(
+            [self._compute_total_area(result_union)], [7.0], rtol=1e-6)
+
+        # Intersection = 1
+        result_inter = pad.boolean_intersection(polygon1, polygon2)
+        self._assert_all_ccw(result_inter)
+        self.assert_allclose(
+            [self._compute_total_area(result_inter)], [1.0], rtol=1e-6)
+
+        # Difference = 6 - 1 = 5
+        result_diff = pad.boolean_difference(polygon1, polygon2)
+        self._assert_all_ccw(result_diff)
+        self.assert_allclose(
+            [self._compute_total_area(result_diff)], [5.0], rtol=1e-6)
+
+    def test_boolean_concave_polygon(self):
+        """Test boolean operations with a concave (L-shaped) polygon."""
+        pad = self.PolygonPad(ndim=2)
+
+        # L-shaped polygon (concave):
+        # (0,0)-(2,0)-(2,1)-(1,1)-(1,2)-(0,2), area = 3
+        l_nodes = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 1.0, 0.0),
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(1.0, 2.0, 0.0),
+            self.Point(0.0, 2.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(l_nodes)
+
+        # Square overlapping the L: (0.5, 0.5)-(1.5, 1.5), area = 1
+        sq_nodes = [
+            self.Point(0.5, 0.5, 0.0),
+            self.Point(1.5, 0.5, 0.0),
+            self.Point(1.5, 1.5, 0.0),
+            self.Point(0.5, 1.5, 0.0)
+        ]
+        polygon2 = pad.add_polygon(sq_nodes)
+
+        # The square partially extends outside the L's notch:
+        #   Band [0.5, 1.0]: full square width (0.5 to 1.5), height 0.5 -> 0.5
+        #   Band [1.0, 1.5]: only x in [0.5, 1.0] (L's left column), -> 0.25
+        # Intersection area = 0.75
+        result_inter = pad.boolean_intersection(polygon1, polygon2)
+        inter_area = self._compute_total_area(result_inter)
+        self.assert_allclose([inter_area], [0.75], rtol=1e-6)
+
+        # Union = L + square - intersection = 3 + 1 - 0.75 = 3.25
+        result_union = pad.boolean_union(polygon1, polygon2)
+        union_area = self._compute_total_area(result_union)
+        self.assert_allclose([union_area], [3.25], rtol=1e-6)
+
+        # Difference(L, square) = L - intersection = 3 - 0.75 = 2.25
+        result_diff = pad.boolean_difference(polygon1, polygon2)
+        diff_area = self._compute_total_area(result_diff)
+        self.assert_allclose([diff_area], [2.25], rtol=1e-6)
+
+    def test_boolean_result_ccw_winding(self):
+        """Test that all result polygons from boolean operations have
+        counter-clockwise winding (non-negative signed area)."""
+        pad = self.PolygonPad(ndim=2)
+
+        nodes1 = [
+            self.Point(0.0, 0.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+            self.Point(2.0, 2.0, 0.0),
+            self.Point(0.0, 2.0, 0.0)
+        ]
+        polygon1 = pad.add_polygon(nodes1)
+
+        nodes2 = [
+            self.Point(1.0, 1.0, 0.0),
+            self.Point(3.0, 1.0, 0.0),
+            self.Point(3.0, 3.0, 0.0),
+            self.Point(1.0, 3.0, 0.0)
+        ]
+        polygon2 = pad.add_polygon(nodes2)
+
+        self._assert_all_ccw(pad.boolean_union(polygon1, polygon2))
+        self._assert_all_ccw(pad.boolean_intersection(polygon1, polygon2))
+        self._assert_all_ccw(pad.boolean_difference(polygon1, polygon2))
+        self._assert_all_ccw(pad.boolean_difference(polygon2, polygon1))
 
 
 class Polygon3dFp32TC(Polygon3dTB, unittest.TestCase):


### PR DESCRIPTION
# Implement Polygon Boolean Operations (Union, Intersection, Difference)

## Summary

Implement polygon boolean operations using **trapezoidal decomposition + Y-band sweep with X-interval merge**. This approach is based on the algorithm described in:

> *"A New Method of Applying Polygon Boolean Operations Based on Trapezoidal Decomposition"*, GIScience & Remote Sensing, Vol 47, No 4 (2010)

The three operations — `boolean_union`, `boolean_intersection`, and `boolean_difference` — are implemented as a single unified algorithm parameterized by a boolean predicate.

## Visualization

The visualization code is not included in this PR and is provided only for reference.

Order (left to right, top to down): original outlined polygonss, original colored polygons, the union reseult, the intersection result, the difference result.

<img width="1221" height="644" alt="image" src="https://github.com/user-attachments/assets/59a41c23-d3ce-4a18-b619-df9dcad30f1d" />

<img width="1262" height="687" alt="Screenshot 2026-03-14 at 2 56 57 PM" src="https://github.com/user-attachments/assets/9d45cc49-23bc-4602-90b1-e97310a7f351" />

<img width="1339" height="663" alt="Screenshot 2026-03-14 at 2 57 35 PM" src="https://github.com/user-attachments/assets/dcd2dfbf-0676-4891-bfc2-32cca3fb8611" />

## Algorithm web explaination

Please use browser to read the web page:
https://gist.github.com/tigercosmos/4a358accfae620ada14a5ffa0776c668

## Algorithm Overview

The algorithm has **two phases**:

| Phase | Description |
|-------|-------------|
| **1. Decomposition** | Each polygon is independently decomposed into horizontal-band trapezoids by the existing `TrapezoidalDecomposer` |
| **2. Boolean Merge** | The two trapezoid sets are combined using a Y-band sweep with an X-interval sweep inside each band |

### Phase 2 in Detail

```
Step 1: Collect critical Y-values
         ├── From trapezoid boundaries (y_bottom, y_top of each trapezoid)
         └── From edge-edge crossings between polygon1 and polygon2 trapezoids

Step 2: For each Y-band [y_low, y_high]:
         ├── Gather X-interval events from spanning trapezoids
         ├── Sort events by X-position
         └── Sweep left-to-right, applying boolean predicate

Step 3: Emit result trapezoids as CCW polygons
```

### Boolean Predicates

| Operation | Predicate | Meaning |
|-----------|-----------|---------|
| **Union** | `count_p1 > 0 OR count_p2 > 0` | Inside either polygon |
| **Intersection** | `count_p1 > 0 AND count_p2 > 0` | Inside both polygons |
| **Difference** | `count_p1 > 0 AND count_p2 == 0` | Inside P1 but not P2 |

### Worked Example

Two overlapping squares: P1 = (0,0)-(2,2), P2 = (1,1)-(3,3).

```
   y=3 - - - - - ┬────────────────┐- - - - - - - - - -
                 │          P2    │        band [2,3]
   y=2 ┬────────────────┐- - - - -│- - - - - - - - - -
       │   P1    │//////│         │        band [1,2]
   y=1 │- - - - -└──────┴─────────┘- - - - - - - - - -
       │                │                  band [0,1]
   y=0 └────────────────┘- - - - - - - - - - - - - - -
       x=0      x=1    x=2       x=3
```

Y-values: {0, 1, 2, 3} → 3 bands.

**Band [1, 2] event sweep:**

```
Events sorted by X:  P1-start@0  P2-start@1  P1-end@2  P2-end@3
                         │            │           │          │
count_p1:                1            1           0          0
count_p2:                0            1           1          0
```

| X | Event | count_p1 | count_p2 | Intersection | Union | Difference |
|---|-------|----------|----------|:---:|:---:|:---:|
| 0 | P1 start | 1 | 0 | - | record left=0 | record left=0 |
| 1 | P2 start | 1 | 1 | record left=1 | (still in) | **emit [0,1]** |
| 2 | P1 end | 0 | 1 | **emit [1,2]** | (still in) | - |
| 3 | P2 end | 0 | 0 | - | **emit [0,3]** | - |

### Handling Slanted Edges

Each event stores **two X-values** — one at band bottom, one at band top — because polygon edges can be slanted. The emitted result is a general trapezoid with four corners:

```
        left_x_top ─────────── right_x_top      ← y_high
       /                              \
      /    result trapezoid            \
     /                                  \
    left_x_bottom ─────────── right_x_bottom    ← y_low
```

The bottom and top edges may have different widths, naturally handling triangles and trapezoids.

### Edge-Crossing Y-Split

When trapezoid edges from different polygons cross within a Y-band, the crossing Y-value is detected and inserted into the critical Y-values set. This subdivides the band so that no two cross-polygon edges swap order within a single sub-band, ensuring correctness.

```txt
Before split:              After split:
┌──────────────┐           ┌──────────────┐
│  ╲   ╱       │           │   ╲  ╱       │ band [y_cross, y_top]
│    ╳         │    →      ├────╳─────────┤ ← y_cross inserted
│   ╱ ╲        │           │   ╱ ╲        │ band [y_bottom, y_cross]
│  ╱   ╲       │           │  ╱   ╲       │
└──────────────┘           └──────────────┘
```

## Key Design Decisions

- **Reuses existing `TrapezoidalDecomposer`** — no new decomposition code needed
- **Unified algorithm** — all three operations share one function (`compute_boolean_with_decomposition`) parameterized by a `BoolOp` enum
- **No custom structs for intermediate data** — works directly with `TrapezoidPad` indices and a `source_of()` lambda
- **Output as trapezoids** — result polygons are emitted as CCW quadrilaterals, matching the existing trapezoidal representation
- **Relative epsilon** — all floating-point comparisons use relative thresholds scaled by coordinate magnitude
- **Degenerate filtering** — zero-area trapezoids from touching edges are skipped
- **Near-duplicate Y merge** — Y-values within relative epsilon are merged to avoid degenerate bands

## Files Changed

| File | Changes |
|------|---------|
| `cpp/modmesh/universe/polygon.hpp` | Added `detail::BoolOp` enum, `detail::compute_boolean_with_decomposition()` function, `decomposed_trapezoids()` accessor, implemented `AreaBooleanUnion/Intersection/Difference::compute()` |
| `tests/test_polygon3d.py` | 13 boolean operation tests covering: overlapping squares, non-overlapping, triangles, containment, identical polygons, shared edges, commutativity, partial vertical overlap, concave polygons, CCW winding verification |

## Test Plan

- [x] All 52 tests pass for both `float32` and `float64`
- [x] Overlapping squares: union=7, intersection=1, difference=3
- [x] Non-overlapping squares: union=2, intersection=0
- [x] Triangles touching at a point: intersection=0
- [x] Containment: union=16, intersection=4, difference=12
- [x] Identical polygons: union=P, intersection=P, difference=empty
- [x] Shared edge: union=2, intersection=0, difference=1
- [x] Commutativity: union(A,B)==union(B,A), intersection(A,B)==intersection(B,A)
- [x] Partial vertical overlap: union=7, intersection=1, difference=5
- [x] Concave (L-shaped) polygon: intersection=0.75, union=3.25, difference=2.25
- [x] All result polygons have CCW winding (non-negative signed area)

## AI Usage
Used Claude Code with Opus 4.6 to implement the draft. Used Codex with 5.3-codex high effort for review. Fine-tuned the implementation manually with both Claude Code and Codex support. Used AI to generate all documents and the PR description.
