### PR TITLE
Add pre-commit and replace redundant CI lint steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,17 +8,11 @@ on:
 
 jobs:
 
-  clang_format_check:
+  pre_commit:
 
     runs-on: ubuntu-latest
 
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
-
-    strategy:
-      matrix:
-        path:
-          - 'cpp'
-          - 'gtests'
 
     steps:
 
@@ -28,29 +22,15 @@ jobs:
         run: |
           echo "github.event_name: ${{ github.event_name }}"
 
-      - name: Add 8G swap (Ubuntu)
-        # Prevent hitting runner's resource limits
-        if: runner.os == 'Linux'
-        run: |
-          # Remove /swapfile first to avoid "fallocate: Text file busy" error
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          free -h
-
-      - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.16.0
+      - uses: actions/setup-python@v5
         with:
-          clang-format-version: '20'
-          check-path: ${{ matrix.path }}
-          fallback-style: 'LLVM' # optional
+          python-version: '3.x'
 
-  tidy_flake8:
+      - uses: pre-commit/action@v3.0.1
 
-    name: Run clang-tidy and flake8 on ${{ matrix.os }}
+  clang_tidy:
+
+    name: Run clang-tidy on ${{ matrix.os }}
 
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
@@ -103,15 +83,6 @@ jobs:
         restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         create-symlink: true
 
-    - name: make cinclude (check_include)
-      run: make cinclude
-
-    - name: make checkascii (check ASCII-only characters)
-      run: make checkascii
-
-    - name: make checktws (check trailing whitespace)
-      run: make checktws
-
     - name: make pilot USE_PYTEST_HELPER_BINDING=OFF
       run: |
         make pilot \
@@ -135,22 +106,15 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-    - name: make flake8
-      run: |
-        make flake8 \
-          ${JOB_MAKE_ARGS} \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
-
   send_email_on_failure:
-    needs: [clang_format_check, tidy_flake8]
+    needs: [pre_commit, clang_tidy]
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |
-        - clang_format_check: ${{ needs.clang_format_check.result }}
-        - tidy_flake8: ${{ needs.tidy_flake8.result }}
+        - pre_commit: ${{ needs.pre_commit.result }}
+        - clang_tidy: ${{ needs.clang_tidy.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, An-Chi Liu <phy.tiger@gmail.com>
+# BSD-style license; see COPYING
+#
+# See https://pre-commit.com for more information
+# Run `pre-commit install` to set up the git hooks.
+# Run `pre-commit run --all-files` to check the entire project.
+# Run `pre-commit autoupdate` to update hook versions.
+repos:
+  # C++ formatting
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.0
+    hooks:
+      - id: clang-format
+        files: ^(cpp|gtests)/.*\.[ch]pp$
+
+  # Python linting
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        exclude: ^(thirdparty|tmp|_deps)/
+
+  # Project-specific checks
+  - repo: local
+    hooks:
+      # Ensure C++ files use angle brackets for includes, not quotes
+      - id: cinclude
+        name: check-include-quotes
+        description: Ensure C++ includes use angle brackets, not quotes
+        entry: '#include\s*"'
+        language: pygrep
+        files: ^cpp/
+
+      # Ensure source files contain only ASCII characters
+      - id: checkascii
+        name: check-ascii
+        description: Ensure source files contain only ASCII characters
+        entry: python3 contrib/lint/check_ascii.py
+        language: system
+        files: \.(py|cpp|hpp|c|h|cxx|hxx|sh|yml|yaml)$|(^|/)(CMakeLists\.txt|[Mm]akefile)$
+        exclude: ^(tmp|_deps|build)/
+
+      # Ensure source files have no trailing whitespace
+      - id: checktws
+        name: check-trailing-whitespace
+        description: Ensure source files have no trailing whitespace
+        entry: python3 contrib/lint/check_ascii.py --check-tws
+        language: system
+        files: \.(py|cpp|hpp|c|h|cxx|hxx|sh|yml|yaml)$|(^|/)(CMakeLists\.txt|[Mm]akefile)$
+        exclude: ^(tmp|_deps|build)/

--- a/contrib/prompt/CLAUDE.md
+++ b/contrib/prompt/CLAUDE.md
@@ -65,6 +65,20 @@ make flake8       # Python style check
 make checkascii   # ASCII character check
 ```
 
+### Pre-commit
+```bash
+# Run all pre-commit hooks on staged files
+pre-commit run
+
+# Run all pre-commit hooks on the entire project
+pre-commit run --all-files
+```
+
+**IMPORTANT**: Always run `pre-commit run --all-files` before committing and
+pushing changes. This ensures clang-format, flake8, include-quote checks,
+ASCII-only characters, and trailing whitespace checks all pass locally before
+CI runs.
+
 ### Cleanup
 ```bash
 # Clean build artifacts


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with hooks matching CI lint checks:
  - **clang-format** (v20.1.0) — C++ formatting for `cpp/` and `gtests/`
  - **flake8** (7.3.0) — Python linting (excludes `thirdparty/tmp/_deps`)
  - **cinclude** — Ensure C++ includes use angle brackets, not quotes
  - **checkascii** — Ensure source files contain only ASCII characters
  - **checktws** — Ensure no trailing whitespace in source files
- Replace redundant CI lint steps with a single `pre_commit` job using [`pre-commit/action`](https://github.com/pre-commit/action)
- Remove the `clang_format_check` job and individual `make cinclude`, `make checkascii`, `make checktws`, `make flake8` steps from CI
- Rename `tidy_flake8` job to `clang_tidy` (now only runs clang-tidy + pilot builds)

## Test plan
- [x] `pre-commit run --all-files` passes all 5 hooks locally
- [x] CI `pre_commit` job passes
- [x] CI `clang_tidy` job passes (unchanged functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)