### PR TITLE
Implement array to scalar division to `SimpleArray`

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -567,6 +567,11 @@ public:
         return A(*static_cast<A const *>(this)).idiv(other);
     }
 
+    A div(value_type scalar) const
+    {
+        return A(*static_cast<A const *>(this)).idiv(scalar);
+    }
+
     A & iadd(A const & other)
     {
         auto athis = static_cast<A *>(this);
@@ -734,6 +739,28 @@ public:
                 *ptr /= *other_ptr;
                 ++ptr;
                 ++other_ptr;
+            }
+        }
+        else
+        {
+            throw std::runtime_error(
+                "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
+        }
+        return *athis;
+    }
+
+    A & idiv(value_type scalar)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            const value_type * const end = athis->end();
+            value_type * ptr = athis->begin();
+
+            while (ptr < end)
+            {
+                *ptr /= scalar;
+                ++ptr;
             }
         }
         else

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -349,7 +349,14 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "mul",
                 [](wrapped_type const & self, value_type scalar)
                 { return self.mul(scalar); })
-            .def("div", &wrapped_type::div)
+            .def(
+                "div",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.div(other); })
+            .def(
+                "div",
+                [](wrapped_type const & self, value_type scalar)
+                { return self.div(scalar); })
             .def("matmul", &wrapped_type::matmul)
             .def("__matmul__", &wrapped_type::matmul)
             // TODO: In-place operation should return reference to self to support function chaining
@@ -387,6 +394,10 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 { self.imul(scalar); })
             .def("idiv", [](wrapped_type & self, wrapped_type const & other)
                  { self.idiv(other); })
+            .def(
+                "idiv",
+                [](wrapped_type & self, value_type scalar)
+                { self.idiv(scalar); })
             .def("imatmul", [](wrapped_type & self, wrapped_type const & other)
                  { self.imatmul(other); })
             .def("__imatmul__", [](wrapped_type & self, wrapped_type const & other)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3052,6 +3052,175 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         ):
             sarr2.idiv(sarr1)
 
+    def test_div_1d(self):
+        def _check_div_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([2, 3, 4, 5, 6, 7, 8, 9], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, narr2).astype(type)
+            sres = sarr1.div(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.idiv(sarr2)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_div_1d_type('int32')
+        _check_div_1d_type('int64')
+        _check_div_1d_type('float32')
+        _check_div_1d_type('float64')
+
+    def test_div_2d(self):
+        def _check_div_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[2, 2, 2, 2],
+                              [3, 3, 3, 3],
+                              [4, 4, 4, 4]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, narr2).astype(type)
+            sres = sarr1.div(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.idiv(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_div_2d_type('int32')
+        _check_div_2d_type('int64')
+        _check_div_2d_type('float32')
+        _check_div_2d_type('float64')
+
+    def test_div_3d(self):
+        def _check_div_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            narr2 = np.arange(1, 25, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, narr2).astype(type)
+            sres = sarr1.div(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.idiv(sarr2)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_div_3d_type('int32')
+        _check_div_3d_type('int64')
+        _check_div_3d_type('float32')
+        _check_div_3d_type('float64')
+
+    def test_div_scalar_1d(self):
+        """Test 1D array scalar divtiplication"""
+        def _check_div_scalar_1d_type(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 3
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, scalar).astype(type)
+            sres = sarr1.div(scalar)
+
+            for i in range(len(narr1)):
+                self.assertEqual(sres[i], nres[i])
+
+            sarr1.idiv(scalar)
+            for i in range(len(narr1)):
+                self.assertEqual(sarr1[i], nres[i])
+
+        _check_div_scalar_1d_type('int32')
+        _check_div_scalar_1d_type('int64')
+        _check_div_scalar_1d_type('float32')
+        _check_div_scalar_1d_type('float64')
+
+    def test_div_scalar_2d(self):
+        """Test 2D array (matrix) scalar divtiplication"""
+        def _check_div_scalar_2d_type(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 2
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, scalar).astype(type)
+            sres = sarr1.div(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sres[i, j], nres[i, j])
+
+            sarr1.idiv(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    self.assertEqual(sarr1[i, j], nres[i, j])
+
+        _check_div_scalar_2d_type('int32')
+        _check_div_scalar_2d_type('int64')
+        _check_div_scalar_2d_type('float32')
+        _check_div_scalar_2d_type('float64')
+
+    def test_div_scalar_3d(self):
+        """Test 3D array scalar divtiplication"""
+        def _check_div_scalar_3d_type(type):
+            narr1 = np.arange(24, dtype=type).reshape((2, 3, 4))
+            sarr1 = self.type_convertor(type)(array=narr1)
+            scalar = 5
+
+            # cast the result array back to the tested data type
+            # Numpy promotes any numerical types to floating point number when
+            # performing division
+            # ref: https://numpy.org/doc/stable/reference/arrays.promotion.html
+            nres = np.divide(narr1, scalar).astype(type)
+            sres = sarr1.div(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sres[i, j, k], nres[i, j, k])
+
+            sarr1.idiv(scalar)
+            for i in range(narr1.shape[0]):
+                for j in range(narr1.shape[1]):
+                    for k in range(narr1.shape[2]):
+                        self.assertEqual(sarr1[i, j, k], nres[i, j, k])
+
+        _check_div_scalar_3d_type('int32')
+        _check_div_scalar_3d_type('int64')
+        _check_div_scalar_3d_type('float32')
+        _check_div_scalar_3d_type('float64')
+
     def test_eye(self):
         """Test eye() static method for creating identity matrices"""
         eye2 = modmesh.SimpleArrayFloat64.eye(10)


### PR DESCRIPTION
This PR implements the division operation between matrices and scalar number for `SimpleArray`, mentioned in issue #588 
 
The following formula is an example of such operation
```math
\underbrace{\begin{bmatrix}
1 & 2 \\
3 & 4 \\ 
\end{bmatrix}}_\text{Matrix} \div \underbrace{2}_\text{scalar} = 
\begin{bmatrix}
0.5 & 1 \\
1.5 & 2 \\ 
\end{bmatrix}
```