### PR TITLE
Fix trapezoid decomposition edge sorting for coincident-x edges

### DIFF
--- a/cpp/modmesh/universe/polygon.hpp
+++ b/cpp/modmesh/universe/polygon.hpp
@@ -1145,9 +1145,14 @@ std::pair<size_t, size_t> TrapezoidalDecomposer<T>::decompose(size_t polygon_id,
         // Sort active edges by x at current y
         std::sort(active_edges.begin(), active_edges.end(), [y_current](const Edge & a, const Edge & b)
                   {
-                          value_type ax = a.x_at_lower_y + a.dxdy * (y_current - a.lower_y);
-                          value_type bx = b.x_at_lower_y + b.dxdy * (y_current - b.lower_y);
-                          return ax < bx; });
+                      value_type ax = a.x_at_lower_y + a.dxdy * (y_current - a.lower_y);
+                      value_type bx = b.x_at_lower_y + b.dxdy * (y_current - b.lower_y);
+                      if (ax != bx)
+                      {
+                          return ax < bx;
+                      }
+                      // If x values are equal, sort by dxdy to ensure consistent ordering of edges
+                      return a.dxdy < b.dxdy; });
 
         // Create trapezoids between pairs of active edges
         for (size_t j = 0; j < active_edges.size() - 1; j += 2)

--- a/tests/test_polygon3d.py
+++ b/tests/test_polygon3d.py
@@ -761,9 +761,45 @@ class Polygon3dTB(ModMeshTB):
         diff_area = self._compute_total_area(result_diff)
         self.assert_allclose([diff_area], [2.25], rtol=1e-6)
 
+    def test_decomposition_edge_order(self):
+        """Test that polygon decomposition produces non-inverted trapezoids.
+        """
+        pad = self.PolygonPad(ndim=2)
+
+        # Triangle 1: apex at bottom y=0, base at y=2
+        # Vertices CCW: (0,2) -> (4,2) -> (2,0)
+        nodes1 = [
+            self.Point(0.0, 2.0, 0.0),
+            self.Point(4.0, 2.0, 0.0),
+            self.Point(2.0, 0.0, 0.0),
+        ]
+        _ = pad.add_polygon(nodes1)
+
+        # Triangle 2: shifted right, apex at bottom y=0
+        # Vertices CCW: (1,3) -> (5,3) -> (3,0)
+        nodes2 = [
+            self.Point(1.0, 3.0, 0.0),
+            self.Point(5.0, 3.0, 0.0),
+            self.Point(3.0, 0.0, 0.0),
+        ]
+        _ = pad.add_polygon(nodes2)
+
+        # Verify decomposition produces non-inverted trapezoids
+        # The apex of each triangles is at y=0,
+        # so the x value at y=0 will be the same for both left and right edges.
+        # Thus, the dxdy should be consider to prevent inverted trapezoids.
+        trap_pad = pad.decomposed_trapezoids()
+        for trap_id in range(trap_pad.size):
+            # At the top of each trapezoid, left_x (p3) <= right_x (p2)
+            self.assertLessEqual(
+                trap_pad.x3(trap_id), trap_pad.x2(trap_id),
+                f"Inverted trapezoid {trap_id}:"
+                f"top-left x={trap_pad.x3(trap_id)}"
+                f" > top-right x={trap_pad.x2(trap_id)}")
+
     def test_boolean_result_ccw_winding(self):
         """Test that all result polygons from boolean operations have
-        counter-clockwise winding (non-negative signed area)."""
+        counter - clockwise winding(non - negative signed area)."""
         pad = self.PolygonPad(ndim=2)
 
         nodes1 = [


### PR DESCRIPTION
When two edges share the same x-coordinate at the current sweep line (e.g., at a triangle apex), the sort was unstable and could produce inverted trapezoids where left_x > right_x. Break ties by comparing dxdy so the left-leaning edge always comes first.

Add test_decomposition_edge_order to verify no inverted trapezoids are produced when decomposing triangles with shared apex y-values.

## Before & After

Before: the union and difference are incorrect (the bottom parts).

**union**
<img width="1287" height="695" alt="Screenshot 2026-03-18 at 4 04 14 PM" src="https://github.com/user-attachments/assets/a5a61b58-199c-4725-a0f2-1706366b4330" />
**difference**
<img width="1297" height="644" alt="Screenshot 2026-03-18 at 4 04 21 PM" src="https://github.com/user-attachments/assets/35e7eff8-a0de-4fcb-b63d-b37dec58a010" />


After: now the union and difference are correct.

**union**
<img width="1374" height="623" alt="Screenshot 2026-03-19 at 8 33 37 PM" src="https://github.com/user-attachments/assets/68e752f7-c4c7-487c-92f5-de5b577beee0" />
**difference**
<img width="1365" height="636" alt="Screenshot 2026-03-19 at 8 33 45 PM" src="https://github.com/user-attachments/assets/c0c09976-2a00-44cc-94f8-27beae154eac" />

## AI Tool

Claude Code with Opus 4.6 for draft. All code, commit and test cases are manually checked and modified.