### PR TITLE
Introduce planned matrix-matrix execution

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1083,6 +1083,7 @@ public:
     }
 
     A matmul(A const & other) const;
+    A matmul_planned(A const & other) const;
     A & imatmul(A const & other);
     A matmul_blas(A const & other) const;
     A & imatmul_blas(A const & other);
@@ -1201,6 +1202,17 @@ A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
     auto const * athis = static_cast<A const *>(this);
     SimpleArrayMatmulHelper<A, T> helper(*athis, other);
     return helper.matmul();
+}
+
+template <typename A, typename T>
+A SimpleArrayMixinCalculators<A, T>::matmul_planned(A const & other) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    MatmulPlan const plan = MatmulPlan::make(*athis, other);
+    A output(plan.output_shape());
+    MatmulExecutor<A> executor(plan, output, *athis, other);
+    executor.execute();
+    return output;
 }
 
 /**

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -28,6 +28,170 @@ inline constexpr bool can_matmul_blas_v = std::is_same_v<T, float> ||
                                           std::is_same_v<T, Complex<float>> ||
                                           std::is_same_v<T, Complex<double>>;
 
+/**
+ * @brief Describe matmul operands as an execution-independent contraction.
+ *
+ * MatmulPlan interprets trailing axes as vector or matrix roles and leading
+ * axes as the batch domain. It validates the contracted dimension, derives
+ * the result shape, and records the signed-stride mappings used to locate
+ * operands in the result batch domain. Broadcast batch axes are represented
+ * by zero strides, so an executor can advance operand offsets without
+ * reinterpreting ranks or broadcasting rules.
+ *
+ * For `(2,1,3,4) @ (1,5,4,6)`, the plan records batch shape `(2,5)`, M=3,
+ * N=6, K=4, output shape `(2,5,3,6)`, and zero-stride batch mappings for
+ * the broadcast axes. It does not allocate the output or evaluate the ten
+ * matrix pairs.
+ *
+ * @note This implementation only plans rank-2 matrix-matrix operands. It
+ * validates K and records M, N, K, the output shape, and signed matrix
+ * strides. It does not have vector roles or a batch domain yet.
+ */
+class MatmulPlan
+{
+public:
+    using shape_type = small_vector<ssize_t>;
+
+    shape_type const & output_shape() const noexcept { return m_output_shape; }
+    ssize_t rows() const noexcept { return m_contraction.m_rows; }
+    ssize_t columns() const noexcept { return m_contraction.m_columns; }
+    ssize_t inner_size() const noexcept { return m_contraction.m_inner_size; }
+    ssize_t lhs_row_stride() const noexcept { return m_strides.m_lhs_row_stride; }
+    ssize_t lhs_inner_stride() const noexcept { return m_strides.m_lhs_inner_stride; }
+    ssize_t rhs_inner_stride() const noexcept { return m_strides.m_rhs_inner_stride; }
+    ssize_t rhs_column_stride() const noexcept { return m_strides.m_rhs_column_stride; }
+
+    template <typename Array>
+    static MatmulPlan make(Array const & lhs, Array const & rhs);
+
+private:
+    struct Contraction
+    {
+        ssize_t m_rows;
+        ssize_t m_columns;
+        ssize_t m_inner_size;
+    }; /* end struct Contraction */
+
+    struct MatrixStrides
+    {
+        ssize_t m_lhs_row_stride;
+        ssize_t m_lhs_inner_stride;
+        ssize_t m_rhs_inner_stride;
+        ssize_t m_rhs_column_stride;
+    }; /* end struct MatrixStrides */
+
+    MatmulPlan(shape_type output_shape, Contraction contraction, MatrixStrides strides);
+
+    shape_type m_output_shape;
+    Contraction m_contraction;
+    MatrixStrides m_strides;
+}; /* end class MatmulPlan */
+
+/**
+ * @brief Execute a MatmulPlan with a layout-appropriate contraction route.
+ *
+ * MatmulExecutor maps vector and matrix roles to DOT, GEMV, or GEMM, then
+ * selects generic, tiled, direct BLAS, or pack-once BLAS execution. It owns
+ * BLAS eligibility, packing reuse, and size thresholds; these decisions do
+ * not change the plan. The constructor only binds a plan and caller-owned
+ * arrays; execute() evaluates the plan.
+ *
+ * For `(2,1,3,4) @ (1,5,4,6)`, the executor visits ten batch offsets and
+ * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
+ * written into the allocated `(2,5,3,6)` output.
+ *
+ * @note This implementation provides only the generic signed-stride
+ * matrix-matrix route. Optimized and vector routes are follow-up work.
+ */
+template <typename Array>
+class MatmulExecutor
+{
+public:
+    MatmulExecutor(MatmulPlan const & plan, Array & output, Array const & lhs, Array const & rhs);
+
+    void execute();
+
+private:
+    using value_type = typename Array::value_type;
+
+    MatmulPlan const & m_plan;
+    value_type * m_output_data;
+    value_type const * m_lhs_data;
+    value_type const * m_rhs_data;
+}; /* end class MatmulExecutor */
+
+inline MatmulPlan::MatmulPlan(shape_type output_shape, Contraction contraction, MatrixStrides strides)
+    : m_output_shape(std::move(output_shape))
+    , m_contraction(contraction)
+    , m_strides(strides)
+{
+}
+
+template <typename Array>
+MatmulPlan MatmulPlan::make(Array const & lhs, Array const & rhs)
+{
+    if (lhs.ndim() != 2 || rhs.ndim() != 2)
+    {
+        throw std::invalid_argument("planned matrix-matrix matmul requires rank-2 operands");
+    }
+    if (lhs.shape(1) != rhs.shape(0))
+    {
+        throw std::invalid_argument(
+            std::format("SimpleArray::matmul_planned(): shape mismatch: "
+                        "this=({},{}) other=({},{})",
+                        lhs.shape(0),
+                        lhs.shape(1),
+                        rhs.shape(0),
+                        rhs.shape(1)));
+    }
+
+    ssize_t const rows = lhs.shape(0);
+    ssize_t const columns = rhs.shape(1);
+    ssize_t const inner_size = lhs.shape(1);
+    return MatmulPlan{
+        shape_type{rows, columns},
+        Contraction{
+            .m_rows = rows,
+            .m_columns = columns,
+            .m_inner_size = inner_size,
+        },
+        MatrixStrides{
+            .m_lhs_row_stride = lhs.stride(0),
+            .m_lhs_inner_stride = lhs.stride(1),
+            .m_rhs_inner_stride = rhs.stride(0),
+            .m_rhs_column_stride = rhs.stride(1),
+        },
+    };
+}
+
+template <typename Array>
+MatmulExecutor<Array>::MatmulExecutor(MatmulPlan const & plan, Array & output, Array const & lhs, Array const & rhs)
+    : m_plan(plan)
+    , m_output_data(output.logical_data())
+    , m_lhs_data(lhs.logical_data())
+    , m_rhs_data(rhs.logical_data())
+{
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::execute()
+{
+    for (ssize_t row = 0; row < m_plan.rows(); ++row)
+    {
+        for (ssize_t column = 0; column < m_plan.columns(); ++column)
+        {
+            value_type total{};
+            for (ssize_t inner = 0; inner < m_plan.inner_size(); ++inner)
+            {
+                ssize_t const lhs_offset = row * m_plan.lhs_row_stride() + inner * m_plan.lhs_inner_stride();
+                ssize_t const rhs_offset = inner * m_plan.rhs_inner_stride() + column * m_plan.rhs_column_stride();
+                total += m_lhs_data[lhs_offset] * m_rhs_data[rhs_offset];
+            }
+            m_output_data[row * m_plan.columns() + column] = total;
+        }
+    }
+}
+
 template <typename A, typename T>
 class SimpleArrayMatmulHelper
 {

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -414,6 +414,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
 
         (*this)
             .def("matmul", &wrapped_type::matmul)
+            .def("matmul_planned", &wrapped_type::matmul_planned)
             .def("matmul_blas", &wrapped_type::matmul_blas)
             .def(
                 "matmul_fast",

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -39,6 +39,11 @@ def profile_matmul_blas_sa(lhs, rhs):
     return lhs.matmul_blas(rhs)
 
 
+@profile_function
+def profile_matmul_planned_sa(lhs, rhs):
+    return lhs.matmul_planned(rhs)
+
+
 def profile_matmul_fast_sa(lhs, rhs, tile_x, tile_y, tile_z):
     name = f"profile_matmul_fast_sa_{tile_x}_{tile_y}_{tile_z}"
     _ = solvcon.CallProfilerProbe(name)
@@ -47,6 +52,24 @@ def profile_matmul_fast_sa(lhs, rhs, tile_x, tile_y, tile_z):
 
 def make_data(dtype, shape):
     return np.random.rand(*shape).astype(dtype)
+
+
+def make_layout_cases(lhs, rhs):
+    return (
+        ("c_contiguous", lhs, rhs),
+        ("non_contiguous",
+         np.flip(lhs, axis=1),
+         np.flip(rhs, axis=0)),
+    )
+
+
+def element_strides(data):
+    return tuple(stride // data.itemsize for stride in data.strides)
+
+
+def print_profile_row(*columns):
+    print(str.format(
+        "| {:20s} | {:15s} | {:15s} |", *(columns[0:3])))
 
 
 def profile_matmul_operation(dtype, shapes, it=10):
@@ -58,42 +81,46 @@ def profile_matmul_operation(dtype, shapes, it=10):
     for m in shapes:
         lhs = make_data(dtype, (m, m))
         rhs = make_data(dtype, (m, m))
-        lhs_sa = make_container(lhs)
-        rhs_sa = make_container(rhs)
-        solvcon.call_profiler.reset()
-        for _ in range(it):
-            profile_matmul_np(lhs, rhs)
-            profile_matmul_naive_sa(lhs_sa, rhs_sa)
-            profile_matmul_blas_sa(lhs_sa, rhs_sa)
-            for tile_x, tile_y, tile_z in tile_configs:
-                profile_matmul_fast_sa(lhs_sa, rhs_sa, tile_x, tile_y, tile_z)
+        for layout, case_lhs, case_rhs in make_layout_cases(lhs, rhs):
+            lhs_sa = make_container(case_lhs)
+            rhs_sa = make_container(case_rhs)
+            solvcon.call_profiler.reset()
+            for _ in range(it):
+                profile_matmul_np(case_lhs, case_rhs)
+                profile_matmul_naive_sa(lhs_sa, rhs_sa)
+                profile_matmul_blas_sa(lhs_sa, rhs_sa)
+                profile_matmul_planned_sa(lhs_sa, rhs_sa)
+                for tile_x, tile_y, tile_z in tile_configs:
+                    profile_matmul_fast_sa(
+                        lhs_sa, rhs_sa, tile_x, tile_y, tile_z)
 
-        res = solvcon.call_profiler.result()["children"]
-        out = {}
-        for r in res:
-            name = r["name"].replace("profile_matmul_", "")
-            out[name] = r["total_time"] / r["count"]
+            res = solvcon.call_profiler.result()["children"]
+            out = {}
+            for r in res:
+                name = r["name"].replace("profile_matmul_", "")
+                out[name] = r["total_time"] / r["count"]
 
-        print(
-            f"## 2D x 2D shape: ({m}, {m}) x ({m}, {m}) dtype:"
-            f"`{np.dtype(dtype)}`\n"
-        )
+            print(f"## 2D x 2D layout: `{layout}` "
+                  f"dtype: `{np.dtype(dtype)}`\n")
+            print(f"- lhs shape: `{case_lhs.shape}`, element strides: "
+                  f"`{element_strides(case_lhs)}`")
+            print(f"- rhs shape: `{case_rhs.shape}`, element strides: "
+                  f"`{element_strides(case_rhs)}`\n")
 
-        def print_row(*cols):
-            print(str.format("| {:20s} | {:15s} | {:15s} |", *(cols[0:3])))
-
-        print_row("func", "per call (ms)", "cmp to np")
-        print_row("-" * 20, "-" * 15, "-" * 15)
-        npbase = out["np"]
-        keys = ["np", "naive_sa", "blas_sa"]
-        keys += [
-            f"fast_sa_{tile_x}_{tile_y}_{tile_z}"
-            for tile_x, tile_y, tile_z in tile_configs
-        ]
-        for key in keys:
-            value = out[key]
-            print_row(f"{key:8s}", f"{value:.3E}", f"{value / npbase:.3f}")
-        print()
+            print_profile_row("func", "per call (ms)", "cmp to np")
+            print_profile_row("-" * 20, "-" * 15, "-" * 15)
+            npbase = out["np"]
+            keys = ["np", "naive_sa", "blas_sa", "planned_sa"]
+            keys += [
+                f"fast_sa_{tile_x}_{tile_y}_{tile_z}"
+                for tile_x, tile_y, tile_z in tile_configs
+            ]
+            for key in keys:
+                value = out[key]
+                print_profile_row(
+                    f"{key:8s}", f"{value:.3E}",
+                    f"{value / npbase:.3f}")
+            print()
 
 
 def main():

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -59,6 +59,35 @@ class MatrixFloat64TC(MatrixTestBase, unittest.TestCase):
 
 class MatmulTestBase(sc.testing.TestBase):
     """Tests for matrix-matrix multiplication"""
+
+    @staticmethod
+    def make_matrix_layouts(data, stride_axis):
+        f_contiguous = np.array(
+            data, dtype=data.dtype.name, order='F', copy=True)
+
+        reversed_storage = np.array(
+            np.flip(data, axis=stride_axis),
+            dtype=data.dtype.name,
+            order='C',
+            copy=True,
+        )
+        negative_stride = np.flip(reversed_storage, axis=stride_axis)
+
+        step_two_shape = list(data.shape)
+        step_two_shape[stride_axis] *= 2
+        step_two_storage = np.empty(step_two_shape, dtype=data.dtype.name)
+        step_two_slices = [slice(None)] * data.ndim
+        step_two_slices[stride_axis] = slice(None, None, 2)
+        step_two = step_two_storage[tuple(step_two_slices)]
+        step_two[...] = data
+
+        return (
+            ('c_contiguous', data),
+            ('f_contiguous', f_contiguous),
+            ('negative_stride', negative_stride),
+            ('step_two', step_two),
+        )
+
     def assert_matmul(self, lhs, rhs, expected):
         result = lhs.matmul(rhs)
 
@@ -83,6 +112,13 @@ class MatmulTestBase(sc.testing.TestBase):
         np.testing.assert_array_almost_equal(blas_result.ndarray,
                                              matmul_result.ndarray)
 
+    def assert_matmul_planned(self, lhs, rhs, expected):
+        result = lhs.matmul_planned(rhs)
+
+        self.assertEqual(list(result.shape), list(expected.shape))
+        np.testing.assert_array_almost_equal(result.ndarray, expected)
+        return result
+
     def test_square(self):
         """Test basic square matrix multiplication"""
         # Create 2x2 matrices
@@ -99,6 +135,7 @@ class MatmulTestBase(sc.testing.TestBase):
         result = self.assert_matmul(a, b, expected)
         self.assert_matmul_fast(a, b, expected, result)
         self.assert_matmul_blas(a, b, expected, result)
+        self.assert_matmul_planned(a, b, expected)
 
     def test_rectangular(self):
         """Test rectangular matrix multiplication"""
@@ -118,6 +155,7 @@ class MatmulTestBase(sc.testing.TestBase):
         result = self.assert_matmul(a, b, expected)
         self.assert_matmul_fast(a, b, expected, result)
         self.assert_matmul_blas(a, b, expected, result)
+        self.assert_matmul_planned(a, b, expected)
 
     def test_identity(self):
         """Test multiplication with identity matrix"""
@@ -131,6 +169,7 @@ class MatmulTestBase(sc.testing.TestBase):
         result = self.assert_matmul(a, identity, a_data)
         self.assert_matmul_fast(a, identity, a_data, result)
         self.assert_matmul_blas(a, identity, a_data, result)
+        self.assert_matmul_planned(a, identity, a_data)
 
     def test_zero(self):
         """Test multiplication with zero matrix"""
@@ -143,6 +182,7 @@ class MatmulTestBase(sc.testing.TestBase):
         result = self.assert_matmul(a, zero, zero_data)
         self.assert_matmul_fast(a, zero, zero_data, result)
         self.assert_matmul_blas(a, zero, zero_data, result)
+        self.assert_matmul_planned(a, zero, zero_data)
 
     def test_dimension_mismatch_error(self):
         """Test error handling for incompatible dimensions"""
@@ -175,6 +215,12 @@ class MatmulTestBase(sc.testing.TestBase):
             r"\(3,3\)"
         ):
             a.matmul_blas(b)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"SimpleArray::matmul_planned\(\): shape mismatch: "
+            r"this=\(2,2\) other=\(3,3\)"
+        ):
+            a.matmul_planned(b)
 
     def test_non_positive_fast_tile_error(self):
         cases = itertools.product(
@@ -305,6 +351,39 @@ class MatmulTestBase(sc.testing.TestBase):
                 result = self.assert_matmul(a, b, expected)
                 self.assert_matmul_fast(a, b, expected, result)
                 self.assert_matmul_blas(a, b, expected, result)
+
+    def test_matrix_layout_combinations(self):
+        """Matrix multiplication supports signed-stride operand layouts."""
+        dtype = np.dtype(self.dtype).name
+
+        lhs_layouts = self.make_matrix_layouts(
+            np.arange(12, dtype=dtype).reshape(3, 4), 1)
+        rhs_layouts = self.make_matrix_layouts(
+            np.arange(8, dtype=dtype).reshape(4, 2), 0)
+        layouts = itertools.product(lhs_layouts, rhs_layouts)
+        for (lhs_case, lhs_data), (rhs_case, rhs_data) in layouts:
+            lhs = self.SimpleArray(array=lhs_data)
+            rhs = self.SimpleArray(array=rhs_data)
+            expected = np.matmul(lhs_data, rhs_data)
+
+            with self.subTest(lhs=lhs_case, rhs=rhs_case):
+                self.assert_matmul_planned(lhs, rhs, expected)
+
+    def test_empty_matrix_dimensions(self):
+        """Matrix multiplication preserves empty output and inner axes."""
+        dtype = np.dtype(self.dtype).name
+        shapes = (((0, 4), (4, 2)),
+                  ((3, 0), (0, 2)),
+                  ((3, 4), (4, 0)))
+        for lhs_shape, rhs_shape in shapes:
+            lhs_data = np.zeros(lhs_shape, dtype=dtype)
+            rhs_data = np.zeros(rhs_shape, dtype=dtype)
+            expected = np.matmul(lhs_data, rhs_data)
+            lhs = self.SimpleArray(shape=lhs_shape, value=0)
+            rhs = self.SimpleArray(shape=rhs_shape, value=0)
+
+            with self.subTest(lhs=lhs_shape, rhs=rhs_shape):
+                self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_wrong_shape_error(self):
         """Test error handling for wrong shapes"""


### PR DESCRIPTION
`SimpleArray::matmul()` mixes shape semantics and traversal inside the legacy implementation, which makes batch planning difficult to add in reviewable steps. This change adds the temporary `SimpleArray::matmul_planned()` entry point for rank-2 matrix-matrix operands.

`MatmulPlan` validates the contracted dimension and records the output shape and signed matrix strides. `MatmulExecutor` immediately consumes that plan through generic contraction. Both remain private implementation types in `buffer/matmul.hpp`; this pull request does not introduce a cross-operation execution facade or unused batch abstractions.

`profiling/profile_matrix_ops.py` compares `matmul_planned()` with NumPy and the existing SimpleArray matrix routes.

## Profiling

The macOS measurements used an Apple M1 with NumPy and `_solvcon` both linked to Accelerate. The generic planned route is already competitive for small matrices. Larger matrices will use size- and layout-aware dispatch to optimized BLAS or tiled routes in later tasks.

### Non-contiguous behavior

`np.flip()` produces views with lhs strides `(m, -1)` and rhs strides `(-m, 1)`. These layouts fail NumPy's [`is_blasable2d()` check](https://github.com/numpy/numpy/blob/v2.2.4/numpy/_core/src/umath/matmul.c.src#L38-L58), so its [matrix dispatch](https://github.com/numpy/numpy/blob/v2.2.4/numpy/_core/src/umath/matmul.c.src#L390-L477) uses the [signed-stride non-BLAS loop](https://github.com/numpy/numpy/blob/v2.2.4/numpy/_core/src/umath/matmul.c.src#L207-L260). The planned executor also contracts the supplied signed strides directly, which explains why the non-contiguous curves are close.

### float32 scaling by input layout

![Float32 matrix multiplication scaling for C-contiguous and non-contiguous inputs](https://github.com/user-attachments/assets/f0b53ad6-6a6d-4459-afe7-8d98a802109e)

### float64 scaling by input layout

![Float64 matrix multiplication scaling for C-contiguous and non-contiguous inputs](https://github.com/user-attachments/assets/ad4fab87-bfa3-442a-9345-a323bd371112)

<details>
<summary>Complete raw profile_matrix_ops Markdown</summary>

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(4, 4)`, element strides: `(4, 1)`
- rhs shape: `(4, 4)`, element strides: `(4, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.185E-01       | 1.000           |
| naive_sa             | 2.312E-03       | 0.020           |
| blas_sa              | 4.542E-02       | 0.383           |
| planned_sa           | 1.238E-03       | 0.010           |
| fast_sa_16_16_16     | 2.437E-03       | 0.021           |
| fast_sa_32_32_32     | 1.991E-03       | 0.017           |
| fast_sa_64_64_64     | 1.917E-03       | 0.016           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(4, 4)`, element strides: `(4, -1)`
- rhs shape: `(4, 4)`, element strides: `(-4, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.783E-03       | 1.000           |
| naive_sa             | 1.254E-03       | 0.703           |
| blas_sa              | 1.187E-03       | 0.666           |
| planned_sa           | 1.025E-03       | 0.575           |
| fast_sa_16_16_16     | 2.092E-03       | 1.173           |
| fast_sa_32_32_32     | 2.621E-03       | 1.470           |
| fast_sa_64_64_64     | 2.646E-03       | 1.484           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(16, 16)`, element strides: `(16, 1)`
- rhs shape: `(16, 16)`, element strides: `(16, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.916E-01       | 1.000           |
| naive_sa             | 4.296E-03       | 0.015           |
| blas_sa              | 1.821E-03       | 0.006           |
| planned_sa           | 3.842E-03       | 0.013           |
| fast_sa_16_16_16     | 4.300E-03       | 0.015           |
| fast_sa_32_32_32     | 4.025E-03       | 0.014           |
| fast_sa_64_64_64     | 3.612E-03       | 0.012           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(16, 16)`, element strides: `(16, -1)`
- rhs shape: `(16, 16)`, element strides: `(-16, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.337E-03       | 1.000           |
| naive_sa             | 3.738E-03       | 0.862           |
| blas_sa              | 3.587E-03       | 0.827           |
| planned_sa           | 3.521E-03       | 0.812           |
| fast_sa_16_16_16     | 4.979E-03       | 1.148           |
| fast_sa_32_32_32     | 4.817E-03       | 1.110           |
| fast_sa_64_64_64     | 4.783E-03       | 1.103           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(64, 64)`, element strides: `(64, 1)`
- rhs shape: `(64, 64)`, element strides: `(64, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.065E-02       | 1.000           |
| naive_sa             | 2.280E-01       | 7.439           |
| blas_sa              | 2.692E-03       | 0.088           |
| planned_sa           | 2.373E-01       | 7.742           |
| fast_sa_16_16_16     | 9.053E-02       | 2.954           |
| fast_sa_32_32_32     | 1.097E-01       | 3.580           |
| fast_sa_64_64_64     | 1.410E-01       | 4.601           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(64, 64)`, element strides: `(64, -1)`
- rhs shape: `(64, 64)`, element strides: `(-64, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.782E-01       | 1.000           |
| naive_sa             | 2.262E-01       | 0.813           |
| blas_sa              | 2.261E-01       | 0.812           |
| planned_sa           | 2.379E-01       | 0.855           |
| fast_sa_16_16_16     | 1.722E-01       | 0.619           |
| fast_sa_32_32_32     | 2.163E-01       | 0.777           |
| fast_sa_64_64_64     | 2.377E-01       | 0.854           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(256, 256)`, element strides: `(256, 1)`
- rhs shape: `(256, 256)`, element strides: `(256, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 6.912E-02       | 1.000           |
| naive_sa             | 2.464E+01       | 356.497         |
| blas_sa              | 5.492E-02       | 0.794           |
| planned_sa           | 2.465E+01       | 356.660         |
| fast_sa_16_16_16     | 5.349E+00       | 77.385          |
| fast_sa_32_32_32     | 6.320E+00       | 91.435          |
| fast_sa_64_64_64     | 8.500E+00       | 122.970         |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(256, 256)`, element strides: `(256, -1)`
- rhs shape: `(256, 256)`, element strides: `(-256, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.997E+01       | 1.000           |
| naive_sa             | 2.509E+01       | 0.837           |
| blas_sa              | 2.506E+01       | 0.836           |
| planned_sa           | 2.501E+01       | 0.835           |
| fast_sa_16_16_16     | 1.065E+01       | 0.355           |
| fast_sa_32_32_32     | 1.156E+01       | 0.386           |
| fast_sa_64_64_64     | 1.491E+01       | 0.497           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(1024, 1024)`, element strides: `(1024, 1)`
- rhs shape: `(1024, 1024)`, element strides: `(1024, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.577E+00       | 1.000           |
| naive_sa             | 2.458E+03       | 536.994         |
| blas_sa              | 3.567E+00       | 0.779           |
| planned_sa           | 3.816E+04       | 8337.898        |
| fast_sa_16_16_16     | 5.680E+02       | 124.091         |
| fast_sa_32_32_32     | 9.822E+02       | 214.587         |
| fast_sa_64_64_64     | 6.412E+02       | 140.087         |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(1024, 1024)`, element strides: `(1024, -1)`
- rhs shape: `(1024, 1024)`, element strides: `(-1024, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.618E+03       | 1.000           |
| naive_sa             | 2.600E+03       | 0.993           |
| blas_sa              | 2.250E+03       | 0.860           |
| planned_sa           | 2.503E+03       | 0.956           |
| fast_sa_16_16_16     | 9.142E+02       | 0.349           |
| fast_sa_32_32_32     | 9.892E+02       | 0.378           |
| fast_sa_64_64_64     | 1.171E+03       | 0.447           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(4, 4)`, element strides: `(4, 1)`
- rhs shape: `(4, 4)`, element strides: `(4, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 9.638E-02       | 1.000           |
| naive_sa             | 6.169E-02       | 0.640           |
| blas_sa              | 2.514E-02       | 0.261           |
| planned_sa           | 1.150E-03       | 0.012           |
| fast_sa_16_16_16     | 2.329E-03       | 0.024           |
| fast_sa_32_32_32     | 1.892E-03       | 0.020           |
| fast_sa_64_64_64     | 1.846E-03       | 0.019           |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(4, 4)`, element strides: `(4, -1)`
- rhs shape: `(4, 4)`, element strides: `(-4, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.767E-03       | 1.000           |
| naive_sa             | 1.241E-03       | 0.703           |
| blas_sa              | 1.125E-03       | 0.637           |
| planned_sa           | 1.017E-03       | 0.576           |
| fast_sa_16_16_16     | 2.004E-03       | 1.134           |
| fast_sa_32_32_32     | 1.871E-03       | 1.059           |
| fast_sa_64_64_64     | 1.842E-03       | 1.043           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(16, 16)`, element strides: `(16, 1)`
- rhs shape: `(16, 16)`, element strides: `(16, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.112E-01       | 1.000           |
| naive_sa             | 4.950E-03       | 0.045           |
| blas_sa              | 1.721E-03       | 0.015           |
| planned_sa           | 3.858E-03       | 0.035           |
| fast_sa_16_16_16     | 4.288E-03       | 0.039           |
| fast_sa_32_32_32     | 3.721E-03       | 0.033           |
| fast_sa_64_64_64     | 3.533E-03       | 0.032           |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(16, 16)`, element strides: `(16, -1)`
- rhs shape: `(16, 16)`, element strides: `(-16, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.633E-03       | 1.000           |
| naive_sa             | 3.687E-03       | 0.796           |
| blas_sa              | 3.604E-03       | 0.778           |
| planned_sa           | 3.508E-03       | 0.757           |
| fast_sa_16_16_16     | 4.933E-03       | 1.065           |
| fast_sa_32_32_32     | 4.804E-03       | 1.037           |
| fast_sa_64_64_64     | 4.779E-03       | 1.031           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(64, 64)`, element strides: `(64, 1)`
- rhs shape: `(64, 64)`, element strides: `(64, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 6.683E-03       | 1.000           |
| naive_sa             | 2.296E-01       | 34.361          |
| blas_sa              | 4.988E-03       | 0.746           |
| planned_sa           | 2.291E-01       | 34.281          |
| fast_sa_16_16_16     | 9.235E-02       | 13.818          |
| fast_sa_32_32_32     | 1.175E-01       | 17.588          |
| fast_sa_64_64_64     | 1.648E-01       | 24.665          |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(64, 64)`, element strides: `(64, -1)`
- rhs shape: `(64, 64)`, element strides: `(-64, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.787E-01       | 1.000           |
| naive_sa             | 2.265E-01       | 0.813           |
| blas_sa              | 2.279E-01       | 0.818           |
| planned_sa           | 2.325E-01       | 0.834           |
| fast_sa_16_16_16     | 1.715E-01       | 0.615           |
| fast_sa_32_32_32     | 1.914E-01       | 0.687           |
| fast_sa_64_64_64     | 2.389E-01       | 0.857           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(256, 256)`, element strides: `(256, 1)`
- rhs shape: `(256, 256)`, element strides: `(256, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.177E-01       | 1.000           |
| naive_sa             | 2.724E+01       | 125.094         |
| blas_sa              | 1.954E-01       | 0.897           |
| planned_sa           | 2.762E+01       | 126.860         |
| fast_sa_16_16_16     | 6.256E+00       | 28.732          |
| fast_sa_32_32_32     | 8.123E+00       | 37.309          |
| fast_sa_64_64_64     | 1.159E+01       | 53.242          |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(256, 256)`, element strides: `(256, -1)`
- rhs shape: `(256, 256)`, element strides: `(-256, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.470E+01       | 1.000           |
| naive_sa             | 2.887E+01       | 0.832           |
| blas_sa              | 2.907E+01       | 0.838           |
| planned_sa           | 2.901E+01       | 0.836           |
| fast_sa_16_16_16     | 1.261E+01       | 0.363           |
| fast_sa_32_32_32     | 1.375E+01       | 0.396           |
| fast_sa_64_64_64     | 1.760E+01       | 0.507           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(1024, 1024)`, element strides: `(1024, 1)`
- rhs shape: `(1024, 1024)`, element strides: `(1024, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.399E+01       | 1.000           |
| naive_sa             | 3.134E+03       | 224.027         |
| blas_sa              | 1.665E+01       | 1.190           |
| planned_sa           | 3.134E+03       | 224.066         |
| fast_sa_16_16_16     | 6.662E+02       | 47.632          |
| fast_sa_32_32_32     | 7.604E+02       | 54.363          |
| fast_sa_64_64_64     | 9.076E+02       | 64.887          |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(1024, 1024)`, element strides: `(1024, -1)`
- rhs shape: `(1024, 1024)`, element strides: `(-1024, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.760E+03       | 1.000           |
| naive_sa             | 2.257E+03       | 0.600           |
| blas_sa              | 2.234E+03       | 0.594           |
| planned_sa           | 2.369E+03       | 0.630           |
| fast_sa_16_16_16     | 6.973E+02       | 0.185           |
| fast_sa_32_32_32     | 8.502E+02       | 0.226           |
| fast_sa_64_64_64     | 1.013E+03       | 0.269           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(9, 9)`, element strides: `(9, 1)`
- rhs shape: `(9, 9)`, element strides: `(9, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.028E-01       | 1.000           |
| naive_sa             | 4.472E-02       | 0.220           |
| blas_sa              | 5.654E-02       | 0.279           |
| planned_sa           | 1.562E-03       | 0.008           |
| fast_sa_16_16_16     | 2.633E-03       | 0.013           |
| fast_sa_32_32_32     | 2.946E-03       | 0.015           |
| fast_sa_64_64_64     | 2.271E-03       | 0.011           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(9, 9)`, element strides: `(9, -1)`
- rhs shape: `(9, 9)`, element strides: `(-9, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.233E-03       | 1.000           |
| naive_sa             | 1.729E-03       | 0.774           |
| blas_sa              | 1.621E-03       | 0.726           |
| planned_sa           | 1.438E-03       | 0.644           |
| fast_sa_16_16_16     | 2.617E-03       | 1.172           |
| fast_sa_32_32_32     | 2.446E-03       | 1.095           |
| fast_sa_64_64_64     | 2.433E-03       | 1.090           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(27, 27)`, element strides: `(27, 1)`
- rhs shape: `(27, 27)`, element strides: `(27, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.770E-01       | 1.000           |
| naive_sa             | 1.431E-02       | 0.038           |
| blas_sa              | 1.983E-03       | 0.005           |
| planned_sa           | 1.285E-02       | 0.034           |
| fast_sa_16_16_16     | 1.045E-02       | 0.028           |
| fast_sa_32_32_32     | 1.022E-02       | 0.027           |
| fast_sa_64_64_64     | 1.018E-02       | 0.027           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(27, 27)`, element strides: `(27, -1)`
- rhs shape: `(27, 27)`, element strides: `(-27, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.560E-02       | 1.000           |
| naive_sa             | 1.277E-02       | 0.818           |
| blas_sa              | 1.265E-02       | 0.811           |
| planned_sa           | 1.263E-02       | 0.810           |
| fast_sa_16_16_16     | 1.600E-02       | 1.026           |
| fast_sa_32_32_32     | 1.505E-02       | 0.965           |
| fast_sa_64_64_64     | 1.504E-02       | 0.964           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(81, 81)`, element strides: `(81, 1)`
- rhs shape: `(81, 81)`, element strides: `(81, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.727E-02       | 1.000           |
| naive_sa             | 5.489E-01       | 14.728          |
| blas_sa              | 5.775E-03       | 0.155           |
| planned_sa           | 5.658E-01       | 15.182          |
| fast_sa_16_16_16     | 1.888E-01       | 5.067           |
| fast_sa_32_32_32     | 2.122E-01       | 5.694           |
| fast_sa_64_64_64     | 2.649E-01       | 7.109           |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(81, 81)`, element strides: `(81, -1)`
- rhs shape: `(81, 81)`, element strides: `(-81, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 5.980E-01       | 1.000           |
| naive_sa             | 5.487E-01       | 0.918           |
| blas_sa              | 5.498E-01       | 0.919           |
| planned_sa           | 5.643E-01       | 0.944           |
| fast_sa_16_16_16     | 3.480E-01       | 0.582           |
| fast_sa_32_32_32     | 3.653E-01       | 0.611           |
| fast_sa_64_64_64     | 4.438E-01       | 0.742           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(243, 243)`, element strides: `(243, 1)`
- rhs shape: `(243, 243)`, element strides: `(243, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 5.363E-02       | 1.000           |
| naive_sa             | 2.006E+01       | 374.043         |
| blas_sa              | 5.037E-02       | 0.939           |
| planned_sa           | 2.006E+01       | 374.117         |
| fast_sa_16_16_16     | 4.758E+00       | 88.727          |
| fast_sa_32_32_32     | 5.561E+00       | 103.690         |
| fast_sa_64_64_64     | 7.318E+00       | 136.459         |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(243, 243)`, element strides: `(243, -1)`
- rhs shape: `(243, 243)`, element strides: `(-243, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.468E+01       | 1.000           |
| naive_sa             | 2.015E+01       | 0.817           |
| blas_sa              | 2.008E+01       | 0.813           |
| planned_sa           | 2.010E+01       | 0.814           |
| fast_sa_16_16_16     | 9.060E+00       | 0.367           |
| fast_sa_32_32_32     | 1.014E+01       | 0.411           |
| fast_sa_64_64_64     | 1.245E+01       | 0.505           |

## 2D x 2D layout: `c_contiguous` dtype: `float32`

- lhs shape: `(729, 729)`, element strides: `(729, 1)`
- rhs shape: `(729, 729)`, element strides: `(729, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.145E+00       | 1.000           |
| naive_sa             | 7.154E+02       | 624.747         |
| blas_sa              | 1.058E+00       | 0.924           |
| planned_sa           | 7.135E+02       | 623.080         |
| fast_sa_16_16_16     | 1.258E+02       | 109.857         |
| fast_sa_32_32_32     | 1.495E+02       | 130.590         |
| fast_sa_64_64_64     | 2.038E+02       | 177.987         |

## 2D x 2D layout: `non_contiguous` dtype: `float32`

- lhs shape: `(729, 729)`, element strides: `(729, -1)`
- rhs shape: `(729, 729)`, element strides: `(-729, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 7.810E+02       | 1.000           |
| naive_sa             | 7.526E+02       | 0.964           |
| blas_sa              | 8.244E+02       | 1.056           |
| planned_sa           | 7.290E+02       | 0.933           |
| fast_sa_16_16_16     | 2.596E+02       | 0.332           |
| fast_sa_32_32_32     | 2.641E+02       | 0.338           |
| fast_sa_64_64_64     | 3.381E+02       | 0.433           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(9, 9)`, element strides: `(9, 1)`
- rhs shape: `(9, 9)`, element strides: `(9, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.775E-01       | 1.000           |
| naive_sa             | 5.092E-03       | 0.013           |
| blas_sa              | 4.352E-02       | 0.115           |
| planned_sa           | 1.642E-03       | 0.004           |
| fast_sa_16_16_16     | 2.667E-03       | 0.007           |
| fast_sa_32_32_32     | 2.267E-03       | 0.006           |
| fast_sa_64_64_64     | 2.204E-03       | 0.006           |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(9, 9)`, element strides: `(9, -1)`
- rhs shape: `(9, 9)`, element strides: `(-9, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.204E-03       | 1.000           |
| naive_sa             | 1.750E-03       | 0.794           |
| blas_sa              | 1.600E-03       | 0.726           |
| planned_sa           | 1.462E-03       | 0.663           |
| fast_sa_16_16_16     | 2.546E-03       | 1.155           |
| fast_sa_32_32_32     | 2.400E-03       | 1.089           |
| fast_sa_64_64_64     | 2.358E-03       | 1.070           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(27, 27)`, element strides: `(27, 1)`
- rhs shape: `(27, 27)`, element strides: `(27, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 8.710E-02       | 1.000           |
| naive_sa             | 1.426E-02       | 0.164           |
| blas_sa              | 2.467E-03       | 0.028           |
| planned_sa           | 1.288E-02       | 0.148           |
| fast_sa_16_16_16     | 1.081E-02       | 0.124           |
| fast_sa_32_32_32     | 1.100E-02       | 0.126           |
| fast_sa_64_64_64     | 1.095E-02       | 0.126           |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(27, 27)`, element strides: `(27, -1)`
- rhs shape: `(27, 27)`, element strides: `(-27, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.565E-02       | 1.000           |
| naive_sa             | 1.277E-02       | 0.816           |
| blas_sa              | 1.270E-02       | 0.812           |
| planned_sa           | 1.264E-02       | 0.807           |
| fast_sa_16_16_16     | 1.885E-02       | 1.204           |
| fast_sa_32_32_32     | 1.510E-02       | 0.964           |
| fast_sa_64_64_64     | 1.500E-02       | 0.958           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(81, 81)`, element strides: `(81, 1)`
- rhs shape: `(81, 81)`, element strides: `(81, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.487E-02       | 1.000           |
| naive_sa             | 5.524E-01       | 15.841          |
| blas_sa              | 1.182E-02       | 0.339           |
| planned_sa           | 5.479E-01       | 15.712          |
| fast_sa_16_16_16     | 1.992E-01       | 5.714           |
| fast_sa_32_32_32     | 2.327E-01       | 6.672           |
| fast_sa_64_64_64     | 3.133E-01       | 8.984           |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(81, 81)`, element strides: `(81, -1)`
- rhs shape: `(81, 81)`, element strides: `(-81, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 5.990E-01       | 1.000           |
| naive_sa             | 5.514E-01       | 0.921           |
| blas_sa              | 5.498E-01       | 0.918           |
| planned_sa           | 5.492E-01       | 0.917           |
| fast_sa_16_16_16     | 3.518E-01       | 0.587           |
| fast_sa_32_32_32     | 3.659E-01       | 0.611           |
| fast_sa_64_64_64     | 4.461E-01       | 0.745           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(243, 243)`, element strides: `(243, 1)`
- rhs shape: `(243, 243)`, element strides: `(243, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.632E-01       | 1.000           |
| naive_sa             | 2.029E+01       | 124.291         |
| blas_sa              | 1.521E-01       | 0.932           |
| planned_sa           | 2.023E+01       | 123.908         |
| fast_sa_16_16_16     | 4.903E+00       | 30.032          |
| fast_sa_32_32_32     | 6.222E+00       | 38.112          |
| fast_sa_64_64_64     | 8.598E+00       | 52.670          |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(243, 243)`, element strides: `(243, -1)`
- rhs shape: `(243, 243)`, element strides: `(-243, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.489E+01       | 1.000           |
| naive_sa             | 2.021E+01       | 0.812           |
| blas_sa              | 2.022E+01       | 0.812           |
| planned_sa           | 2.024E+01       | 0.813           |
| fast_sa_16_16_16     | 9.019E+00       | 0.362           |
| fast_sa_32_32_32     | 9.663E+00       | 0.388           |
| fast_sa_64_64_64     | 1.251E+01       | 0.503           |

## 2D x 2D layout: `c_contiguous` dtype: `float64`

- lhs shape: `(729, 729)`, element strides: `(729, 1)`
- rhs shape: `(729, 729)`, element strides: `(729, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.112E+00       | 1.000           |
| naive_sa             | 7.244E+02       | 176.185         |
| blas_sa              | 3.706E+00       | 0.901           |
| planned_sa           | 7.267E+02       | 176.732         |
| fast_sa_16_16_16     | 1.315E+02       | 31.972          |
| fast_sa_32_32_32     | 1.689E+02       | 41.071          |
| fast_sa_64_64_64     | 2.410E+02       | 58.614          |

## 2D x 2D layout: `non_contiguous` dtype: `float64`

- lhs shape: `(729, 729)`, element strides: `(729, -1)`
- rhs shape: `(729, 729)`, element strides: `(-729, 1)`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 7.638E+02       | 1.000           |
| naive_sa             | 7.236E+02       | 0.947           |
| blas_sa              | 7.701E+02       | 1.008           |
| planned_sa           | 7.530E+02       | 0.986           |
| fast_sa_16_16_16     | 2.549E+02       | 0.334           |
| fast_sa_32_32_32     | 2.714E+02       | 0.355           |
| fast_sa_64_64_64     | 3.422E+02       | 0.448           |

</details>

Matrix correctness passes all 44 tests in `tests/test_matrix.py`. Full clang-format, flake8, include-ordering, ASCII, and trailing-whitespace lint also passes.

Related to #1172.