### PR TITLE
Clarify profiler units and balance timed wrappers

### DIFF
--- a/cpp/solvcon/profiling/SerializableProfiler.hpp
+++ b/cpp/solvcon/profiling/SerializableProfiler.hpp
@@ -114,12 +114,14 @@ public:
     }
 
     MM_DECL_SERIALIZABLE(
+        register_member("time_unit", m_time_unit);
         register_member("radix_tree", m_root);
         register_member("id_map", m_id_map);
         register_member("unique_id", m_unique_id);)
 
 private:
 
+    std::string m_time_unit = "ns";
     SerializableRadixTreeNode m_root;
     std::unordered_map<std::string, key_type> m_id_map;
     key_type m_unique_id;

--- a/cpp/solvcon/profiling/pymod/wrap_profile.cpp
+++ b/cpp/solvcon/profiling/pymod/wrap_profile.cpp
@@ -114,6 +114,7 @@ pybind11::dict WrapCallProfiler::result(CallProfiler & profiler)
         return {};
     }
     py::dict result;
+    result["time_unit"] = "ms";
     std::queue<const RadixTreeNode<CallerProfile> *> node_queue;
     std::unordered_map<const RadixTreeNode<CallerProfile> *, py::dict> dict_storage;
 

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -85,6 +85,36 @@ private:
 
 }; /* end class WrapperProfilerStatus */
 
+class WrapperProfilerGuard
+{
+
+public:
+
+    WrapperProfilerGuard()
+        : m_enabled(WrapperProfilerStatus::me().enabled())
+    {
+    }
+
+    WrapperProfilerGuard(WrapperProfilerGuard const &) = delete;
+    WrapperProfilerGuard(WrapperProfilerGuard &&) = delete;
+    WrapperProfilerGuard & operator=(WrapperProfilerGuard const &) = delete;
+    WrapperProfilerGuard & operator=(WrapperProfilerGuard &&) = delete;
+
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    ~WrapperProfilerGuard()
+    {
+        if (m_enabled)
+        {
+            CallProfiler::instance().end_caller();
+        }
+    }
+
+private:
+
+    bool m_enabled;
+
+}; /* end class WrapperProfilerGuard */
+
 struct mmtag
 {
 }; /* end struct mmtag */
@@ -107,14 +137,6 @@ struct process_attribute<solvcon::python::mmtag>
         if (solvcon::python::WrapperProfilerStatus::me().enabled())
         {
             solvcon::CallProfiler::instance().start_caller(get_name(call), nullptr);
-        }
-    }
-
-    static void postcall(function_call &, handle &)
-    {
-        if (solvcon::python::WrapperProfilerStatus::me().enabled())
-        {
-            solvcon::CallProfiler::instance().end_caller();
         }
     }
 
@@ -281,11 +303,13 @@ public:
         return *static_cast<std::add_pointer_t<wrapper_type>>(this);          \
     }
 
+// ref: https://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard
 #define DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)                             \
     template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
     wrapper_type & METHOD##_timed(Args &&... args)                            \
     {                                                                         \
-        m_cls.METHOD(std::forward<Args>(args)..., mmtag());                   \
+        using guard_type = pybind11::call_guard<WrapperProfilerGuard>;        \
+        m_cls.METHOD(std::forward<Args>(args)..., mmtag(), guard_type());     \
         return *static_cast<std::add_pointer_t<wrapper_type>>(this);          \
     }
 

--- a/solvcon/pilot/panel/_profiling.py
+++ b/solvcon/pilot/panel/_profiling.py
@@ -76,7 +76,8 @@ class Profiling(_gui_common.PilotFeature):
         self._tree_view = QTreeView(self._table)
 
         self._model = QStandardItemModel(self._tree_view)
-        self._model.setHorizontalHeaderLabels(["Total Time", "Symbol Name"])
+        self._model.setHorizontalHeaderLabels(
+            ["Total Time (ms)", "Symbol Name"])
 
         def _recursive_add_item(
                 parent: QStandardItem,
@@ -270,7 +271,7 @@ class RunProfiling(_gui_common.PilotFeature):
 
         self._model = QStandardItemModel(self._tree_view)
         self._model.setHorizontalHeaderLabels(
-            ["Symbol Name", "Total Time", "Count"])
+            ["Symbol Name", "Total Time (ms)", "Count"])
 
         def _recursive_add_item(
                 parent: QStandardItem,

--- a/solvcon/profiling/_result.py
+++ b/solvcon/profiling/_result.py
@@ -137,7 +137,7 @@ class ProfilingResultPrinter:
 
     Each dictionary must contain at least the following keys:
         - "name": Name of the function (str)
-        - "total_time": Total execution time in seconds (float)
+        - "total_time": Total execution time in milliseconds (float)
         - "count": Number of times the function was called (int)
         - "children": A list of child profiling results (list)
 

--- a/tests/data/profiler_python_schema.json
+++ b/tests/data/profiler_python_schema.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "properties": {
+        "time_unit": {"const": "ms"},
         "name": {"type": "string"},
         "total_time": {"type": "number"},
         "count": {"type": "integer"},
@@ -22,7 +23,7 @@
             }
         }
     },
-    "required": ["name", "total_time", "count", "children"],
+    "required": ["time_unit", "name", "total_time", "count", "children"],
     "definitions": {
         "child": {
             "type": "object",

--- a/tests/test_callprofiler.py
+++ b/tests/test_callprofiler.py
@@ -58,6 +58,7 @@ class CallProfilerTC(unittest.TestCase):
         solvcon.call_profiler.reset()
         foo1()
         result = solvcon.call_profiler.result()
+        self.assertEqual(result["time_unit"], "ms")
 
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                             "data", "profiler_python_schema.json")
@@ -174,7 +175,7 @@ class CallProfilerTC(unittest.TestCase):
         solvcon.call_profiler.reset()
         sdict = json.loads(solvcon.call_profiler.serialize())
 
-        # There are 3 keys in the serialization_dict
+        self.assertEqual(sdict["time_unit"], "ns")
         self.assertEqual(sdict["id_map"], {})
         self.assertEqual(sdict["unique_id"], 0)
         self.assertIn("radix_tree", sdict)
@@ -200,9 +201,9 @@ class CallProfilerTC(unittest.TestCase):
         solvcon.call_profiler.reset()
         bar()
         foo()
+        result_children = solvcon.call_profiler.result()["children"]
         sdict = json.loads(solvcon.call_profiler.serialize())
 
-        # There are 3 keys in the serialization_dict
         self.assertEqual(sdict["id_map"], {'bar': 0, 'foo': 1})
         self.assertEqual(sdict["unique_id"], 3)
         self.assertIn("radix_tree", sdict)
@@ -222,6 +223,9 @@ class CallProfilerTC(unittest.TestCase):
         self.assertEqual(bar_child["name"], "bar")
         self.assertEqual(bar_child["call_count"], 1)
         self.assertGreaterEqual(bar_child["total_time"], 5e6)
+        self.assertEqual(
+            bar_child["total_time"] / 1e6,
+            result_children[0]["total_time"])
         self.assertEqual(bar_child["children"], [])
 
         foo_child = children[1]
@@ -250,7 +254,6 @@ class CallProfilerTC(unittest.TestCase):
             busy_loop(0.001)
             sdict = json.loads(solvcon.call_profiler.serialize())
 
-            # There are 3 keys in the serialization_dict
             self.assertEqual(sdict["id_map"], {})
             self.assertEqual(sdict["unique_id"], 0)
             self.assertIn("radix_tree", sdict)
@@ -305,5 +308,20 @@ class CallProfilerTC(unittest.TestCase):
         self.assertGreater(init_result["total_time"], 0)
         self.assertEqual(2, clone_result["count"])
         self.assertGreater(clone_result["total_time"], 0)
+
+    def test_wrapper_exception_keeps_profiler_balanced(self):
+        solvcon.wrapper_profiler_status.enable()
+        solvcon.call_profiler.reset()
+
+        with self.assertRaisesRegex(
+                ValueError, "size 1 must be a multiple of alignment 16"):
+            solvcon.ConcreteBuffer(1, alignment=16)
+
+        solvcon.ConcreteBuffer(16, alignment=16)
+        result = solvcon.call_profiler.result()
+        constructor = result["children"][0]
+        self.assertNotIn("current_node", constructor)
+        self.assertEqual(constructor["count"], 2)
+        self.assertEqual(constructor["children"], [])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`CallProfiler.result()` reports `total_time` in milliseconds while `CallProfiler.serialize()` reports it in nanoseconds, but neither output identifies its unit. This change adds `time_unit: "ms"` to `result()` and `time_unit: "ns"` to `serialize()` without changing either numeric representation, and labels millisecond values in the Python printer and Pilot UI.

Timed pybind11 wrappers start a profiler frame in `mmtag::precall()` and previously ended it in `postcall()`. pybind11 skips `postcall()` when the wrapped C++ call or return conversion throws, leaving the failed frame current and nesting later calls below it. This change moves frame retirement to a `pybind11::call_guard` destructor so successful and exceptional calls both balance the profiler stack while `precall()` still supplies the wrapper name.

Related to #1190.

Related to #1187.
