### PR TITLE
Use one signed SimpleArray shape type

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -159,10 +159,10 @@ static inline void dispatch_tile_inner(
 SimpleArrayCopier::SimpleArrayCopier(
     buffer_type const & src_buffer,
     ssize_t const src_body_offset,
-    sshape_type const & src_stride,
+    shape_type const & src_stride,
     buffer_type & dst_buffer,
     ssize_t const dst_body_offset,
-    sshape_type const & dst_stride,
+    shape_type const & dst_stride,
     shape_type const & shape,
     size_t const itemsize)
     : m_src(src_buffer.data<int8_t>() + src_body_offset)
@@ -249,7 +249,7 @@ void SimpleArrayCopier::tiled_nd() const
         outer_total *= m_shape[k];
     }
 
-    detail::sshape_type outer_idx(ia, 0);
+    detail::shape_type outer_idx(ia, 0);
     for (ssize_t step = 0; step < outer_total; ++step)
     {
         // Resolve outer-axis base offsets (in bytes) for this slab.
@@ -298,7 +298,7 @@ void SimpleArrayCopier::naive() const
     size_t const ndim = m_shape.size();
     size_t const itemsize = m_itemsize;
     auto const signed_itemsize = static_cast<ssize_t>(itemsize);
-    detail::sshape_type idx(ndim, 0);
+    detail::shape_type idx(ndim, 0);
     for (ssize_t step = 0; step < total; ++step)
     {
         ssize_t src_off = 0;

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -110,7 +110,6 @@ namespace detail
 {
 
 using shape_type = small_vector<ssize_t>;
-using sshape_type = small_vector<ssize_t>;
 
 /**
  * @brief Enumerate SimpleArray indices with nghost included.
@@ -154,9 +153,9 @@ public:
         }
     }
 
-    sshape_type first() const { return m_lower; }
+    shape_type first() const { return m_lower; }
 
-    bool next(sshape_type & idx) const
+    bool next(shape_type & idx) const
     {
         for (size_t i = idx.size(); i > 0; --i)
         {
@@ -177,8 +176,8 @@ public:
 
 private:
 
-    sshape_type m_lower;
-    sshape_type m_upper;
+    shape_type m_lower;
+    shape_type m_upper;
 
     template <typename Array>
     static ssize_t lower_bound(Array const & array, ssize_t dim)
@@ -205,7 +204,6 @@ struct SimpleArrayInternalTypes
 {
     using value_type = T;
     using shape_type = detail::shape_type;
-    using sshape_type = detail::sshape_type;
     using buffer_type = ConcreteBuffer;
 }; /* end struct SimpleArrayInternalTypes */
 
@@ -254,7 +252,6 @@ public:
 
     using value_type = typename internal_types::value_type;
     using shape_type = typename internal_types::shape_type;
-    using sshape_type = typename internal_types::sshape_type;
 
     value_type sum() const
     {
@@ -316,14 +313,14 @@ private:
     // at(sidx) performs.
     static value_type sum_strided(value_type const * data,
                                   shape_type const & shape,
-                                  sshape_type const & stride)
+                                  shape_type const & stride)
     {
         const size_t ndim = shape.size();
         ssize_t const last_dim = shape[ndim - 1];
         const ssize_t last_stride = stride[ndim - 1];
 
         value_type acc = zero();
-        sshape_type prefix(ndim - 1, 0);
+        shape_type prefix(ndim - 1, 0);
         do
         {
             ssize_t offset = 0;
@@ -340,7 +337,7 @@ private:
         return acc;
     }
 
-    static bool next_prefix(sshape_type & idx,
+    static bool next_prefix(shape_type & idx,
                             shape_type const & shape)
     {
         for (size_t i = idx.size(); i > 0; --i)
@@ -368,7 +365,6 @@ public:
 
     using value_type = typename internal_types::value_type;
     using shape_type = typename internal_types::shape_type;
-    using sshape_type = typename internal_types::sshape_type;
     using real_type = typename detail::select_real_t<value_type>::type;
 
     template <typename RedFn, typename... RedArgs>
@@ -421,9 +417,9 @@ public:
         }
         auto const red_range = IndexRange(*athis, red_axes);
 
-        sshape_type full_idx(ndim, 0);
+        shape_type full_idx(ndim, 0);
         auto const out_range = IndexRange(result);
-        sshape_type out_idx = out_range.first();
+        shape_type out_idx = out_range.first();
 
         do
         {
@@ -436,7 +432,7 @@ public:
             }
 
             small_vector<value_type> slice;
-            sshape_type red_idx = red_range.first();
+            shape_type red_idx = red_range.first();
 
             do
             {
@@ -472,7 +468,7 @@ public:
         const size_t n = athis->size();
         small_vector<T> acopy(n);
         auto const range = IndexRange(*athis);
-        sshape_type sidx = range.first();
+        shape_type sidx = range.first();
         size_t i = 0;
         do
         {
@@ -507,7 +503,7 @@ public:
     {
         small_vector<value_type> weight_sv(weight.size());
         auto const range = IndexRange(weight);
-        sshape_type sidx = range.first();
+        shape_type sidx = range.first();
         size_t i = 0;
         do
         {
@@ -532,7 +528,7 @@ public:
         value_type sum = 0;
         value_type total_weight = 0;
         auto const range = IndexRange(*athis);
-        sshape_type sidx = range.first();
+        shape_type sidx = range.first();
         do
         {
             sum += athis->at(sidx) * weight.at(sidx);
@@ -617,7 +613,7 @@ public:
         }
 
         auto const range = IndexRange(*athis);
-        sshape_type sidx = range.first();
+        shape_type sidx = range.first();
         value_type const mu = athis->mean();
         real_type acc = 0;
         if constexpr (is_complex_v<value_type>)
@@ -1417,7 +1413,6 @@ public:
 
     using value_type = typename internal_types::value_type;
     using shape_type = typename internal_types::shape_type;
-    using sshape_type = typename internal_types::sshape_type;
 
     static A eye(ssize_t n)
     {
@@ -1626,7 +1621,6 @@ public:
     using rebind = SimpleArray<U>;
     using value_type = typename internal_types::value_type;
     using shape_type = typename internal_types::shape_type;
-    using sshape_type = typename internal_types::sshape_type;
     using buffer_type = typename internal_types::buffer_type;
 
     enum class ArrayOrder : std::uint8_t
@@ -1732,7 +1726,7 @@ public:
                 throw std::runtime_error("SimpleArray: input buffer size must be divisible");
             }
             m_shape = shape_type{static_cast<ssize_t>(nitem)};
-            m_stride = sshape_type{1};
+            m_stride = shape_type{1};
             m_buffer = buffer;
             update_data_pointers();
         }
@@ -1782,7 +1776,7 @@ public:
     }
 
     explicit SimpleArray(shape_type const & shape,
-                         sshape_type const & stride,
+                         shape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer,
                          ArrayOrder array_order)
         : SimpleArray(shape, stride, buffer, 0, array_order)
@@ -1790,7 +1784,7 @@ public:
     }
 
     explicit SimpleArray(shape_type const & shape,
-                         sshape_type const & stride,
+                         shape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer,
                          size_t data_offset,
                          ArrayOrder array_order)
@@ -1807,14 +1801,14 @@ public:
     }
 
     explicit SimpleArray(shape_type const & shape,
-                         sshape_type const & stride,
+                         shape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer)
         : SimpleArray(shape, stride, buffer, 0)
     {
     }
 
     explicit SimpleArray(shape_type const & shape,
-                         sshape_type const & stride,
+                         shape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer,
                          size_t data_offset)
         : SimpleArray(buffer)
@@ -1894,10 +1888,10 @@ public:
         return *this;
     }
 
-    static sshape_type calc_stride(shape_type const & shape)
+    static shape_type calc_stride(shape_type const & shape)
     {
         validate_shape(shape);
-        sshape_type stride(shape.size());
+        shape_type stride(shape.size());
         if (!shape.empty())
         {
             stride[shape.size() - 1] = 1;
@@ -1909,7 +1903,7 @@ public:
         return stride;
     }
 
-    static T * calc_body(T * data, sshape_type const & stride, ssize_t nghost)
+    static T * calc_body(T * data, shape_type const & stride, ssize_t nghost)
     {
         if (nullptr == data || stride.empty() || 0 == nghost)
         {
@@ -1917,7 +1911,7 @@ public:
         }
         else
         {
-            sshape_type idx(stride.size(), 0);
+            shape_type idx(stride.size(), 0);
             idx[0] = nghost;
             data += buffer_offset(stride, idx);
         }
@@ -1961,29 +1955,29 @@ public:
 
     value_type const & at(ssize_t it) const
     {
-        sshape_type const idx{normalize_index(it)};
+        shape_type const idx{normalize_index(it)};
         ssize_t const offset = buffer_offset(m_stride, idx);
         return *(logical_data() + offset);
     }
     value_type & at(ssize_t it)
     {
-        sshape_type const idx{normalize_index(it)};
+        shape_type const idx{normalize_index(it)};
         ssize_t const offset = buffer_offset(m_stride, idx);
         return *(logical_data() + offset);
     }
 
-    value_type const & at(std::vector<ssize_t> const & idx) const { return at(sshape_type(idx)); }
-    value_type & at(std::vector<ssize_t> const & idx) { return at(sshape_type(idx)); }
+    value_type const & at(std::vector<ssize_t> const & idx) const { return at(shape_type(idx)); }
+    value_type & at(std::vector<ssize_t> const & idx) { return at(shape_type(idx)); }
 
-    value_type const & at(sshape_type const & sidx) const
+    value_type const & at(shape_type const & sidx) const
     {
-        sshape_type const idx = normalize_index(sidx);
+        shape_type const idx = normalize_index(sidx);
         ssize_t const offset = buffer_offset(m_stride, idx);
         return *(logical_data() + offset);
     }
-    value_type & at(sshape_type const & sidx)
+    value_type & at(shape_type const & sidx)
     {
-        sshape_type const idx = normalize_index(sidx);
+        shape_type const idx = normalize_index(sidx);
         ssize_t const offset = buffer_offset(m_stride, idx);
         return *(logical_data() + offset);
     }
@@ -1992,7 +1986,7 @@ public:
     shape_type const & shape() const { return m_shape; }
     ssize_t shape(ssize_t it) const noexcept { return m_shape[it]; }
     ssize_t & shape(ssize_t it) noexcept { return m_shape[it]; }
-    sshape_type const & stride() const { return m_stride; }
+    shape_type const & stride() const { return m_stride; }
     ssize_t stride(ssize_t it) const noexcept { return m_stride[it]; }
     ssize_t & stride(ssize_t it) noexcept { return m_stride[it]; }
 
@@ -2131,7 +2125,7 @@ private:
     }
 
     static bool is_c_contiguous(shape_type const & shape,
-                                sshape_type const & stride)
+                                shape_type const & stride)
     {
         if (std::ranges::contains(shape, 0))
         {
@@ -2150,7 +2144,7 @@ private:
     }
 
     static bool is_f_contiguous(shape_type const & shape,
-                                sshape_type const & stride)
+                                shape_type const & stride)
     {
         if (std::ranges::contains(shape, 0))
         {
@@ -2174,7 +2168,7 @@ private:
     }
 
     static void check_c_contiguous(shape_type const & shape,
-                                   sshape_type const & stride)
+                                   shape_type const & stride)
     {
         if (!is_c_contiguous(shape, stride))
         {
@@ -2183,7 +2177,7 @@ private:
     }
 
     static void check_f_contiguous(shape_type const & shape,
-                                   sshape_type const & stride)
+                                   shape_type const & stride)
     {
         if (!is_f_contiguous(shape, stride))
         {
@@ -2229,7 +2223,7 @@ private:
         return to_nonnegative_index(shifted_index, dim_length);
     }
 
-    sshape_type normalize_index(sshape_type const & idx) const
+    shape_type normalize_index(shape_type const & idx) const
     {
         auto index2string = [&idx]() -> std::string
         {
@@ -2263,7 +2257,7 @@ private:
                             m_shape.size()));
         }
 
-        sshape_type normalized(idx.size());
+        shape_type normalized(idx.size());
         for (size_t dim = 0; dim < m_shape.size(); ++dim)
         {
             ssize_t const dim_length = m_shape[dim];
@@ -2331,11 +2325,11 @@ private:
     }
 
     static void validate_layout(shape_type const & shape,
-                                sshape_type const & stride,
+                                shape_type const & stride,
                                 size_t buffer_nbytes,
                                 size_t data_offset);
 
-    static ssize_t storage_size(shape_type const & shape, sshape_type const & stride)
+    static ssize_t storage_size(shape_type const & shape, shape_type const & stride)
     {
         if (shape.empty())
         {
@@ -2351,7 +2345,7 @@ private:
     shape_type m_shape;
     /// Each element in this vector is the number of elements (not number of
     /// bytes) to skip for advancing an index in the corresponding dimension.
-    sshape_type m_stride;
+    shape_type m_stride;
 
     /// Pointer to the array's logical origin within the buffer.
     value_type * m_logical_data = nullptr;
@@ -2418,7 +2412,7 @@ void SimpleArray<T>::update_data_pointers(size_t data_offset)
 
 template <typename T>
 void SimpleArray<T>::validate_layout(shape_type const & shape,
-                                     sshape_type const & stride,
+                                     shape_type const & stride,
                                      size_t buffer_nbytes,
                                      size_t data_offset)
 {
@@ -2608,16 +2602,15 @@ class SimpleArrayCopier
 public:
 
     using shape_type = detail::shape_type;
-    using sshape_type = detail::sshape_type;
     using buffer_type = ConcreteBuffer;
 
     SimpleArrayCopier(
         buffer_type const & src_buffer,
         ssize_t src_body_offset,
-        sshape_type const & src_stride,
+        shape_type const & src_stride,
         buffer_type & dst_buffer,
         ssize_t dst_body_offset,
-        sshape_type const & dst_stride,
+        shape_type const & dst_stride,
         shape_type const & shape,
         size_t itemsize);
 
@@ -2638,8 +2631,8 @@ private:
     int8_t const * m_src;
     int8_t * m_dst;
     shape_type const & m_shape;
-    sshape_type const & m_src_stride;
-    sshape_type const & m_dst_stride;
+    shape_type const & m_src_stride;
+    shape_type const & m_dst_stride;
     size_t m_itemsize;
 
 }; /* end class SimpleArrayCopier */
@@ -2686,7 +2679,7 @@ void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
         throw std::runtime_error("SimpleArray::transpose: axis size mismatch");
     }
     shape_type new_shape(m_shape.size(), -1);
-    sshape_type new_stride(m_stride.size());
+    shape_type new_stride(m_stride.size());
     for (ssize_t it = 0; it < ndim(); ++it)
     {
         if (axis[it] < 0 || axis[it] >= ndim())
@@ -2790,7 +2783,7 @@ SimpleArray<T> SimpleArray<T>::to_column_major() const
     }
     // Compute column-major strides: the fastest-varying axis is the leading
     // one (stride[0] == 1).
-    sshape_type fstride(m_shape.size());
+    shape_type fstride(m_shape.size());
     fstride[0] = 1;
     for (size_t i = 1; i < m_shape.size(); ++i)
     {
@@ -3016,7 +3009,7 @@ SimpleArray<U> detail::SimpleArrayMixinSearch<A, T>::where(SimpleArray<U> const 
     // Use logical indices here. Non-contiguous arrays need IndexRange and at()
     // so each access follows the array's stride and ghost offset.
     auto const range = IndexRange(*athis);
-    sshape_type idx = range.first();
+    shape_type idx = range.first();
 
     do
     {

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -20,7 +20,7 @@ namespace detail
 {
 
 inline solvcon::detail::shape_type shape_from_slices(
-    std::vector<solvcon::detail::sshape_type> const & slices)
+    std::vector<solvcon::detail::shape_type> const & slices)
 {
     solvcon::detail::shape_type shape(slices.size());
     for (size_t axis = 0; axis < slices.size(); ++axis)
@@ -36,10 +36,9 @@ template <typename T /* original type */, typename D /* for destination type */>
 struct TypeBroadcastImpl
 {
     using shape_type = solvcon::detail::shape_type;
-    using sshape_type = solvcon::detail::sshape_type;
 
     static ssize_t input_offset(pybind11::array_t<D> const & arr_in,
-                                sshape_type const & sidx)
+                                shape_type const & sidx)
     {
         ssize_t offset = 0;
         for (pybind11::ssize_t axis = 0; axis < arr_in.ndim(); ++axis)
@@ -50,8 +49,8 @@ struct TypeBroadcastImpl
     }
 
     static ssize_t output_offset(SimpleArray<T> const & arr_out,
-                                 std::vector<sshape_type> const & slices,
-                                 sshape_type const & sidx)
+                                 std::vector<shape_type> const & slices,
+                                 shape_type const & sidx)
     {
         ssize_t offset = 0;
         for (ssize_t axis = 0; axis < arr_out.ndim(); ++axis)
@@ -64,10 +63,10 @@ struct TypeBroadcastImpl
 
     // NOLINTNEXTLINE(misc-no-recursion)
     static void copy_idx(SimpleArray<T> & arr_out,
-                         std::vector<sshape_type> const & slices,
+                         std::vector<shape_type> const & slices,
                          pybind11::array_t<D> const * arr_in,
                          shape_type const & left_shape,
-                         sshape_type sidx,
+                         shape_type sidx,
                          ssize_t dim)
     {
         using out_type = typename std::remove_reference_t<decltype(arr_out[0])>;
@@ -101,7 +100,7 @@ struct TypeBroadcastImpl
     }
 
     static void broadcast(SimpleArray<T> & arr_out,
-                          std::vector<sshape_type> const & slices,
+                          std::vector<shape_type> const & slices,
                           pybind11::array const & arr_in)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -109,7 +108,7 @@ struct TypeBroadcastImpl
 
         ssize_t const ndim = arr_out.ndim();
         shape_type const left_shape = detail::shape_from_slices(slices);
-        sshape_type const sidx_init(ndim, 0);
+        shape_type const sidx_init(ndim, 0);
         copy_idx(arr_out, slices, arr_new, left_shape, sidx_init, ndim - 1);
     }
 }; /* end struct TypeBroadcastImpl */
@@ -118,10 +117,9 @@ template <typename T>
 struct TypeBroadcast
 {
     using shape_type = solvcon::detail::shape_type;
-    using sshape_type = solvcon::detail::sshape_type;
 
     static void check_shape(SimpleArray<T> const & arr_out,
-                            std::vector<sshape_type> const & slices,
+                            std::vector<shape_type> const & slices,
                             pybind11::array const & arr_in)
     {
         pybind11::ssize_t const right_ndim = arr_in.ndim();
@@ -149,7 +147,7 @@ struct TypeBroadcast
     }
 
     static void broadcast(SimpleArray<T> & arr_out,
-                          std::vector<sshape_type> const & slices,
+                          std::vector<shape_type> const & slices,
                           pybind11::array const & arr_in)
     {
         if (dtype_is_type<bool>(arr_in))

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -160,7 +160,6 @@ class ArrayPropertyHelper
 {
 public:
     using shape_type = solvcon::detail::shape_type;
-    using sshape_type = solvcon::detail::sshape_type;
 
     static void broadcast_array_using_ellipsis(SimpleArray<T> & arr_out, pybind11::array const & arr_in)
     {
@@ -324,14 +323,14 @@ private:
         }
     }
 
-    static std::vector<sshape_type> make_default_slices(SimpleArray<T> const & arr)
+    static std::vector<shape_type> make_default_slices(SimpleArray<T> const & arr)
     {
-        std::vector<sshape_type> slices;
+        std::vector<shape_type> slices;
         auto const & shape = arr.shape();
         slices.reserve(shape.size());
         for (ssize_t const dim : shape)
         {
-            sshape_type default_slice(4);
+            shape_type default_slice(4);
             default_slice[0] = 0; // start
             default_slice[1] = dim; // stop
             default_slice[2] = 1; // step
@@ -343,7 +342,7 @@ private:
 
     static pybind11::object shift_slice_bound(pybind11::handle bound, ssize_t offset);
 
-    static void copy_slice(sshape_type & slice_out,
+    static void copy_slice(shape_type & slice_out,
                            pybind11::slice const & slice_in,
                            ssize_t length,
                            ssize_t offset)
@@ -406,7 +405,7 @@ private:
     }
 
     static void process_slices(pybind11::tuple const & tuple,
-                               std::vector<sshape_type> & slices,
+                               std::vector<shape_type> & slices,
                                SimpleArray<T> const & arr)
     {
         namespace py = pybind11;
@@ -456,7 +455,7 @@ private:
     }
 
     static void broadcast_array_using_slice(SimpleArray<T> & arr_out,
-                                            std::vector<sshape_type> const & slices,
+                                            std::vector<shape_type> const & slices,
                                             pybind11::array const & arr_in)
     {
         TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -714,7 +714,7 @@ WrapSimpleArray<T>::make_array_from_numpy(pybind11::array & arr_in)
     }
 
     solvcon::detail::shape_type shape;
-    solvcon::detail::sshape_type stride;
+    solvcon::detail::shape_type stride;
     constexpr auto itemsize = static_cast<ssize_t>(sizeof(value_type));
     ssize_t byte_span_begin = 0;
     ssize_t byte_span_end = 0;

--- a/gtests/test_nopython_mdspan.cpp
+++ b/gtests/test_nopython_mdspan.cpp
@@ -518,7 +518,7 @@ TEST(SimpleArray, mdspan_non_contiguous)
     // array is neither C- nor F-contiguous over the underlying buffer.
     using array_type = mm::SimpleArray<double>;
     array_type::shape_type const shape{3, 4};
-    array_type::sshape_type const stride{8, 1};
+    array_type::shape_type const stride{8, 1};
     auto buffer = mm::ConcreteBuffer::construct(3 * 8 * sizeof(double));
     array_type arr(shape, stride, buffer);
     for (size_t i = 0; i < 24; ++i) { arr.data(i) = static_cast<double>(i); }
@@ -586,7 +586,7 @@ TEST(SimpleArray, mdspan_negative_strides)
 
     using array_type = mm::SimpleArray<double>;
     array_type::shape_type const shape{2, 3};
-    array_type::sshape_type const stride{-3, -1};
+    array_type::shape_type const stride{-3, -1};
     auto buffer = mm::ConcreteBuffer::construct(6 * sizeof(double));
     for (size_t i = 0; i < 6; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
 
@@ -623,7 +623,7 @@ TEST(SimpleArray, mdspan_mixed_strides_with_padding)
 
     using array_type = mm::SimpleArray<double>;
     array_type::shape_type const shape{2, 3, 2, 4};
-    array_type::sshape_type const stride{-40, 10, -5, 1};
+    array_type::shape_type const stride{-40, 10, -5, 1};
     auto buffer = mm::ConcreteBuffer::construct(72 * sizeof(double));
     for (size_t i = 0; i < 72; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
 


### PR DESCRIPTION
SimpleArray defines both `shape_type` and `sshape_type` as `small_vector<ssize_t>`, so the second alias does not provide a distinct representation.

This change removes `sshape_type` from the buffer core, broadcasting and assignment helpers, Python bindings, and C++ tests. Shapes, axes, strides, slices, and indices now consistently use `shape_type`. Array layout, indexing, and signed-stride behavior remain unchanged.

Related to #1176.
