### PR TITLE
Add drawing shape interface to World

### DIFF
--- a/cpp/modmesh/pilot/RWorld.cpp
+++ b/cpp/modmesh/pilot/RWorld.cpp
@@ -146,8 +146,8 @@ RLines::RLines(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * paren
     , m_renderer(new Qt3DRender::QGeometryRenderer())
     , m_material(new Qt3DExtras::QDiffuseSpecularMaterial())
 {
-    // Create segment pad
-    std::shared_ptr<SegmentPadFp64> segments = world->segments()->clone();
+    // Collect all segments except those from removed shapes.
+    std::shared_ptr<SegmentPadFp64> segments = world->collect_live_segments();
     // Create sampled segments in a pad from the curves
     std::shared_ptr<SegmentPadFp64> csegs = world->curves()->sample(/*length*/ 0.1);
     // Extend the overall segment pad with the sampled segments

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -29,13 +29,49 @@
  */
 
 #include <modmesh/base.hpp>
+#include <modmesh/buffer/SimpleCollector.hpp>
 #include <modmesh/universe/bernstein.hpp>
 #include <modmesh/universe/bezier.hpp>
+#include <modmesh/universe/rtree.hpp>
 
 #include <deque>
+#include <vector>
 
 namespace modmesh
 {
+
+enum class ShapeType : uint8_t
+{
+    DEAD = 0, ///< deleted / unused slot
+    TRIANGLE = 1,
+}; /* end of enum class ShapeType */
+
+/**
+ * Lightweight record mapping a shape ID to its segment range in the pad.
+ */
+struct ShapeRecord
+{
+    ShapeType type;
+    size_t segment_offset; ///< first index in SegmentPad
+    size_t segment_count; ///< number of segments this shape occupies
+}; /* end of struct ShapeRecord */
+
+/**
+ * Entry stored in the R-tree: shape ID + bounding box.
+ */
+template <typename T>
+struct ShapeEntry
+{
+    int32_t shape_id;
+    BoundBox2d<T> bbox;
+    bool operator==(ShapeEntry const & other) const { return shape_id == other.shape_id; }
+}; /* end of struct ShapeEntry */
+
+template <typename T>
+struct RTreeValueOps<ShapeEntry<T>, BoundBox2d<T>>
+{
+    static BoundBox2d<T> calc_bound_box(ShapeEntry<T> const & entry) { return entry.bbox; }
+}; /* end of struct RTreeValueOps */
 
 /**
  * Manage all geometry entities.
@@ -60,10 +96,11 @@ public:
     using point_type = Point3d<T>;
     using segment_type = Segment3d<T>;
     using bezier_type = Bezier3d<T>;
-
     using point_pad_type = PointPad<T>;
     using segment_pad_type = SegmentPad<T>;
     using curve_pad_type = CurvePad<T>;
+    using bbox_type = BoundBox2d<T>;
+    using rtree_type = RTree<ShapeEntry<T>, bbox_type>;
 
     template <typename... Args>
     static std::shared_ptr<World<T>> construct(Args &&... args)
@@ -75,6 +112,7 @@ public:
         : m_points(point_pad_type::construct(/* ndim */ 3))
         , m_segments(segment_pad_type::construct(/* ndim */ 3))
         , m_curves(curve_pad_type::construct(/* ndim */ 3))
+        , m_rtree(std::make_unique<rtree_type>())
     {
     }
 
@@ -105,6 +143,7 @@ public:
     void add_segment(segment_type const & segment)
     {
         m_segments->append(segment);
+        m_bare_segment_indices.push_back(m_segments->size() - 1);
     }
     void add_segment(point_type const & p0, point_type const & p1)
     {
@@ -136,6 +175,44 @@ public:
     }
     std::shared_ptr<curve_pad_type> const & curves() { return m_curves; }
 
+    /**
+     * Add a triangle by decomposing it into 3 segments in the pad.
+     * Returns the shape ID for later reference.
+     */
+    int32_t add_triangle(T x0, T y0, T x1, T y1, T x2, T y2);
+
+    /**
+     * Translate all segments belonging to a shape by (dx, dy).
+     */
+    void translate_shape(int32_t shape_id, value_type dx, value_type dy);
+
+    /**
+     * Remove a shape from the R-tree and registry.
+     * Segments remain in the pad as dead data; use clear() to reclaim.
+     */
+    void remove_shape(int32_t shape_id);
+
+    ShapeType shape_type_of(int32_t shape_id) const { return find_shape_or_throw(shape_id).type; }
+
+    size_t nshape() const { return m_nshape; }
+
+    /**
+     * Query the R-tree for shapes whose bounding box overlaps the viewport.
+     */
+    std::vector<int32_t> query_visible(T min_x, T min_y, T max_x, T max_y) const;
+
+    /**
+     * Collect all segments except those belonging to DEAD shapes.
+     * Includes bare segments (added via add_segment) and live shape segments.
+     */
+    std::shared_ptr<segment_pad_type> collect_live_segments() const;
+
+    /**
+     * Remove all geometry entities (points, segments, curves, shapes)
+     * from the world. Rebuilds pads from scratch to reclaim memory.
+     */
+    void clear();
+
 private:
 
     void check_size(size_t i, size_t s, char const * msg) const
@@ -146,11 +223,171 @@ private:
         }
     }
 
+    bbox_type compute_shape_bbox(ShapeRecord const & rec) const;
+
+    /// Check if shape_id is valid and not DEAD.
+    /// @throw std::out_of_range if shape_id is out of bounds or shape is DEAD.
+    void check_shape_id(int32_t shape_id) const;
+
+    ShapeRecord const & find_shape_or_throw(int32_t shape_id) const
+    {
+        check_shape_id(shape_id);
+        return m_shape_registry[shape_id];
+    }
+
+    ShapeRecord & find_shape_or_throw(int32_t shape_id)
+    {
+        check_shape_id(shape_id);
+        return m_shape_registry[shape_id];
+    }
+
     std::shared_ptr<point_pad_type> m_points;
+
     std::shared_ptr<segment_pad_type> m_segments;
+    SimpleCollector<size_t> m_bare_segment_indices; ///< indices of segments not owned by any shape
+
     std::shared_ptr<curve_pad_type> m_curves;
 
+    // TODO: Replace std::vector with a custom SoA container and BoundBoxPad
+    // auxiliary class. Consider moving the registry into the R-tree.
+    std::vector<ShapeRecord> m_shape_registry;
+
+    size_t m_nshape = 0; ///< count of live (non-DEAD) shapes
+    std::unique_ptr<rtree_type> m_rtree; ///< spatial index for shapes for viewport query
+
 }; /* end class World */
+
+template <typename T>
+int32_t World<T>::add_triangle(T x0, T y0, T x1, T y1, T x2, T y2)
+{
+    size_t offset = m_segments->size();
+    m_segments->append(point_type(x0, y0, 0), point_type(x1, y1, 0));
+    m_segments->append(point_type(x1, y1, 0), point_type(x2, y2, 0));
+    m_segments->append(point_type(x2, y2, 0), point_type(x0, y0, 0));
+
+    int32_t shape_id = static_cast<int32_t>(m_shape_registry.size());
+    m_shape_registry.push_back(ShapeRecord{ShapeType::TRIANGLE, offset, 3});
+    ++m_nshape;
+    m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(m_shape_registry[shape_id])});
+    return shape_id;
+}
+
+template <typename T>
+void World<T>::translate_shape(int32_t shape_id, value_type dx, value_type dy)
+{
+    ShapeRecord const & rec = find_shape_or_throw(shape_id);
+    // Remove old entry from R-tree before modifying segments.
+    m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+    for (uint32_t i = 0; i < rec.segment_count; ++i)
+    {
+        size_t idx = rec.segment_offset + i;
+        m_segments->x0(idx) += dx;
+        m_segments->y0(idx) += dy;
+        m_segments->x1(idx) += dx;
+        m_segments->y1(idx) += dy;
+    }
+    // Reinsert with updated bounding box.
+    m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+}
+
+template <typename T>
+void World<T>::remove_shape(int32_t shape_id)
+{
+    ShapeRecord & rec = find_shape_or_throw(shape_id);
+    m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+    rec.type = ShapeType::DEAD;
+    --m_nshape;
+}
+
+template <typename T>
+std::vector<int32_t> World<T>::query_visible(T min_x, T min_y, T max_x, T max_y) const
+{
+    bbox_type viewport(min_x, min_y, max_x, max_y);
+    std::vector<ShapeEntry<T>> hits;
+    m_rtree->search(viewport, hits);
+    std::vector<int32_t> ids;
+    ids.reserve(hits.size());
+    for (auto const & entry : hits)
+    {
+        ids.push_back(entry.shape_id);
+    }
+    return ids;
+}
+
+template <typename T>
+std::shared_ptr<typename World<T>::segment_pad_type> World<T>::collect_live_segments() const
+{
+    // Mark segment indices owned by DEAD shapes.
+    small_vector<bool> dead(m_segments->size(), false);
+    for (auto const & rec : m_shape_registry)
+    {
+        if (rec.type != ShapeType::DEAD)
+        {
+            continue;
+        }
+        for (uint32_t i = 0; i < rec.segment_count; ++i)
+        {
+            dead[rec.segment_offset + i] = true;
+        }
+    }
+    auto result = segment_pad_type::construct(/* ndim */ 3);
+    for (size_t i = 0; i < m_segments->size(); ++i)
+    {
+        if (!dead[i])
+        {
+            // includes both bare segments and segments of live shapes
+            result->append(m_segments->get(i));
+        }
+    }
+    return result;
+}
+
+template <typename T>
+void World<T>::clear()
+{
+    m_points = point_pad_type::construct(/* ndim */ 3);
+    m_segments = segment_pad_type::construct(/* ndim */ 3);
+    m_curves = curve_pad_type::construct(/* ndim */ 3);
+    // TODO: SimpleCollector should have a `clear()` method.
+    m_bare_segment_indices = SimpleCollector<size_t>();
+    m_shape_registry.clear();
+    m_nshape = 0;
+    m_rtree = std::make_unique<rtree_type>();
+}
+
+template <typename T>
+typename World<T>::bbox_type World<T>::compute_shape_bbox(ShapeRecord const & rec) const
+{
+    T mn_x = std::numeric_limits<T>::max();
+    T mn_y = std::numeric_limits<T>::max();
+    T mx_x = std::numeric_limits<T>::lowest();
+    T mx_y = std::numeric_limits<T>::lowest();
+    for (uint32_t i = 0; i < rec.segment_count; ++i)
+    {
+        size_t idx = rec.segment_offset + i;
+        mn_x = std::min({mn_x, m_segments->x0(idx), m_segments->x1(idx)});
+        mn_y = std::min({mn_y, m_segments->y0(idx), m_segments->y1(idx)});
+        mx_x = std::max({mx_x, m_segments->x0(idx), m_segments->x1(idx)});
+        mx_y = std::max({mx_y, m_segments->y0(idx), m_segments->y1(idx)});
+    }
+    return bbox_type(mn_x, mn_y, mx_x, mx_y);
+}
+
+template <typename T>
+void World<T>::check_shape_id(int32_t shape_id) const
+{
+    if (shape_id < 0 ||
+        static_cast<size_t>(shape_id) >= m_shape_registry.size())
+    {
+        throw std::out_of_range(
+            std::format("World: shape_id {} not found", shape_id));
+    }
+    if (m_shape_registry[shape_id].type == ShapeType::DEAD)
+    {
+        throw std::invalid_argument(
+            std::format("World: shape_id {} is DEAD", shape_id));
+    }
+}
 
 using WorldFp32 = World<float>;
 using WorldFp64 = World<double>;

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -62,6 +62,7 @@ protected:
     WrapWorld & wrap_point();
     WrapWorld & wrap_segment();
     WrapWorld & wrap_bezier();
+    WrapWorld & wrap_triangle();
 };
 /* end class WrapWorld */
 
@@ -76,6 +77,7 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
         .wrap_point()
         .wrap_segment()
         .wrap_bezier()
+        .wrap_triangle()
         //
         ;
 }
@@ -90,6 +92,41 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
             py::init(
                 []()
                 { return wrapped_type::construct(); }))
+        //
+        ;
+
+    (*this)
+        .def_property_readonly("nshape", &wrapped_type::nshape)
+        .def(
+            "remove_shape",
+            &wrapped_type::remove_shape,
+            py::arg("shape_id"))
+        .def(
+            "shape_type_of",
+            [](wrapped_type const & self, int32_t shape_id)
+            {
+                ShapeType st = self.shape_type_of(shape_id);
+                switch (st)
+                {
+                case ShapeType::TRIANGLE: return std::string("triangle");
+                default: return std::string("unknown");
+                }
+            },
+            py::arg("shape_id"))
+        .def("clear", &wrapped_type::clear)
+        .def(
+            "translate_shape",
+            &wrapped_type::translate_shape,
+            py::arg("shape_id"),
+            py::arg("dx"),
+            py::arg("dy"))
+        .def(
+            "query_visible",
+            &wrapped_type::query_visible,
+            py::arg("min_x"),
+            py::arg("min_y"),
+            py::arg("max_x"),
+            py::arg("max_y"))
         //
         ;
 
@@ -217,6 +254,30 @@ WrapWorld<T> & WrapWorld<T>::wrap_bezier()
                 return self.bezier_at(i);
             })
         .def_property_readonly("curves", &wrapped_type::curves)
+        //
+        ;
+
+    return *this;
+}
+
+template <typename T>
+WrapWorld<T> & WrapWorld<T>::wrap_triangle()
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            "add_triangle",
+            [](wrapped_type & self, value_type x0, value_type y0, value_type x1, value_type y1, value_type x2, value_type y2)
+            {
+                return self.add_triangle(x0, y0, x1, y1, x2, y2);
+            },
+            py::arg("x0"),
+            py::arg("y0"),
+            py::arg("x1"),
+            py::arg("y1"),
+            py::arg("x2"),
+            py::arg("y2"))
         //
         ;
 

--- a/cpp/modmesh/universe/rtree.hpp
+++ b/cpp/modmesh/universe/rtree.hpp
@@ -411,7 +411,9 @@ private:
             return node;
         }
 
-        node_type * best_child = nullptr;
+        // Initialize to first child to avoid undefined behavior when all
+        // enlargements equal std::numeric_limits<value_type>::max().
+        node_type * best_child = &node->nodes.front();
         value_type min_enlargement = std::numeric_limits<value_type>::max();
 
         for (auto & child : node->nodes)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -272,4 +272,119 @@ class WorldFp64TC(WorldTB, unittest.TestCase):
     def test_type(self):
         self.assertIs(modmesh.WorldFp64, self.World)
 
+
+class WorldShapeTC(unittest.TestCase):
+    """Shape registry: add, translate, remove, clear."""
+
+    def setUp(self):
+        self.w = modmesh.WorldFp64()
+
+    def test_add_triangle(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.assertEqual(self.w.nshape, 1)
+        self.assertEqual(self.w.nsegment, 3)
+        self.assertEqual(self.w.shape_type_of(sid), "triangle")
+
+    def test_add_multiple(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.add_triangle(2, 2, 3, 2, 2, 3)
+        self.assertEqual(self.w.nshape, 2)
+        self.assertEqual(self.w.nsegment, 6)
+
+    def test_ids_are_unique(self):
+        s0 = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        s1 = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.assertNotEqual(s0, s1)
+
+    def test_translate(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.translate_shape(sid, 10, 20)
+        seg = self.w.segment(0)
+        self.assertAlmostEqual(seg.x0, 10.0)
+        self.assertAlmostEqual(seg.y0, 20.0)
+        self.assertAlmostEqual(seg.x1, 11.0)
+        self.assertAlmostEqual(seg.y1, 20.0)
+
+    def test_translate_isolates_shapes(self):
+        s0 = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.add_triangle(0, 0, 2, 0, 0, 2)
+        self.w.translate_shape(s0, 10, 10)
+        self.assertAlmostEqual(self.w.segment(0).x0, 10.0)
+        self.assertAlmostEqual(self.w.segment(3).x0, 0.0)
+
+    def test_remove(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.remove_shape(sid)
+        self.assertEqual(self.w.nshape, 0)
+
+    def test_remove_nonexistent_raises(self):
+        with self.assertRaises(IndexError):
+            self.w.remove_shape(999)
+
+    def test_remove_dead_raises(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.remove_shape(sid)
+        with self.assertRaises(ValueError):
+            self.w.remove_shape(sid)
+
+    def test_translate_dead_raises(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.remove_shape(sid)
+        with self.assertRaises(ValueError):
+            self.w.translate_shape(sid, 1, 1)
+
+    def test_shape_type_of_dead_raises(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.remove_shape(sid)
+        with self.assertRaises(ValueError):
+            self.w.shape_type_of(sid)
+
+    def test_clear(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.add_triangle(2, 2, 3, 2, 2, 3)
+        self.w.add_segment(
+            s=modmesh.Segment3dFp64(
+                modmesh.Point3dFp64(0, 0),
+                modmesh.Point3dFp64(1, 1),
+            )
+        )
+        self.w.clear()
+        self.assertEqual(self.w.nshape, 0)
+        self.assertEqual(self.w.nsegment, 0)
+
+
+class WorldViewportTC(unittest.TestCase):
+    """R-tree spatial index and viewport query."""
+
+    def setUp(self):
+        self.w = modmesh.WorldFp64()
+
+    def test_all_visible(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.add_triangle(2, 2, 3, 2, 2, 3)
+        ids = self.w.query_visible(-1, -1, 10, 10)
+        self.assertEqual(len(ids), 2)
+
+    def test_partial_visible(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.add_triangle(100, 100, 101, 100, 100, 101)
+        ids = self.w.query_visible(-1, -1, 2, 2)
+        self.assertEqual(len(ids), 1)
+
+    def test_none_visible(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.assertEqual(len(self.w.query_visible(50, 50, 60, 60)), 0)
+
+    def test_visible_after_translate(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.translate_shape(sid, 200, 200)
+        self.assertEqual(len(self.w.query_visible(-1, -1, 2, 2)), 0)
+        self.assertEqual(
+            len(self.w.query_visible(199, 199, 202, 202)), 1)
+
+    def test_visible_after_remove(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.remove_shape(sid)
+        self.assertEqual(len(self.w.query_visible(-1, -1, 10, 10)), 0)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## Changes

**World.hpp**: Add `ShapeType` enum, `ShapeRecord` struct, and `ShapeEntry` R-tree entry type. World gains a shape registry (`std::vector<ShapeRecord>`) and R-tree (`RTree<ShapeEntry<T>, BoundBox2d<T>>`) as new members. New methods:
- `add_triangle()` — appends 3 segments to `SegmentPad`, records offset/count, inserts bounding box into R-tree
- `translate_shape()` — modifies segments in-place, updates R-tree
- `remove_shape()` — marks `ShapeRecord` as DEAD, removes from R-tree
- `query_visible()` — R-tree viewport query returning shape IDs
- `collect_live_segments()` — returns a new `SegmentPad` excluding segments owned by DEAD shapes
- `clear()` — resets all pads, registry, and R-tree

**wrap_World.cpp**: Add `wrap_triangle()` exposing `add_triangle`. Added `translate_shape`, `remove_shape`, `nshape`, `shape_type_of`, `query_visible`, and `clear` to `wrap_management`.

**RWorld.cpp**: `RLines` constructor uses `collect_live_segments()` instead of `segments()->clone()` so removed shapes are not rendered.

**test_universe.py**: 16 tests covering shape CRUD, DEAD shape error handling, and R-tree viewport queries.

## Example

```
import modmesh as mm
from _modmesh import pilot

world = mm.WorldFp64()

# Add some triangles
t0 = world.add_triangle(0, 0, 10, 0, 5, 8)
t1 = world.add_triangle(15, 0, 25, 0, 20, 8)
t2 = world.add_triangle(0, 15, 10, 15, 5, 23)

# Translate one
world.translate_shape(t1, 0, 15)

# Remove one
world.remove_shape(t2)

# Render
widget = pilot.mgr.add3DWidget()
widget.updateWorld(world)
widget.showMark()
```

## Screenshot
<img width="1061" height="812" alt="Screenshot 2026-04-11 at 4 44 49 AM" src="https://github.com/user-attachments/assets/e21a7261-558e-4293-a3e7-b9ba700bf549" />
