### PR TITLE
Fix macOS CI symlink conflicts for clang tools and ccache

### DIFF
--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -25,8 +25,15 @@ runs:
         # qt6 versioning independently from the OS.
         # brew install llvm@21 qt6
         brew install llvm@21
-        ln -s "$(brew --prefix llvm@21)/bin/clang-format" "/usr/local/bin/clang-format"
-        ln -s "$(brew --prefix llvm@21)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+        # The macos-15 runner ships with Homebrew llvm@18 linked into
+        # /usr/local/bin/ (clang, clang++, clang-format, clang-tidy, etc.).
+        # Use -sf to overwrite the existing clang-format/clang-tidy with
+        # our llvm@21 versions, and remove clang/clang++ so that
+        # ccache-action (create-symlink: true) can create its own symlinks.
+        # Ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
+        ln -sf "$(brew --prefix llvm@21)/bin/clang-format" "/usr/local/bin/clang-format"
+        ln -sf "$(brew --prefix llvm@21)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+        rm -f /usr/local/bin/clang /usr/local/bin/clang++
 
     - name: install qt
       if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"


### PR DESCRIPTION
## Summary
- Use `ln -sf` (force) instead of `ln -s` when symlinking `clang-format` and `clang-tidy` from `llvm@21` into `/usr/local/bin/`, since the runner has pre-installed `llvm@18` symlinks at the same paths
- Remove pre-installed `/usr/local/bin/clang` and `/usr/local/bin/clang++` so that `ccache-action`'s `create-symlink: true` can create its own symlinks without "File exists" errors

## Test plan
- [x] Verify the "Run clang-tidy and flake8 on macos-15-intel" CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)