### PR TITLE
Correct rank-1 matmul for signed strides

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -446,7 +446,7 @@ A SimpleArrayMatmulHelper<A, T>::matmul_vec_vec()
     value_type v = 0;
     for (ssize_t i = 0; i < k; ++i)
     {
-        v += m_lhs(i) * m_rhs.data(i);
+        v += m_lhs(i) * m_rhs(i);
     }
     m_result.data(0) = v;
     return std::move(m_result);

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -385,6 +385,30 @@ class MatmulTestBase(sc.testing.TestBase):
             with self.subTest(lhs=lhs_shape, rhs=rhs_shape):
                 self.assert_matmul_planned(lhs, rhs, expected)
 
+    def test_matmul_with_strided_vectors(self):
+        """Matmul supports every pairing of contiguous and strided vectors."""
+        dtype = np.dtype(self.dtype).name
+        vectors = {
+            'contiguous': np.arange(8, dtype=dtype),
+            'negative': np.arange(8, dtype=dtype)[::-1],
+            'step_two': np.arange(16, dtype=dtype)[::2],
+        }
+        methods = ('matmul', 'matmul_fast', 'matmul_blas')
+
+        cases = itertools.product(vectors, vectors, methods)
+        for lhs_case, rhs_case, method in cases:
+            lhs_data = vectors[lhs_case]
+            rhs_data = vectors[rhs_case]
+            lhs = self.SimpleArray(array=lhs_data)
+            rhs = self.SimpleArray(array=rhs_data)
+            expected = np.matmul(lhs_data, rhs_data)
+
+            with self.subTest(
+                    lhs=lhs_case, rhs=rhs_case, method=method):
+                result = getattr(lhs, method)(rhs)
+                self.assertEqual((1,), result.shape)
+                np.testing.assert_allclose(result.ndarray[0], expected)
+
     def test_wrong_shape_error(self):
         """Test error handling for wrong shapes"""
 


### PR DESCRIPTION
Rank-1 matmul currently uses strided indexing for the lhs but raw contiguous buffer indexing for the rhs. A reversed rhs therefore returns an incorrect dot product:

```python
values = np.arange(8.0)[::-1]
array = solvcon.SimpleArrayFloat64(array=values)

np.matmul(values, values)  # 140.0
array.matmul(array)        # 56.0 before this change
```

This change reads the rhs through the existing `operator()` strided accessor, matching the lhs and the other generic matmul paths. It introduces no new accessor or execution abstraction.

Differential unit tests cover the full Cartesian product of contiguous, negative, and step-two lhs/rhs layouts for float32 and float64. The same cases run through `matmul()`, `matmul_fast()`, and `matmul_blas()`.

Related to #1172.
