### PR TITLE
Add clear() method to SimpleCollector

### DIFF
--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -128,6 +128,8 @@ public:
         m_end = m_begin + length;
     }
 
+    void clear() { m_end = m_begin; }
+
     /**
      * Push up the size by amount.
      * @param amount

--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -106,6 +106,7 @@ public:
 
     void reserve(size_t cap) { expander().reserve(cap * ITEMSIZE); }
     void expand(size_t length) { expander().expand(length * ITEMSIZE); }
+    void clear() { expander().clear(); }
 
     value_type const & at(size_t it) const
     {

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -584,8 +584,13 @@ WrapSimpleCollector<T>::WrapSimpleCollector(pybind11::module & mod, char const *
             py::arg("length"),
             py::arg("alignment") = 0)
         .def_timed(py::init<>())
+        //
+        ;
+
+    (*this)
         .def_timed("reserve", &wrapped_type::reserve, py::arg("cap"))
         .def_timed("expand", &wrapped_type::expand, py::arg("length"))
+        .def_timed("clear", &wrapped_type::clear)
         .def_property_readonly("capacity", &wrapped_type::capacity)
         .def_property_readonly("alignment", &wrapped_type::alignment)
         .def("__len__", &wrapped_type::size)

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -348,8 +348,7 @@ void World<T>::clear()
     m_points = point_pad_type::construct(/* ndim */ 3);
     m_segments = segment_pad_type::construct(/* ndim */ 3);
     m_curves = curve_pad_type::construct(/* ndim */ 3);
-    // TODO: SimpleCollector should have a `clear()` method.
-    m_bare_segment_indices = SimpleCollector<size_t>();
+    m_bare_segment_indices.clear();
     m_shape_registry.clear();
     m_nshape = 0;
     m_rtree = std::make_unique<rtree_type>();

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3942,6 +3942,84 @@ class SimpleCollectorTC(unittest.TestCase):
         for it in range(16):
             self.assertEqual(it * 3.14, arr[it])
 
+    def test_clear(self):
+        # Clear an empty collector.
+        ct = modmesh.SimpleCollectorFloat64()
+        self.assertEqual(0, ct.capacity)
+        self.assertEqual(0, len(ct))
+        ct.clear()
+        self.assertEqual(0, ct.capacity)
+        self.assertEqual(0, len(ct))
+
+        # Clear a collector with data from push_back.
+        ct = modmesh.SimpleCollectorFloat64()
+        for it in range(5):
+            ct.push_back(it * 1.1)
+        self.assertEqual(5, len(ct))
+        old_capacity = ct.capacity
+        self.assertGreater(old_capacity, 0)
+
+        ct.clear()
+        self.assertEqual(0, len(ct))
+        self.assertEqual(old_capacity, ct.capacity)  # capacity preserved
+
+        # After clear, accessing index 0 should raise.
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 0 is out of bounds with size 0"
+        ):
+            ct[0]
+
+        # Can push_back again after clear.
+        ct.push_back(42.0)
+        self.assertEqual(1, len(ct))
+        self.assertEqual(42.0, ct[0])
+        self.assertEqual(old_capacity, ct.capacity)  # capacity still preserved
+
+        # Clear a collector created with initial size.
+        ct = modmesh.SimpleCollectorFloat64(10)
+        self.assertEqual(10, len(ct))
+        self.assertEqual(10, ct.capacity)
+        ct.clear()
+        self.assertEqual(0, len(ct))
+        self.assertEqual(10, ct.capacity)
+
+    def test_clear_with_alignment(self):
+        ct = modmesh.SimpleCollectorFloat64(16, 16)
+        self.assertEqual(16, ct.alignment)
+        self.assertEqual(16, len(ct))
+
+        ct.clear()
+        self.assertEqual(0, len(ct))
+        self.assertEqual(16, ct.capacity)
+        self.assertEqual(16, ct.alignment)  # alignment preserved
+
+    def test_clear_after_as_array(self):
+        ct = modmesh.SimpleCollectorFloat64()
+        for it in range(5):
+            ct.push_back(it * 1.1)
+        self.assertEqual(5, len(ct))
+
+        arr = ct.as_array()
+        self.assertEqual(5, len(arr))
+        for it in range(5):
+            self.assertEqual(it * 1.1, arr[it])
+
+        # Clearing the collector resets its size but keeps its capacity,
+        # and the SimpleArray returned earlier retains its data.
+        old_capacity = ct.capacity
+        ct.clear()
+        self.assertEqual(0, len(ct))
+        self.assertEqual(old_capacity, ct.capacity)
+        self.assertEqual(5, len(arr))
+        for it in range(5):
+            self.assertEqual(it * 1.1, arr[it])
+
+        # Collector can be reused after clear.
+        ct.push_back(42.0)
+        self.assertEqual(1, len(ct))
+        self.assertEqual(42.0, ct[0])
+
     def test_alignment_preserved_in_as_concrete(self):
         ep = modmesh.BufferExpander(128, 16)
         self.assertEqual(16, ep.alignment)


### PR DESCRIPTION
## Summary
- Add `clear()` method to `BufferExpander` and `SimpleCollector` that resets size to 0 while preserving allocated memory and capacity (similar to `std::vector::clear()`)
- Expose `clear()` in Python bindings for all `SimpleCollector` types
- Update `World::clear()` to use the new method instead of the workaround `m_bare_segment_indices = SimpleCollector<size_t>()`
- Separate pybind11 constructor and method bindings into two `(*this)` sections per style guide

For issue #725.

## Test plan
- [x] `test_clear` — verifies clearing empty, populated, and initially-sized collectors; checks capacity preservation, out-of-bounds after clear, and push_back reuse
- [x] `test_clear_with_alignment` — verifies alignment is preserved after clear
- [x] All existing `SimpleCollectorTC` tests pass (12/12)
- [x] `make lint` clean (clang-format + flake8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)