### PR TITLE
Unify BoundBox2d and BoundBox3d into a single BoundBox3d

### DIFF
--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -63,14 +63,14 @@ template <typename T>
 struct ShapeEntry
 {
     int32_t shape_id;
-    BoundBox2d<T> bbox;
+    BoundBox3d<T> bbox;
     bool operator==(ShapeEntry const & other) const { return shape_id == other.shape_id; }
 }; /* end of struct ShapeEntry */
 
 template <typename T>
-struct RTreeValueOps<ShapeEntry<T>, BoundBox2d<T>>
+struct RTreeValueOps<ShapeEntry<T>, BoundBox3d<T>>
 {
-    static BoundBox2d<T> calc_bound_box(ShapeEntry<T> const & entry) { return entry.bbox; }
+    static BoundBox3d<T> calc_bound_box(ShapeEntry<T> const & entry) { return entry.bbox; }
 }; /* end of struct RTreeValueOps */
 
 /**
@@ -99,7 +99,7 @@ public:
     using point_pad_type = PointPad<T>;
     using segment_pad_type = SegmentPad<T>;
     using curve_pad_type = CurvePad<T>;
-    using bbox_type = BoundBox2d<T>;
+    using bbox_type = BoundBox3d<T>;
     using rtree_type = RTree<ShapeEntry<T>, bbox_type>;
 
     template <typename... Args>
@@ -302,7 +302,7 @@ void World<T>::remove_shape(int32_t shape_id)
 template <typename T>
 std::vector<int32_t> World<T>::query_visible(T min_x, T min_y, T max_x, T max_y) const
 {
-    bbox_type viewport(min_x, min_y, max_x, max_y);
+    bbox_type viewport(min_x, min_y, T(0), max_x, max_y, T(0));
     std::vector<ShapeEntry<T>> hits;
     m_rtree->search(viewport, hits);
     std::vector<int32_t> ids;
@@ -369,7 +369,7 @@ typename World<T>::bbox_type World<T>::compute_shape_bbox(ShapeRecord const & re
         mx_x = std::max({mx_x, m_segments->x0(idx), m_segments->x1(idx)});
         mx_y = std::max({mx_y, m_segments->y0(idx), m_segments->y1(idx)});
     }
-    return bbox_type(mn_x, mn_y, mx_x, mx_y);
+    return bbox_type(mn_x, mn_y, T(0), mx_x, mx_y, T(0));
 }
 
 template <typename T>

--- a/cpp/modmesh/universe/rtree.hpp
+++ b/cpp/modmesh/universe/rtree.hpp
@@ -42,74 +42,8 @@
 namespace modmesh
 {
 
-/// Bounding box for 2D objects
-/// @tparam T floating-point type
-template <typename T>
-class BoundBox2d : public NumberBase<int32_t, T>
-{
-
-public:
-    using value_type = T;
-
-private:
-    value_type m_min_x;
-    value_type m_min_y;
-    value_type m_max_x;
-    value_type m_max_y;
-
-public:
-
-    /// construct a bounding box with given min and max coordinates
-    BoundBox2d(value_type min_x_in, value_type min_y_in, value_type max_x_in, value_type max_y_in)
-        : m_min_x(min_x_in)
-        , m_min_y(min_y_in)
-        , m_max_x(max_x_in)
-        , m_max_y(max_y_in)
-    {
-    }
-
-    /// construct a bounding box that encloses two bounding boxes
-    BoundBox2d(const BoundBox2d & a, const BoundBox2d & b)
-        : m_min_x(std::min(a.m_min_x, b.m_min_x))
-        , m_min_y(std::min(a.m_min_y, b.m_min_y))
-        , m_max_x(std::max(a.m_max_x, b.m_max_x))
-        , m_max_y(std::max(a.m_max_y, b.m_max_y))
-    {
-    }
-
-    value_type min_x() const { return m_min_x; }
-    value_type min_y() const { return m_min_y; }
-    value_type max_x() const { return m_max_x; }
-    value_type max_y() const { return m_max_y; }
-
-    /// check if this bounding box overlap another bounding box
-    bool overlap(BoundBox2d const & other) const
-    {
-        return !(other.m_min_x > m_max_x || other.m_max_x < m_min_x || other.m_min_y > m_max_y || other.m_max_y < m_min_y);
-    }
-
-    /// check if this bounding box contain another bounding box
-    bool contain(BoundBox2d const & other) const
-    {
-        return (other.m_min_x >= m_min_x && other.m_max_x <= m_max_x && other.m_min_y >= m_min_y && other.m_max_y <= m_max_y);
-    }
-
-    value_type calc_area() const
-    {
-        return (m_max_x - m_min_x) * (m_max_y - m_min_y);
-    }
-
-    /// expand the bounding box to include another bounding box
-    void expand(BoundBox2d const & other)
-    {
-        m_min_x = std::min(m_min_x, other.m_min_x);
-        m_min_y = std::min(m_min_y, other.m_min_y);
-        m_max_x = std::max(m_max_x, other.m_max_x);
-        m_max_y = std::max(m_max_y, other.m_max_y);
-    }
-}; /* end of struct BoundBox2d */
-
-/// Bounding box for 3D objects, e.g., Point3d, Segment3d, Triangle3d, etc.
+/// Bounding box for 2D and 3D objects, e.g., Point3d, Segment3d, Triangle3d, etc.
+/// For 2D usage, callers pass min_z = max_z = 0 explicitly.
 /// @tparam T floating-point type
 template <typename T>
 class BoundBox3d : public NumberBase<int32_t, T>
@@ -170,9 +104,15 @@ public:
                 other.m_min_z >= m_min_z && other.m_max_z <= m_max_z);
     }
 
+    /// 2D area (dx*dy) when z-extent = 0, else 3D volume (dx*dy*dz).
+    /// Do not mix 2D and 3D boxes in one RTree: the split heuristic
+    /// needs a monotonic measure within a single tree.
     value_type calc_area() const
     {
-        return (m_max_x - m_min_x) * (m_max_y - m_min_y) * (m_max_z - m_min_z);
+        const value_type dx = m_max_x - m_min_x;
+        const value_type dy = m_max_y - m_min_y;
+        const value_type dz = m_max_z - m_min_z;
+        return dz == value_type(0) ? dx * dy : dx * dy * dz;
     }
 
     void expand(BoundBox3d const & other)

--- a/gtests/test_nopython_rtree.cpp
+++ b/gtests/test_nopython_rtree.cpp
@@ -46,16 +46,16 @@ struct Point2D
     }
 };
 
-using TestBoundBox2d = modmesh::BoundBox2d<double>;
+using TestBoundBox3d = modmesh::BoundBox3d<double>;
 
 struct Point2DValueOps
 {
-    static TestBoundBox2d calc_bound_box(Point2D const & item)
+    static TestBoundBox3d calc_bound_box(Point2D const & item)
     {
-        return TestBoundBox2d(item.x, item.y, item.x, item.y);
+        return TestBoundBox3d(item.x, item.y, 0.0, item.x, item.y, 0.0);
     }
 
-    static TestBoundBox2d calc_group_bound_box(std::vector<Point2D> const & items)
+    static TestBoundBox3d calc_group_bound_box(std::vector<Point2D> const & items)
     {
         double min_x = std::numeric_limits<double>::max();
         double min_y = std::numeric_limits<double>::max();
@@ -69,7 +69,7 @@ struct Point2DValueOps
             max_x = std::max(max_x, item.x);
             max_y = std::max(max_y, item.y);
         }
-        return TestBoundBox2d(min_x, min_y, max_x, max_y);
+        return TestBoundBox3d(min_x, min_y, 0.0, max_x, max_y, 0.0);
     }
 };
 
@@ -85,7 +85,6 @@ struct Point3D
     }
 };
 
-using TestBoundBox3d = modmesh::BoundBox3d<double>;
 struct Point3DValueOps
 {
     static TestBoundBox3d calc_bound_box(Point3D const & item)
@@ -119,14 +118,14 @@ TEST(RTree, basic_operations)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{1.0, 1.0});
     rtree.insert(Point2D{2.0, 2.0});
     rtree.insert(Point2D{3.0, 3.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(1.5, 1.5, 2.5, 2.5), results);
+    rtree.search(TestBoundBox3d(1.5, 1.5, 0.0, 2.5, 2.5, 0.0), results);
     EXPECT_EQ(results.size(), 1);
     EXPECT_EQ(results[0].x, 2.0);
     EXPECT_EQ(results[0].y, 2.0);
@@ -158,7 +157,7 @@ TEST(RTree, complex_operations)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps, 4> rtree; // Small max items per node to force splits
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps, 4> rtree; // Small max items per node to force splits
 
     // Insert multiple points
     for (int i = 0; i < 100; ++i)
@@ -168,13 +167,13 @@ TEST(RTree, complex_operations)
 
     // Search for a range
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(20.0, 20.0, 30.0, 30.0), results);
+    rtree.search(TestBoundBox3d(20.0, 20.0, 0.0, 30.0, 30.0, 0.0), results);
     EXPECT_EQ(results.size(), 11); // Points from (20,20) to (30,30)
 
     // Remove a point and verify it's gone
     rtree.remove(Point2D{25.0, 25.0});
     results.clear();
-    rtree.search(TestBoundBox2d(20.0, 20.0, 30.0, 30.0), results);
+    rtree.search(TestBoundBox3d(20.0, 20.0, 0.0, 30.0, 30.0, 0.0), results);
     EXPECT_EQ(results.size(), 10); // One less after removal
 }
 
@@ -182,10 +181,10 @@ TEST(RTree, empty_tree_operations)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 0);
 
     rtree.remove(Point2D{1.0, 1.0});
@@ -196,19 +195,19 @@ TEST(RTree, single_point_operations)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{5.0, 5.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 1);
     EXPECT_EQ(results[0].x, 5.0);
     EXPECT_EQ(results[0].y, 5.0);
 
     rtree.remove(Point2D{5.0, 5.0});
     results.clear();
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 0);
 }
 
@@ -216,18 +215,18 @@ TEST(RTree, overlapping_search_regions)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{5.0, 5.0});
     rtree.insert(Point2D{15.0, 15.0});
     rtree.insert(Point2D{25.0, 25.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 20.0, 20.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 20.0, 20.0, 0.0), results);
     EXPECT_EQ(results.size(), 2);
 
     results.clear();
-    rtree.search(TestBoundBox2d(10.0, 10.0, 30.0, 30.0), results);
+    rtree.search(TestBoundBox3d(10.0, 10.0, 0.0, 30.0, 30.0, 0.0), results);
     EXPECT_EQ(results.size(), 2);
 }
 
@@ -235,17 +234,17 @@ TEST(RTree, boundary_conditions)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{10.0, 10.0});
     rtree.insert(Point2D{20.0, 20.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(10.0, 10.0, 20.0, 20.0), results);
+    rtree.search(TestBoundBox3d(10.0, 10.0, 0.0, 20.0, 20.0, 0.0), results);
     EXPECT_EQ(results.size(), 2);
 
     results.clear();
-    rtree.search(TestBoundBox2d(10.1, 10.1, 19.9, 19.9), results);
+    rtree.search(TestBoundBox3d(10.1, 10.1, 0.0, 19.9, 19.9, 0.0), results);
     EXPECT_EQ(results.size(), 0);
 }
 
@@ -253,7 +252,7 @@ TEST(RTree, large_scale_insertion_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps, 8> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps, 8> rtree;
 
     for (int i = 0; i < 1000; ++i)
     {
@@ -261,7 +260,7 @@ TEST(RTree, large_scale_insertion_2d)
     }
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_GT(results.size(), 0);
 }
 
@@ -269,7 +268,7 @@ TEST(RTree, random_insertion_and_search_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps, 16> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps, 16> rtree;
     std::mt19937 gen(42);
     std::uniform_real_distribution<> dis(0.0, 100.0);
 
@@ -282,7 +281,7 @@ TEST(RTree, random_insertion_and_search_2d)
     }
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(40.0, 40.0, 60.0, 60.0), results);
+    rtree.search(TestBoundBox3d(40.0, 40.0, 0.0, 60.0, 60.0, 0.0), results);
 
     int expected_count = 0;
     for (const auto & pt : inserted_points)
@@ -299,7 +298,7 @@ TEST(RTree, multiple_removals_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps, 4> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps, 4> rtree;
 
     for (int i = 0; i < 50; ++i)
     {
@@ -312,7 +311,7 @@ TEST(RTree, multiple_removals_2d)
     }
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 50.0, 50.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 50.0, 50.0, 0.0), results);
     EXPECT_EQ(results.size(), 25);
 }
 
@@ -320,7 +319,7 @@ TEST(RTree, scattered_points_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{0.0, 0.0});
     rtree.insert(Point2D{100.0, 100.0});
@@ -328,11 +327,11 @@ TEST(RTree, scattered_points_2d)
     rtree.insert(Point2D{50.0, -50.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(-60.0, -60.0, 110.0, 110.0), results);
+    rtree.search(TestBoundBox3d(-60.0, -60.0, 0.0, 110.0, 110.0, 0.0), results);
     EXPECT_EQ(results.size(), 4);
 
     results.clear();
-    rtree.search(TestBoundBox2d(-10.0, -10.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(-10.0, -10.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 1);
 }
 
@@ -340,19 +339,19 @@ TEST(RTree, duplicate_points_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     rtree.insert(Point2D{5.0, 5.0});
     rtree.insert(Point2D{5.0, 5.0});
     rtree.insert(Point2D{5.0, 5.0});
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 3);
 
     rtree.remove(Point2D{5.0, 5.0});
     results.clear();
-    rtree.search(TestBoundBox2d(0.0, 0.0, 10.0, 10.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 10.0, 10.0, 0.0), results);
     EXPECT_EQ(results.size(), 2);
 }
 
@@ -454,7 +453,7 @@ TEST(RTree, stress_test_insert_remove_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps, 8> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps, 8> rtree;
     std::mt19937 gen(999);
     std::uniform_real_distribution<> dis(0.0, 1000.0);
 
@@ -472,7 +471,7 @@ TEST(RTree, stress_test_insert_remove_2d)
     }
 
     std::vector<Point2D> results;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 1000.0, 1000.0), results);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 1000.0, 1000.0, 0.0), results);
     EXPECT_EQ(results.size(), points.size() / 2);
 }
 
@@ -480,7 +479,7 @@ TEST(RTree, non_overlapping_searches_2d)
 {
     using namespace modmesh;
 
-    RTree<Point2D, TestBoundBox2d, Point2DValueOps> rtree;
+    RTree<Point2D, TestBoundBox3d, Point2DValueOps> rtree;
 
     for (int i = 0; i < 10; ++i)
     {
@@ -488,10 +487,10 @@ TEST(RTree, non_overlapping_searches_2d)
     }
 
     std::vector<Point2D> results1;
-    rtree.search(TestBoundBox2d(0.0, 0.0, 25.0, 25.0), results1);
+    rtree.search(TestBoundBox3d(0.0, 0.0, 0.0, 25.0, 25.0, 0.0), results1);
 
     std::vector<Point2D> results2;
-    rtree.search(TestBoundBox2d(50.0, 50.0, 100.0, 100.0), results2);
+    rtree.search(TestBoundBox3d(50.0, 50.0, 0.0, 100.0, 100.0, 0.0), results2);
 
     EXPECT_GT(results1.size(), 0);
     EXPECT_GT(results2.size(), 0);


### PR DESCRIPTION
## Summary

`BoundBox2d` is redundant because a `BoundBox3d` with zero z-extent already represents a 2D box. This PR deletes it. Code that needed a 2D box now builds a `BoundBox3d` with `z = 0`.

One behavior change is that `calc_area()` now returns `dx*dy` for planar boxes and `dx*dy*dz` for volumetric boxes. The R-tree split heuristic requires this value to increase as boxes grow. That assumption still holds because each `RTree` in the codebase stores only one box type: `World` uses planar boxes, and `PolygonPad` uses volumetric boxes.

- Remove `BoundBox2d`; use `BoundBox3d` for both 2D (`z = 0`) and 3D.
- `calc_area()` → rectangle area for planar boxes, volume for volumetric boxes.
- Update `World.hpp` (`ShapeEntry`, `RTreeValueOps`, `bbox_type`, `compute_shape_bbox`, `query_visible`) and the RTree gtests to the unified API.

Related to #721.

## Test plan

- [x] `make gtest` — all 126 tests pass, including the 18 RTree cases.
- [x] `make buildext` — Python extension builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)