### PR TITLE
Add one-liner rule and AI PR guidelines

### DIFF
--- a/STYLE.rst
+++ b/STYLE.rst
@@ -581,7 +581,24 @@ C++ Function Body Placement
 Move non-accessor function bodies to be outside the class declaration when the
 code is not 2-3 times longer than an accessor. Keep short accessors inline in
 the class declaration as described in the encapsulation section. Other function
-bodies should be defined outside:
+bodies should be defined outside.
+
+If a function body is very simple (e.g., a single return or assignment
+statement), write it as a one-liner to keep the code compact:
+
+.. code-block:: cpp
+
+  // GOOD: very simple function as a one-liner.
+  double internal_value() const { return m_internal_value; }
+  void set_flag(bool v) { m_flag = v; }
+
+  // BAD: unnecessary multi-line form for a trivial body.
+  double internal_value() const
+  {
+      return m_internal_value;
+  }
+
+Other function bodies should be defined outside:
 
 .. code-block:: cpp
 

--- a/contrib/prompt/CLAUDE.md
+++ b/contrib/prompt/CLAUDE.md
@@ -201,6 +201,8 @@ styles are summarized here.
 - Move non-accessor function bodies to be outside the class declaration when
   the code is not 2-3 times longer than an accessor.
 - Keep short accessors inline in the class declaration.
+- If a function body is very simple (e.g., a single return or assignment),
+  write it as a one-liner (e.g., `double value() const { return m_value; }`).
 
 ### C++ pybind11 Binding Style
 - Separate constructors and other bindings (methods, properties, etc.) into two
@@ -229,6 +231,13 @@ Python:
 ```python
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:
 ```
+
+## Pull Request Guidelines
+
+When opening a pull request, reference the related issue (e.g., "Related to
+#725") instead of using closing keywords like "close #725", "closes #725",
+or "fixes #725". We do not let PR and commit log comments to mandate the
+management.
 
 ## Development Workflow
 


### PR DESCRIPTION
Extend STYLE.rst's function-body-placement section with a one-liner rule for trivial bodies and mirror it in contrib/prompt/CLAUDE.md. Add a new "Pull Request Guidelines" section in CLAUDE.md telling AI-authored PRs to reference the related issue instead of using closing keywords, so the maintainer controls when an issue actually closes.