### PR TITLE
Add axis support to SimpleArray argmin and argmax

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1369,42 +1369,21 @@ class SimpleArrayMixinSearch
 private:
 
     using internal_types = detail::SimpleArrayInternalTypes<T>;
+    using shape_type = typename internal_types::shape_type;
+    using sshape_type = typename internal_types::sshape_type;
+
+    ssize_t normalize_axis(ssize_t axis, char const * op) const;
+    shape_type reduced_shape(ssize_t axis) const;
 
 public:
 
     using value_type = typename internal_types::value_type;
 
-    size_t argmin() const
-    {
-        size_t min_index = 0;
-        value_type min_value = std::numeric_limits<value_type>::max();
-        auto athis = static_cast<A const *>(this);
-        for (size_t i = 0; i < athis->size(); ++i)
-        {
-            if (athis->data(i) < min_value)
-            {
-                min_value = athis->data(i);
-                min_index = i;
-            }
-        }
-        return min_index;
-    }
+    size_t argmin() const;
+    size_t argmax() const;
 
-    size_t argmax() const
-    {
-        size_t max_index = 0;
-        value_type max_value = std::numeric_limits<value_type>::lowest();
-        auto athis = static_cast<A const *>(this);
-        for (size_t i = 0; i < athis->size(); ++i)
-        {
-            if (athis->data(i) > max_value)
-            {
-                max_value = athis->data(i);
-                max_index = i;
-            }
-        }
-        return max_index;
-    }
+    SimpleArray<uint64_t> argmin(ssize_t axis) const;
+    SimpleArray<uint64_t> argmax(ssize_t axis) const;
 
     SimpleArray<uint64_t> argwhere() const;
 
@@ -3002,6 +2981,204 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     return ret;
 }
 
+template <typename A, typename T>
+ssize_t detail::SimpleArrayMixinSearch<A, T>::normalize_axis(ssize_t axis, char const * op) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    ssize_t const ndim = athis->ndim();
+
+    if (axis < 0)
+    {
+        axis += ndim;
+    }
+    if (axis < 0 || axis >= ndim)
+    {
+        throw std::invalid_argument(std::format(
+            "SimpleArray::{}(): axis {} is out of bounds for array of dimension {}",
+            op,
+            axis,
+            ndim));
+    }
+    if (athis->shape(axis) == 0)
+    {
+        throw std::invalid_argument(std::format(
+            "SimpleArray::{}(): axis {} has size 0, cannot compute",
+            op,
+            axis));
+    }
+
+    return axis;
+}
+
+template <typename A, typename T>
+typename detail::SimpleArrayMixinSearch<A, T>::shape_type
+detail::SimpleArrayMixinSearch<A, T>::reduced_shape(ssize_t axis) const
+{
+    auto const * athis = static_cast<A const *>(this);
+
+    shape_type result_shape;
+    for (ssize_t dim = 0; dim < athis->ndim(); ++dim)
+    {
+        if (dim != axis)
+        {
+            result_shape.push_back(athis->shape(dim));
+        }
+    }
+
+    return result_shape;
+}
+
+template <typename A, typename T>
+size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
+{
+    auto athis = static_cast<A const *>(this);
+
+    if (athis->size() == 0)
+    {
+        throw std::invalid_argument("SimpleArray::argmin(): "
+                                    "attempt to get argmin of an empty sequence");
+    }
+
+    auto const range = IndexRange(*athis);
+    sshape_type idx = range.first();
+
+    value_type min_value = athis->at(idx);
+    size_t min_index = 0;
+    size_t flat_index = 0;
+
+    do
+    {
+        value_type const current_value = athis->at(idx);
+        if (current_value < min_value)
+        {
+            min_value = current_value;
+            min_index = flat_index;
+        }
+        ++flat_index;
+    } while (range.next(idx));
+
+    return min_index;
+}
+
+template <typename A, typename T>
+size_t detail::SimpleArrayMixinSearch<A, T>::argmax() const
+{
+    auto athis = static_cast<A const *>(this);
+
+    if (athis->size() == 0)
+    {
+        throw std::invalid_argument("SimpleArray::argmax(): "
+                                    "attempt to get argmax of an empty sequence");
+    }
+
+    auto const range = IndexRange(*athis);
+    sshape_type idx = range.first();
+
+    value_type max_value = athis->at(idx);
+    size_t max_index = 0;
+    size_t flat_index = 0;
+
+    do
+    {
+        value_type const current_value = athis->at(idx);
+        if (current_value > max_value)
+        {
+            max_value = current_value;
+            max_index = flat_index;
+        }
+        ++flat_index;
+    } while (range.next(idx));
+
+    return max_index;
+}
+
+template <typename A, typename T>
+SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis) const
+{
+    auto athis = static_cast<A const *>(this);
+
+    axis = normalize_axis(axis, "argmin");
+    SimpleArray<uint64_t> result(reduced_shape(axis));
+
+    auto const out_range = IndexRange(result);
+    sshape_type out_idx = out_range.first();
+
+    do
+    {
+        sshape_type in_idx(athis->ndim(), 0);
+
+        for (ssize_t dim = 0, out_dim = 0; dim < athis->ndim(); ++dim)
+        {
+            if (dim == axis)
+            {
+                continue;
+            }
+            in_idx[dim] = out_idx[out_dim++];
+        }
+
+        in_idx[axis] = 0;
+        value_type min_value = athis->at(in_idx);
+        uint64_t min_index = 0;
+
+        for (ssize_t i = 1; i < athis->shape(axis); ++i)
+        {
+            in_idx[axis] = i;
+            value_type const current_value = athis->at(in_idx);
+            if (current_value < min_value)
+            {
+                min_value = current_value;
+                min_index = static_cast<uint64_t>(i);
+            }
+        }
+        result.at(out_idx) = min_index;
+    } while (out_range.next(out_idx));
+
+    return result;
+}
+
+template <typename A, typename T>
+SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis) const
+{
+    auto athis = static_cast<A const *>(this);
+
+    axis = normalize_axis(axis, "argmax");
+    SimpleArray<uint64_t> result(reduced_shape(axis));
+
+    auto const out_range = IndexRange(result);
+    sshape_type out_idx = out_range.first();
+
+    do
+    {
+        sshape_type in_idx(athis->ndim(), 0);
+
+        for (ssize_t dim = 0, out_dim = 0; dim < athis->ndim(); ++dim)
+        {
+            if (dim == axis)
+            {
+                continue;
+            }
+            in_idx[dim] = out_idx[out_dim++];
+        }
+
+        in_idx[axis] = 0;
+        value_type max_value = athis->at(in_idx);
+        uint64_t max_index = 0;
+
+        for (ssize_t i = 1; i < athis->shape(axis); ++i)
+        {
+            in_idx[axis] = i;
+            value_type const current_value = athis->at(in_idx);
+            if (current_value > max_value)
+            {
+                max_value = current_value;
+                max_index = static_cast<uint64_t>(i);
+            }
+        }
+        result.at(out_idx) = max_index;
+    } while (out_range.next(out_idx));
+
+    return result;
+}
 template <typename A, typename T>
 SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
 {

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -3050,7 +3050,7 @@ template <typename A, typename T>
 ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_buffer_index(
     A const & array, shape_type const & idx)
 {
-    ssize_t const origin = static_cast<ssize_t>(
+    auto const origin = static_cast<ssize_t>(
         array.logical_data() - array.data());
     return origin + unchecked_logical_offset(array, idx);
 }

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -3034,8 +3034,7 @@ detail::SimpleArrayMixinSearch<A, T>::reduced_shape(ssize_t axis) const
 }
 
 template <typename A, typename T>
-ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_logical_offset(
-    A const & array, shape_type const & idx)
+ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_logical_offset(A const & array, shape_type const & idx)
 {
     ssize_t offset = 0;
     for (ssize_t dim = 0; dim < array.ndim(); ++dim)
@@ -3047,11 +3046,9 @@ ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_logical_offset(
 }
 
 template <typename A, typename T>
-ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_buffer_index(
-    A const & array, shape_type const & idx)
+ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_buffer_index(A const & array, shape_type const & idx)
 {
-    auto const origin = static_cast<ssize_t>(
-        array.logical_data() - array.data());
+    auto const origin = static_cast<ssize_t>(array.logical_data() - array.data());
     return origin + unchecked_logical_offset(array, idx);
 }
 
@@ -3103,8 +3100,7 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
 
     do
     {
-        value_type const current_value = *(
-            ptr + unchecked_logical_offset(*athis, idx));
+        value_type const current_value = *(ptr + unchecked_logical_offset(*athis, idx));
 
         if constexpr (std::is_floating_point_v<value_type>)
         {
@@ -3172,8 +3168,7 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmax() const
 
     do
     {
-        value_type const current_value = *(
-            ptr + unchecked_logical_offset(*athis, idx));
+        value_type const current_value = *(ptr + unchecked_logical_offset(*athis, idx));
 
         if constexpr (std::is_floating_point_v<value_type>)
         {

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <array>
 #include <concepts>
+#include <cmath>
 #include <format>
 #include <functional>
 #include <limits>
@@ -34,6 +35,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #ifdef _MSC_VER
@@ -1370,10 +1372,11 @@ private:
 
     using internal_types = detail::SimpleArrayInternalTypes<T>;
     using shape_type = typename internal_types::shape_type;
-    using sshape_type = typename internal_types::sshape_type;
 
     ssize_t normalize_axis(ssize_t axis, char const * op) const;
     shape_type reduced_shape(ssize_t axis) const;
+    static ssize_t unchecked_logical_offset(A const & array,
+                                            shape_type const & idx);
 
 public:
 
@@ -3029,6 +3032,19 @@ detail::SimpleArrayMixinSearch<A, T>::reduced_shape(ssize_t axis) const
 }
 
 template <typename A, typename T>
+ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_logical_offset(
+    A const & array, shape_type const & idx)
+{
+    ssize_t offset = 0;
+    for (ssize_t dim = 0; dim < array.ndim(); ++dim)
+    {
+        ssize_t const lower = IndexRange::index_from_offset(array, dim, 0);
+        offset += (idx[dim] - lower) * array.stride(dim);
+    }
+    return offset;
+}
+
+template <typename A, typename T>
 size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
 {
     auto athis = static_cast<A const *>(this);
@@ -3039,16 +3055,53 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
                                     "attempt to get argmin of an empty sequence");
     }
 
-    auto const range = IndexRange(*athis);
-    sshape_type idx = range.first();
+    if (athis->is_c_contiguous())
+    {
+        value_type const * ptr = athis->logical_data();
+        value_type min_value = ptr[0];
+        size_t min_index = 0;
+        size_t const size = athis->size();
 
-    value_type min_value = athis->at(idx);
+        for (size_t i = 1; i < size; ++i)
+        {
+            value_type const current_value = ptr[i];
+
+            if constexpr (std::is_floating_point_v<value_type>)
+            {
+                if (std::isnan(current_value))
+                {
+                    return i;
+                }
+            }
+            if (current_value < min_value)
+            {
+                min_value = current_value;
+                min_index = i;
+            }
+        }
+        return min_index;
+    }
+
+    auto const range = IndexRange(*athis);
+    shape_type idx = range.first();
+
+    value_type const * ptr = athis->logical_data();
+    value_type min_value = *(ptr + unchecked_logical_offset(*athis, idx));
     size_t min_index = 0;
     size_t flat_index = 0;
 
     do
     {
-        value_type const current_value = athis->at(idx);
+        value_type const current_value = *(
+            ptr + unchecked_logical_offset(*athis, idx));
+
+        if constexpr (std::is_floating_point_v<value_type>)
+        {
+            if (std::isnan(current_value))
+            {
+                return flat_index;
+            }
+        }
         if (current_value < min_value)
         {
             min_value = current_value;
@@ -3071,16 +3124,53 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmax() const
                                     "attempt to get argmax of an empty sequence");
     }
 
-    auto const range = IndexRange(*athis);
-    sshape_type idx = range.first();
+    if (athis->is_c_contiguous())
+    {
+        value_type const * ptr = athis->logical_data();
+        value_type max_value = ptr[0];
+        size_t max_index = 0;
+        size_t const size = athis->size();
 
-    value_type max_value = athis->at(idx);
+        for (size_t i = 1; i < size; ++i)
+        {
+            value_type const current_value = ptr[i];
+
+            if constexpr (std::is_floating_point_v<value_type>)
+            {
+                if (std::isnan(current_value))
+                {
+                    return i;
+                }
+            }
+            if (current_value > max_value)
+            {
+                max_value = current_value;
+                max_index = i;
+            }
+        }
+        return max_index;
+    }
+
+    auto const range = IndexRange(*athis);
+    shape_type idx = range.first();
+
+    value_type const * ptr = athis->logical_data();
+    value_type max_value = *(ptr + unchecked_logical_offset(*athis, idx));
     size_t max_index = 0;
     size_t flat_index = 0;
 
     do
     {
-        value_type const current_value = athis->at(idx);
+        value_type const current_value = *(
+            ptr + unchecked_logical_offset(*athis, idx));
+
+        if constexpr (std::is_floating_point_v<value_type>)
+        {
+            if (std::isnan(current_value))
+            {
+                return flat_index;
+            }
+        }
         if (current_value > max_value)
         {
             max_value = current_value;
@@ -3100,12 +3190,17 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
     axis = normalize_axis(axis, "argmin");
     SimpleArray<uint64_t> result(reduced_shape(axis));
 
+    if (result.size() == 0)
+    {
+        return result;
+    }
+
     auto const out_range = IndexRange(result);
-    sshape_type out_idx = out_range.first();
+    shape_type out_idx = out_range.first();
 
     do
     {
-        sshape_type in_idx(athis->ndim(), 0);
+        shape_type in_idx(athis->ndim(), 0);
 
         for (ssize_t dim = 0, out_dim = 0; dim < athis->ndim(); ++dim)
         {
@@ -3113,17 +3208,26 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
             {
                 continue;
             }
-            in_idx[dim] = out_idx[out_dim++];
+
+            in_idx[dim] = IndexRange::index_from_offset(*athis, dim, out_idx[out_dim++]);
         }
 
-        in_idx[axis] = 0;
+        in_idx[axis] = IndexRange::index_from_offset(*athis, axis, 0);
         value_type min_value = athis->at(in_idx);
         uint64_t min_index = 0;
 
         for (ssize_t i = 1; i < athis->shape(axis); ++i)
         {
-            in_idx[axis] = i;
+            in_idx[axis] = IndexRange::index_from_offset(*athis, axis, i);
             value_type const current_value = athis->at(in_idx);
+            if constexpr (std::is_floating_point_v<value_type>)
+            {
+                if (std::isnan(current_value))
+                {
+                    min_index = static_cast<uint64_t>(i);
+                    break;
+                }
+            }
             if (current_value < min_value)
             {
                 min_value = current_value;
@@ -3144,12 +3248,17 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
     axis = normalize_axis(axis, "argmax");
     SimpleArray<uint64_t> result(reduced_shape(axis));
 
+    if (result.size() == 0)
+    {
+        return result;
+    }
+
     auto const out_range = IndexRange(result);
-    sshape_type out_idx = out_range.first();
+    shape_type out_idx = out_range.first();
 
     do
     {
-        sshape_type in_idx(athis->ndim(), 0);
+        shape_type in_idx(athis->ndim(), 0);
 
         for (ssize_t dim = 0, out_dim = 0; dim < athis->ndim(); ++dim)
         {
@@ -3157,17 +3266,26 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
             {
                 continue;
             }
-            in_idx[dim] = out_idx[out_dim++];
+
+            in_idx[dim] = IndexRange::index_from_offset(*athis, dim, out_idx[out_dim++]);
         }
 
-        in_idx[axis] = 0;
+        in_idx[axis] = IndexRange::index_from_offset(*athis, axis, 0);
         value_type max_value = athis->at(in_idx);
         uint64_t max_index = 0;
 
         for (ssize_t i = 1; i < athis->shape(axis); ++i)
         {
-            in_idx[axis] = i;
+            in_idx[axis] = IndexRange::index_from_offset(*athis, axis, i);
             value_type const current_value = athis->at(in_idx);
+            if constexpr (std::is_floating_point_v<value_type>)
+            {
+                if (std::isnan(current_value))
+                {
+                    max_index = static_cast<uint64_t>(i);
+                    break;
+                }
+            }
             if (current_value > max_value)
             {
                 max_value = current_value;

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1377,6 +1377,8 @@ private:
     shape_type reduced_shape(ssize_t axis) const;
     static ssize_t unchecked_logical_offset(A const & array,
                                             shape_type const & idx);
+    static ssize_t unchecked_buffer_index(A const & array,
+                                          shape_type const & idx);
 
 public:
 
@@ -3045,6 +3047,15 @@ ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_logical_offset(
 }
 
 template <typename A, typename T>
+ssize_t detail::SimpleArrayMixinSearch<A, T>::unchecked_buffer_index(
+    A const & array, shape_type const & idx)
+{
+    ssize_t const origin = static_cast<ssize_t>(
+        array.logical_data() - array.data());
+    return origin + unchecked_logical_offset(array, idx);
+}
+
+template <typename A, typename T>
 size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
 {
     auto athis = static_cast<A const *>(this);
@@ -3188,6 +3199,11 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
     auto athis = static_cast<A const *>(this);
 
     axis = normalize_axis(axis, "argmin");
+    if (athis->ndim() == 1)
+    {
+        throw std::invalid_argument(
+            "SimpleArray::argmin(axis): use argmin() for a 1D array");
+    }
     SimpleArray<uint64_t> result(reduced_shape(axis));
 
     if (result.size() == 0)
@@ -3197,6 +3213,8 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
 
     auto const out_range = IndexRange(result);
     shape_type out_idx = out_range.first();
+    ssize_t const axis_stride = athis->stride(axis);
+    size_t output_index = 0;
 
     do
     {
@@ -3213,13 +3231,14 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
         }
 
         in_idx[axis] = IndexRange::index_from_offset(*athis, axis, 0);
-        value_type min_value = athis->at(in_idx);
+        ssize_t const input_index = unchecked_buffer_index(*athis, in_idx);
+        value_type min_value = (*athis)[static_cast<size_t>(input_index)];
         uint64_t min_index = 0;
 
         for (ssize_t i = 1; i < athis->shape(axis); ++i)
         {
-            in_idx[axis] = IndexRange::index_from_offset(*athis, axis, i);
-            value_type const current_value = athis->at(in_idx);
+            ssize_t const current_index = input_index + i * axis_stride;
+            value_type const current_value = (*athis)[static_cast<size_t>(current_index)];
             if constexpr (std::is_floating_point_v<value_type>)
             {
                 if (std::isnan(current_value))
@@ -3234,7 +3253,7 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
                 min_index = static_cast<uint64_t>(i);
             }
         }
-        result.at(out_idx) = min_index;
+        result[output_index++] = min_index;
     } while (out_range.next(out_idx));
 
     return result;
@@ -3246,6 +3265,13 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
     auto athis = static_cast<A const *>(this);
 
     axis = normalize_axis(axis, "argmax");
+
+    if (athis->ndim() == 1)
+    {
+        throw std::invalid_argument(
+            "SimpleArray::argmax(axis): use argmax() for a 1D array");
+    }
+
     SimpleArray<uint64_t> result(reduced_shape(axis));
 
     if (result.size() == 0)
@@ -3255,6 +3281,8 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
 
     auto const out_range = IndexRange(result);
     shape_type out_idx = out_range.first();
+    ssize_t const axis_stride = athis->stride(axis);
+    size_t output_index = 0;
 
     do
     {
@@ -3271,13 +3299,14 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
         }
 
         in_idx[axis] = IndexRange::index_from_offset(*athis, axis, 0);
-        value_type max_value = athis->at(in_idx);
+        ssize_t const input_index = unchecked_buffer_index(*athis, in_idx);
+        value_type max_value = (*athis)[static_cast<size_t>(input_index)];
         uint64_t max_index = 0;
 
         for (ssize_t i = 1; i < athis->shape(axis); ++i)
         {
-            in_idx[axis] = IndexRange::index_from_offset(*athis, axis, i);
-            value_type const current_value = athis->at(in_idx);
+            ssize_t const current_index = input_index + i * axis_stride;
+            value_type const current_value = (*athis)[static_cast<size_t>(current_index)];
             if constexpr (std::is_floating_point_v<value_type>)
             {
                 if (std::isnan(current_value))
@@ -3292,7 +3321,7 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
                 max_index = static_cast<uint64_t>(i);
             }
         }
-        result.at(out_idx) = max_index;
+        result[output_index++] = max_index;
     } while (out_range.next(out_idx));
 
     return result;

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -631,8 +631,32 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
 
         (*this)
-            .def("argmin", &wrapped_type::argmin)
-            .def("argmax", &wrapped_type::argmax)
+            .def("argmin", [](wrapped_type const & self, py::object const & axis)
+                 {
+                    if (axis.is_none())
+                    {
+                        return py::cast(self.argmin());
+                    }
+                    auto const axis_value = axis.cast<ssize_t>();
+                    if (self.ndim() == 1 && (axis_value == 0 || axis_value == -1))
+                    {
+                        return py::cast(self.argmin());
+                    }
+                    return py::cast(self.argmin(axis_value)); },
+                 py::arg("axis") = py::none())
+            .def("argmax", [](wrapped_type const & self, py::object const & axis)
+                 {
+                    if (axis.is_none())
+                    {
+                        return py::cast(self.argmax());
+                    }
+                    auto const axis_value = axis.cast<ssize_t>();
+                    if (self.ndim() == 1 && (axis_value == 0 || axis_value == -1))
+                    {
+                        return py::cast(self.argmax());
+                    }
+                    return py::cast(self.argmax(axis_value)); },
+                 py::arg("axis") = py::none())
             .def("argwhere", &wrapped_type::argwhere)
             //
             ;

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -65,6 +65,18 @@ TEST(SimpleArray, minmaxsum)
     EXPECT_EQ(arr_int.max(), 9);
 }
 
+TEST(SimpleArray, argminmax_axis_rejects_rank_zero_result)
+{
+    using namespace solvcon;
+
+    SimpleArray<double> array(small_vector<ssize_t>{3}, 0.0);
+
+    EXPECT_THROW(array.argmin(0), std::invalid_argument);
+    EXPECT_THROW(array.argmin(-1), std::invalid_argument);
+    EXPECT_THROW(array.argmax(0), std::invalid_argument);
+    EXPECT_THROW(array.argmax(-1), std::invalid_argument);
+}
+
 TEST(SimpleArray, abs)
 {
     using namespace solvcon;

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4442,6 +4442,65 @@ class SimpleArraySearchTC(unittest.TestCase):
         self.assertEqual(narr.argmin(), sarr.argmin())
         self.assertEqual(narr.argmax(), sarr.argmax())
 
+        with self.subTest(name='empty_array'):
+            narr = np.array([], dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            with self.assertRaises(ValueError):
+                sarr.argmin()
+            with self.assertRaises(ValueError):
+                sarr.argmax()
+
+        with self.subTest(name='non_contiguous'):
+            data = np.zeros((4, 6), dtype='float64')
+            data[0, 0] = -1
+            data[0, 1] = 999
+            data[0, 3] = -999
+            data[2, 4] = 10
+            narr = data[::2, ::2]
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            self.assertEqual(sarr.argmin(), 0)
+            self.assertEqual(sarr.argmax(), 5)
+            self.assertEqual(narr.argmin(), sarr.argmin())
+            self.assertEqual(narr.argmax(), sarr.argmax())
+
+    def test_argminmax_axis(self):
+        with self.subTest(name='1d_contiguous'):
+            narr = np.arange(10, dtype='uint64')
+            sarr = solvcon.SimpleArrayUint64(array=narr)
+            self.assertEqual(sarr.argmin(axis=0), 0)
+            self.assertEqual(sarr.argmax(axis=0), 9)
+            self.assertEqual(sarr.argmin(axis=0), np.argmin(narr, axis=0))
+            self.assertEqual(sarr.argmax(axis=0), np.argmax(narr, axis=0))
+
+        for name, sarr_type, narr, axis in [
+            ('2d_contiguous', solvcon.SimpleArrayFloat64,
+             np.arange(12, dtype='float64').reshape(3, 4), 1),
+            ('3d_contiguous', solvcon.SimpleArrayInt32,
+             np.arange(24, dtype='int32').reshape(2, 3, 4), 2),
+            ('4d_contiguous', solvcon.SimpleArrayFloat32,
+             np.arange(120, dtype='float32').reshape(2, 3, 4, 5), 3),
+            ('negative_axis', solvcon.SimpleArrayFloat32,
+             np.arange(120, dtype='float32').reshape(2, 3, 4, 5), -1)]:
+            with self.subTest(name=name):
+                sarr = sarr_type(array=narr)
+                np.testing.assert_array_equal(sarr.argmin(axis=axis).ndarray,
+                                              np.argmin(narr, axis=axis))
+                np.testing.assert_array_equal(sarr.argmax(axis=axis).ndarray,
+                                              np.argmax(narr, axis=axis))
+
+        with self.subTest(name='non_contiguous'):
+            data = np.zeros((4, 6), dtype='float64')
+            data[0, 0] = -1
+            data[0, 1] = 999
+            data[0, 3] = -999
+            data[2, 4] = 10
+            narr = data[::-1, ::-1]
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            np.testing.assert_array_equal(sarr.argmin(axis=0).ndarray,
+                                          np.argmin(narr, axis=0))
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          np.argmax(narr, axis=1))
+
     def test_argwhere(self):
         # test 1-D data
         data = [1, 3, 5, 7, 9]

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4471,10 +4471,10 @@ class SimpleArraySearchTC(unittest.TestCase):
             self.assertEqual(narr_negative.argmax(), sarr_negative.argmax())
 
         with self.subTest(name='nan_values'):
-            narr = np.array([[1.0, 0.0, np.nan]], dtype='float64')
+            narr = np.array([[1.0, np.nan, np.nan]], dtype='float64')
             sarr = solvcon.SimpleArrayFloat64(array=narr)
-            self.assertEqual(sarr.argmin(), 2)
-            self.assertEqual(sarr.argmax(), 2)
+            self.assertEqual(sarr.argmin(), 1)
+            self.assertEqual(sarr.argmax(), 1)
             self.assertEqual(narr.argmin(), sarr.argmin())
             self.assertEqual(narr.argmax(), sarr.argmax())
 
@@ -4591,7 +4591,7 @@ class SimpleArraySearchTC(unittest.TestCase):
                                               expected_result)
 
         with self.subTest(name='nan_values'):
-            narr = np.array([[1.0, np.nan, 0.0]], dtype='float64')
+            narr = np.array([[1.0, np.nan, np.nan]], dtype='float64')
             sarr = solvcon.SimpleArrayFloat64(array=narr)
 
             expected_argmin = np.array([1], dtype='uint64')

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4463,6 +4463,28 @@ class SimpleArraySearchTC(unittest.TestCase):
             self.assertEqual(narr.argmin(), sarr.argmin())
             self.assertEqual(narr.argmax(), sarr.argmax())
 
+            narr_negative = data[::-1, ::-1]
+            sarr_negative = solvcon.SimpleArrayFloat64(array=narr_negative)
+            self.assertEqual(sarr_negative.argmin(), 20)
+            self.assertEqual(sarr_negative.argmax(), 22)
+            self.assertEqual(narr_negative.argmin(), sarr_negative.argmin())
+            self.assertEqual(narr_negative.argmax(), sarr_negative.argmax())
+
+        with self.subTest(name='nan_values'):
+            narr = np.array([[1.0, 0.0, np.nan]], dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            self.assertEqual(sarr.argmin(), 2)
+            self.assertEqual(sarr.argmax(), 2)
+            self.assertEqual(narr.argmin(), sarr.argmin())
+            self.assertEqual(narr.argmax(), sarr.argmax())
+
+            narr = narr[::-1, ::-1]
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            self.assertEqual(sarr.argmin(), 0)
+            self.assertEqual(sarr.argmax(), 0)
+            self.assertEqual(narr.argmin(), sarr.argmin())
+            self.assertEqual(narr.argmax(), sarr.argmax())
+
     def test_argminmax_axis(self):
         with self.subTest(name='1d_contiguous'):
             narr = np.arange(10, dtype='uint64')
@@ -4483,6 +4505,16 @@ class SimpleArraySearchTC(unittest.TestCase):
              np.arange(120, dtype='float32').reshape(2, 3, 4, 5), -1)]:
             with self.subTest(name=name):
                 sarr = sarr_type(array=narr)
+
+                expected_shape = np.delete(narr.shape, axis)
+                expected_argmin = np.full(expected_shape, 0, dtype='uint64')
+                expected_argmax = np.full(
+                    expected_shape, narr.shape[axis] - 1, dtype='uint64')
+
+                np.testing.assert_array_equal(sarr.argmin(axis=axis).ndarray,
+                                              expected_argmin)
+                np.testing.assert_array_equal(sarr.argmax(axis=axis).ndarray,
+                                              expected_argmax)
                 np.testing.assert_array_equal(sarr.argmin(axis=axis).ndarray,
                                               np.argmin(narr, axis=axis))
                 np.testing.assert_array_equal(sarr.argmax(axis=axis).ndarray,
@@ -4494,10 +4526,83 @@ class SimpleArraySearchTC(unittest.TestCase):
             data[0, 1] = 999
             data[0, 3] = -999
             data[2, 4] = 10
+
             narr = data[::-1, ::-1]
             sarr = solvcon.SimpleArrayFloat64(array=narr)
+
+            expected_argmin_axis0 = np.array(
+                [0, 0, 3, 0, 0, 3], dtype='uint64')
+            expected_argmax_axis0 = np.array(
+                [0, 1, 0, 0, 3, 0], dtype='uint64')
+            expected_argmin_axis1 = np.array([0, 0, 0, 2], dtype='uint64')
+            expected_argmax_axis1 = np.array([0, 1, 0, 4], dtype='uint64')
+
+            np.testing.assert_array_equal(sarr.argmin(axis=0).ndarray,
+                                          expected_argmin_axis0)
+            np.testing.assert_array_equal(sarr.argmax(axis=0).ndarray,
+                                          expected_argmax_axis0)
+            np.testing.assert_array_equal(sarr.argmin(axis=1).ndarray,
+                                          expected_argmin_axis1)
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          expected_argmax_axis1)
             np.testing.assert_array_equal(sarr.argmin(axis=0).ndarray,
                                           np.argmin(narr, axis=0))
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          np.argmax(narr, axis=1))
+
+        with self.subTest(name='ghost'):
+            narr = np.array([
+                [9.0, 1.0, 8.0],
+                [7.0, 6.0, 0.0],
+                [5.0, 4.0, 3.0],
+            ], dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+            sarr.nghost = 1
+
+            expected_argmin_axis0 = np.array([2, 0, 1], dtype='uint64')
+            expected_argmin_axis1 = np.array([1, 2, 2], dtype='uint64')
+            expected_argmax_axis0 = np.array([0, 1, 0], dtype='uint64')
+            expected_argmax_axis1 = np.array([0, 0, 0], dtype='uint64')
+
+            np.testing.assert_array_equal(sarr.argmin(axis=0).ndarray,
+                                          expected_argmin_axis0)
+            np.testing.assert_array_equal(sarr.argmin(axis=1).ndarray,
+                                          expected_argmin_axis1)
+            np.testing.assert_array_equal(sarr.argmax(axis=0).ndarray,
+                                          expected_argmax_axis0)
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          expected_argmax_axis1)
+            np.testing.assert_array_equal(sarr.argmin(axis=0).ndarray,
+                                          np.argmin(narr, axis=0))
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          np.argmax(narr, axis=1))
+
+        for name, shape, reduced_shape, axis in [
+            ('2d_zero_retained_axis', (0, 3), (0,), 1),
+            ('3d_zero_retained_axis', (2, 0, 3), (0, 3), 0),
+        ]:
+            with self.subTest(name=name):
+                sarr = solvcon.SimpleArrayFloat64(shape=shape, value=0.0)
+                expected_result = np.empty(reduced_shape, dtype='uint64')
+
+                np.testing.assert_array_equal(sarr.argmin(axis=axis).ndarray,
+                                              expected_result)
+                np.testing.assert_array_equal(sarr.argmax(axis=axis).ndarray,
+                                              expected_result)
+
+        with self.subTest(name='nan_values'):
+            narr = np.array([[1.0, np.nan, 0.0]], dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=narr)
+
+            expected_argmin = np.array([1], dtype='uint64')
+            expected_argmax = np.array([1], dtype='uint64')
+
+            np.testing.assert_array_equal(sarr.argmin(axis=1).ndarray,
+                                          expected_argmin)
+            np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
+                                          expected_argmax)
+            np.testing.assert_array_equal(sarr.argmin(axis=1).ndarray,
+                                          np.argmin(narr, axis=1))
             np.testing.assert_array_equal(sarr.argmax(axis=1).ndarray,
                                           np.argmax(narr, axis=1))
 


### PR DESCRIPTION
<!---->

This PR add axis-aware reductions back to `SimpleArray::argmin()` and `SimpleArray::argmax()` while keeping the existing no-axis flat-index behavior.

The implementation now walks logical indices with stride-aware access, so flat and axis reductions work for non-contiguous NumPy-backed arrays, including sliced and negative-stride views. Empty reductions now raise `ValueError` through the Python binding.

The Python wrapper accepts `axis=None` for the existing scalar result and integer axes for reduced `SimpleArrayUint64` results. The 1D axis case returns a scalar to match NumPy behavior.

Tests cover flat reductions, empty arrays, non-contiguous views, negative axes, and axis reductions across multiple dimensions.

Related to #519 .

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
