### PR TITLE
Retire completed CallProfiler callbacks

### DIFF
--- a/cpp/solvcon/profiling/RadixTree.cpp
+++ b/cpp/solvcon/profiling/RadixTree.cpp
@@ -41,6 +41,7 @@ void CallProfiler::end_caller()
     call_profile.stop_stopwatch(); // Update profiling information to the pending time and count
     m_pending_nodes.insert(m_radix_tree.get_current_node());
     m_radix_tree.move_current_to_parent(); // Pop the caller from the call stack
+    m_cancel_callbacks.pop_back();
 
     if (m_radix_tree.get_current_node() == m_radix_tree.get_root()) // If the root function ends, update all pending nodes and stable items
     {

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -26,6 +26,8 @@ protected:
         return pProfiler->m_radix_tree;
     }
 
+    size_t cancel_callback_count() const { return pProfiler->m_cancel_callbacks.size(); }
+
     CallProfiler * pProfiler;
 }; /* end class CallProfilerTest */
 
@@ -204,6 +206,30 @@ TEST_F(CallProfilerTest, cancel)
     test1();
 
     EXPECT_EQ(radix_tree().get_unique_node(), 0);
+}
+
+TEST_F(CallProfilerTest, retire_cancel_callbacks)
+{
+    pProfiler->reset();
+
+    {
+        CallProfilerProbe outer(*pProfiler, "outer");
+        EXPECT_EQ(cancel_callback_count(), 1);
+
+        {
+            CallProfilerProbe inner(*pProfiler, "inner");
+            EXPECT_EQ(cancel_callback_count(), 2);
+        }
+
+        EXPECT_EQ(cancel_callback_count(), 1);
+    }
+
+    EXPECT_EQ(cancel_callback_count(), 0);
+
+    CallProfilerProbe active(*pProfiler, "active");
+    EXPECT_EQ(cancel_callback_count(), 1);
+    pProfiler->cancel();
+    EXPECT_EQ(cancel_callback_count(), 0);
 }
 
 } /* end namespace detail */


### PR DESCRIPTION
CallProfiler currently retains cancellation callbacks after their `CallProfilerProbe` instances have finished. A later cancellation can invoke a lambda that captures a destroyed probe, and AddressSanitizer reports a stack-use-after-return:

```cpp
auto & profiler = solvcon::CallProfiler::instance();
{
    solvcon::CallProfilerProbe completed(profiler, "completed");
}

solvcon::CallProfilerProbe active(profiler, "active");
profiler.cancel();
```

This change removes each callback when `end_caller()` retires its profiler frame, keeping cancellation registrations aligned with the active probe stack.

Related to #1188.
