### PR TITLE
Increase swap of ubuntu runner to avoid CI failure

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -9,14 +9,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Add 8G swap
+    - name: Add 12G swap
       # Prevent hitting runner's resource limits when running clang-tidy
       shell: bash
       run: |
         # Remove /swapfile first to avoid "fallocate: Text file busy" error
         sudo swapoff -a
         sudo rm -f /swapfile
-        sudo fallocate -l 8G /swapfile
+        sudo fallocate -l 12G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile
         sudo swapon /swapfile


### PR DESCRIPTION
The CI action [failed](https://github.com/solvcon/modmesh/actions/runs/24280038147/job/70906378483) after merging PR #716. The failure due to job time-out is assumed to be caused by lack of memory in ubuntu runner.

This PR, therefore, add 4GB swap to the ubuntu runner (from 8GB to 12GB) and the effectiveness has been [verified in my forked repo](https://github.com/KHLee529/modmesh/actions/runs/24307280526) where this job always failed.
