### PR TITLE
Give the Painter tool box its icons, labels, and shortcuts

### DIFF
--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -9,19 +9,20 @@
 #include <stdexcept>
 #include <vector>
 
-#include <solvcon/pilot/canvas/DrawTool.hpp>
-#include <solvcon/pilot/app/RAction.hpp>
-#include <solvcon/pilot/app/RMenuModel.hpp>
-#include <solvcon/pilot/app/RShortcutManager.hpp>
-#include <solvcon/pilot/theme/RThemeManager.hpp>
-#include <Qt>
-#include <QMenuBar>
-#include <QMenu>
 #include <QAction>
 #include <QActionGroup>
 #include <QColor>
+#include <QMenu>
+#include <QMenuBar>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <Qt>
+
+#include <solvcon/pilot/app/RAction.hpp>
+#include <solvcon/pilot/app/RMenuModel.hpp>
+#include <solvcon/pilot/app/RShortcutManager.hpp>
+#include <solvcon/pilot/canvas/DrawTool.hpp>
+#include <solvcon/pilot/theme/RThemeManager.hpp>
 
 namespace solvcon
 {
@@ -160,6 +161,18 @@ R2DWidget * RManager::add2DWidget()
     {
         viewer = new R2DWidget(/*parent*/ m_mdiArea);
         viewer->followTheme(m_themeManager);
+
+        if (m_menuModel)
+        {
+            for (std::string const & tool : draw_tool_names())
+            {
+                if (QAction * act = m_menuModel->action("draw.tool." + tool))
+                {
+                    viewer->addAction(act);
+                }
+            }
+        }
+
         viewer->setWindowTitle("2D canvas");
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);

--- a/cpp/solvcon/pilot/app/RManager.hpp
+++ b/cpp/solvcon/pilot/app/RManager.hpp
@@ -177,7 +177,7 @@ private:
 
     /**
      * Active canvas drawing tool, shared by every 2D canvas. Starts on
-     * the default tool (pan navigation).
+     * the default tool (select).
      */
     std::string m_draw_tool = default_draw_tool_name();
 }; /* end class RManager */

--- a/cpp/solvcon/pilot/app/RShortcutManager.cpp
+++ b/cpp/solvcon/pilot/app/RShortcutManager.cpp
@@ -86,14 +86,26 @@ Qt::Key toQtKey(Key key)
         return Qt::Key_F4;
     case Key::A:
         return Qt::Key_A;
+    case Key::C:
+        return Qt::Key_C;
     case Key::D:
         return Qt::Key_D;
+    case Key::E:
+        return Qt::Key_E;
     case Key::I:
         return Qt::Key_I;
+    case Key::L:
+        return Qt::Key_L;
     case Key::P:
         return Qt::Key_P;
+    case Key::R:
+        return Qt::Key_R;
     case Key::S:
         return Qt::Key_S;
+    case Key::T:
+        return Qt::Key_T;
+    case Key::V:
+        return Qt::Key_V;
     case Key::W:
         return Qt::Key_W;
     case Key::Z:

--- a/cpp/solvcon/pilot/app/keymap.cpp
+++ b/cpp/solvcon/pilot/app/keymap.cpp
@@ -39,6 +39,17 @@ std::vector<ShortcutBinding> sharedSeed()
 
         // Like VSCode, the pilot binds Console to physical Ctrl+Grave on every platform.
         {ShortcutCommand::Console, KeyChord{KeyMod::Control, Key::Grave}, ShortcutContext::Window},
+
+        // The draw tools take unmodified letters, as every drawing program
+        // does. Widget context is what makes that safe: the actions are added
+        // to each canvas, so a letter reaches a tool only while a canvas holds
+        // the keyboard and never while the user types in a field or a console.
+        {ShortcutCommand::DrawToolSelect, KeyChord{KeyMod::None, Key::V}, ShortcutContext::Widget},
+        {ShortcutCommand::DrawToolLine, KeyChord{KeyMod::None, Key::L}, ShortcutContext::Widget},
+        {ShortcutCommand::DrawToolTriangle, KeyChord{KeyMod::None, Key::T}, ShortcutContext::Widget},
+        {ShortcutCommand::DrawToolRectangle, KeyChord{KeyMod::None, Key::R}, ShortcutContext::Widget},
+        {ShortcutCommand::DrawToolEllipse, KeyChord{KeyMod::None, Key::E}, ShortcutContext::Widget},
+        {ShortcutCommand::DrawToolCircle, KeyChord{KeyMod::None, Key::C}, ShortcutContext::Widget},
     };
 }
 
@@ -99,6 +110,18 @@ std::string_view commandId(ShortcutCommand command)
         return "panel.painter";
     case ShortcutCommand::New2DCanvas:
         return "canvas.blank_2d";
+    case ShortcutCommand::DrawToolSelect:
+        return "draw.tool.select";
+    case ShortcutCommand::DrawToolLine:
+        return "draw.tool.line";
+    case ShortcutCommand::DrawToolTriangle:
+        return "draw.tool.triangle";
+    case ShortcutCommand::DrawToolRectangle:
+        return "draw.tool.rectangle";
+    case ShortcutCommand::DrawToolEllipse:
+        return "draw.tool.ellipse";
+    case ShortcutCommand::DrawToolCircle:
+        return "draw.tool.circle";
     }
     throw std::logic_error("Unexpected command");
 }

--- a/cpp/solvcon/pilot/app/keymap.hpp
+++ b/cpp/solvcon/pilot/app/keymap.hpp
@@ -88,10 +88,16 @@ enum class Key
     Space,
     F4,
     A,
+    C,
     D,
+    E,
     I,
+    L,
     P,
+    R,
     S,
+    T,
+    V,
     W,
     Z
 };
@@ -134,7 +140,13 @@ enum class ShortcutCommand
     AgentPanel,
     InspectorPanel,
     PainterPanel,
-    New2DCanvas
+    New2DCanvas,
+    DrawToolSelect,
+    DrawToolLine,
+    DrawToolTriangle,
+    DrawToolRectangle,
+    DrawToolEllipse,
+    DrawToolCircle
 };
 
 struct ShortcutBinding
@@ -159,7 +171,13 @@ inline constexpr auto ALL_SHORTCUT_COMMANDS = std::to_array<ShortcutCommand>(
      ShortcutCommand::AgentPanel,
      ShortcutCommand::InspectorPanel,
      ShortcutCommand::PainterPanel,
-     ShortcutCommand::New2DCanvas});
+     ShortcutCommand::New2DCanvas,
+     ShortcutCommand::DrawToolSelect,
+     ShortcutCommand::DrawToolLine,
+     ShortcutCommand::DrawToolTriangle,
+     ShortcutCommand::DrawToolRectangle,
+     ShortcutCommand::DrawToolEllipse,
+     ShortcutCommand::DrawToolCircle});
 
 struct ShortcutCapabilities
 {

--- a/cpp/solvcon/pilot/canvas/DrawTool.cpp
+++ b/cpp/solvcon/pilot/canvas/DrawTool.cpp
@@ -46,13 +46,13 @@ QPointF to_screen_qpoint(ViewTransform2dFp64 const & view, DrawPoint const & p)
     return QPointF(sx, sy);
 }
 
-/// The default navigation tool: a left-button drag pans and zooms the view instead of drawing.
-class PanTool : public DrawToolBase
+/// The default tool: a drag selects and edits a shape, or pans and zooms the view on empty space.
+class SelectTool : public DrawToolBase
 {
 
 public:
 
-    static constexpr char const * NAME = "pan";
+    static constexpr char const * NAME = "select";
 
     std::string name() const override { return NAME; }
 
@@ -64,7 +64,7 @@ protected:
 
     void paint_outline(QPainter &, ViewTransform2dFp64 const &, std::span<DrawPoint const>) const override {}
 
-}; /* end class PanTool */
+}; /* end class SelectTool */
 
 /// Circle defined by two gesture points: the center and a point on the rim.
 class CircleTool : public DrawToolBase
@@ -302,8 +302,8 @@ struct ToolEntry
 }; /* end struct ToolEntry */
 
 ToolEntry const TOOL_TABLE[] = {
-    {PanTool::NAME, []() -> std::unique_ptr<DrawToolBase>
-     { return std::make_unique<PanTool>(); }},
+    {SelectTool::NAME, []() -> std::unique_ptr<DrawToolBase>
+     { return std::make_unique<SelectTool>(); }},
     {LineTool::NAME, []() -> std::unique_ptr<DrawToolBase>
      { return std::make_unique<LineTool>(); }},
     {TriangleTool::NAME, []() -> std::unique_ptr<DrawToolBase>

--- a/cpp/solvcon/pilot/canvas/DrawTool.hpp
+++ b/cpp/solvcon/pilot/canvas/DrawTool.hpp
@@ -89,7 +89,7 @@ std::vector<std::string> const & draw_tool_names();
 
 /**
  * Name of the default tool a fresh canvas starts with: the first
- * registered tool, which is the pan navigation tool.
+ * registered tool, which is the select tool.
  *
  * @return The default tool name.
  */

--- a/cpp/solvcon/pilot/canvas/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.cpp
@@ -40,7 +40,7 @@ constexpr double MAX_ZOOM = 1.0e6;
 // world.
 constexpr double MIN_DRAW_DRAG_PX = 2.0;
 
-// Screen-pixel slop for picking a shape with the pan tool. Converted to a
+// Screen-pixel slop for picking a shape with the select tool. Converted to a
 // world tolerance through the current zoom so thin shapes stay selectable.
 constexpr double PICK_TOLERANCE_PX = 5.0;
 
@@ -120,7 +120,7 @@ void R2DWidget::setDrawTool(std::string const & name)
     m_drawing = false;
     m_selected = -1;
     m_drag = EditDrag::None;
-    // A crosshair signals draw mode; the pan tool keeps the default arrow.
+    // A crosshair signals draw mode; the select tool keeps the default arrow.
     if (m_tool->can_draw_shape())
     {
         setCursor(Qt::CrossCursor);
@@ -176,7 +176,7 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
     // Rubber-band preview of the shape currently being dragged, if any.
     paintDrawPreview(painter);
 
-    // Selection box and rotate handle for the pan tool, if any.
+    // Selection box and rotate handle for the select tool, if any.
     paintSelection(painter);
 }
 
@@ -372,7 +372,7 @@ void R2DWidget::mousePressEvent(QMouseEvent * event)
             event->accept();
             return;
         }
-        // Pan tool: rotate the selection, move a picked shape, or fall
+        // Select tool: rotate the selection, move a picked shape, or fall
         // back to panning the view on empty space.
         if (isOnRotateHandle(pos))
         {

--- a/cpp/solvcon/pilot/canvas/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.hpp
@@ -69,7 +69,7 @@ public:
     void setDrawTool(std::string const & name);
 
     /**
-     * Id of the shape selected with the pan tool, or -1 when none is selected.
+     * Id of the shape selected with the select tool, or -1 when none is selected.
      * Selection is cleared by switching tools or worlds.
      */
     int32_t selectedShape() const { return m_selected; }
@@ -162,13 +162,13 @@ private:
 
     /**
      * Paint the active tool's rubber-band preview while a drag is in progress;
-     * a no-op for the pan tool or when no drag is underway.
+     * a no-op for the select tool or when no drag is underway.
      */
     void paintDrawPreview(QPainter & painter) const;
 
     /**
      * Paint the selection box and rotate handle for the active selection; a
-     * no-op unless the pan tool has a live shape selected.
+     * no-op unless the select tool has a live shape selected.
      */
     void paintSelection(QPainter & painter) const;
 
@@ -200,7 +200,7 @@ private:
      */
     void finishEdit();
 
-    /// Which gesture the current pan-tool left-drag performs.
+    /// Which gesture the current select-tool left-drag performs.
     enum class EditDrag
     {
         None, ///< No left-drag in progress.
@@ -230,8 +230,8 @@ private:
     double m_draw_current_x = 0.0; ///< Live pointer, world coordinates.
     double m_draw_current_y = 0.0;
 
-    int32_t m_selected = -1; ///< Pan-tool selected shape id, or -1.
-    EditDrag m_drag = EditDrag::None; ///< Active pan-tool left-drag gesture.
+    int32_t m_selected = -1; ///< Select-tool selected shape id, or -1.
+    EditDrag m_drag = EditDrag::None; ///< Active select-tool left-drag gesture.
     double m_move_last_x = 0.0; ///< Previous pointer, world coordinates (Move).
     double m_move_last_y = 0.0;
     double m_rotate_cx = 0.0; ///< Rotation pivot, world coordinates (Rotate).

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -904,7 +904,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRMenuModel
 // Keep these ordinals aligned with tests/test_pilot_shortcut.py so a reorder
 // fails the C++ build instead of silently rebinding the wrong chord.
 static_assert(static_cast<unsigned>(KeyMod::Primary) == 1);
-static_assert(static_cast<int>(Key::Z) == 11);
+static_assert(static_cast<int>(Key::Z) == 17);
 
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
     : public WrapBase<WrapRManager, RManager>

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -18,6 +18,12 @@ namespace
 constexpr std::array<solvcon::PlatformId, 3> PLATFORMS = {
     solvcon::PlatformId::Linux, solvcon::PlatformId::Mac, solvcon::PlatformId::Windows};
 
+struct CommandChord
+{
+    solvcon::ShortcutCommand command;
+    solvcon::Key key;
+}; /* end struct CommandChord */
+
 } /* end namespace */
 
 TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
@@ -39,15 +45,10 @@ TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
                   (solvcon::KeyChord{solvcon::KeyMod::None, solvcon::Key::Escape}));
         EXPECT_EQ(reset->context, solvcon::ShortcutContext::Widget);
 
-        struct PanelChord
-        {
-            solvcon::ShortcutCommand command;
-            solvcon::Key key;
-        }; /* end struct PanelChord */
         for (auto const & panel : {
-                 PanelChord{solvcon::ShortcutCommand::AgentPanel, solvcon::Key::A},
-                 PanelChord{solvcon::ShortcutCommand::InspectorPanel, solvcon::Key::I},
-                 PanelChord{solvcon::ShortcutCommand::PainterPanel, solvcon::Key::P},
+                 CommandChord{solvcon::ShortcutCommand::AgentPanel, solvcon::Key::A},
+                 CommandChord{solvcon::ShortcutCommand::InspectorPanel, solvcon::Key::I},
+                 CommandChord{solvcon::ShortcutCommand::PainterPanel, solvcon::Key::P},
              })
         {
             auto const * binding = solvcon::bindingFor(platform, panel.command);
@@ -75,6 +76,28 @@ TEST(PilotKeymapTable, ConsoleSharesGraveAcrossPlatforms)
         ASSERT_NE(console, nullptr);
         EXPECT_EQ(std::get<solvcon::KeyChord>(console->key),
                   (solvcon::KeyChord{solvcon::KeyMod::Control, solvcon::Key::Grave}));
+    }
+}
+
+TEST(PilotKeymapTable, GivesEveryDrawToolAnUnmodifiedLetterInWidgetContext)
+{
+    for (auto platform : PLATFORMS)
+    {
+        for (auto const & tool : {
+                 CommandChord{solvcon::ShortcutCommand::DrawToolSelect, solvcon::Key::V},
+                 CommandChord{solvcon::ShortcutCommand::DrawToolLine, solvcon::Key::L},
+                 CommandChord{solvcon::ShortcutCommand::DrawToolTriangle, solvcon::Key::T},
+                 CommandChord{solvcon::ShortcutCommand::DrawToolRectangle, solvcon::Key::R},
+                 CommandChord{solvcon::ShortcutCommand::DrawToolEllipse, solvcon::Key::E},
+                 CommandChord{solvcon::ShortcutCommand::DrawToolCircle, solvcon::Key::C},
+             })
+        {
+            auto const * binding = solvcon::bindingFor(platform, tool.command);
+            ASSERT_NE(binding, nullptr) << solvcon::commandId(tool.command);
+            EXPECT_EQ(std::get<solvcon::KeyChord>(binding->key),
+                      (solvcon::KeyChord{solvcon::KeyMod::None, tool.key}));
+            EXPECT_EQ(binding->context, solvcon::ShortcutContext::Widget);
+        }
     }
 }
 

--- a/solvcon/pilot/canvas/_painter_gui.py
+++ b/solvcon/pilot/canvas/_painter_gui.py
@@ -7,6 +7,7 @@ Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from . import _painter_icons
 from ..base import _gui_common
 from .._pilot_core import draw_tool_names, default_draw_tool_name
 
@@ -14,6 +15,11 @@ __all__ = [
     'PainterPanel',
     'Painter',
 ]
+
+
+# Qt 6.6 added this event, and the theme backends still guard for older Qt.
+# Naming it in a class body would fail the import of the whole pilot there.
+_DPR_CHANGE_EVENT = getattr(QtCore.QEvent, 'DevicePixelRatioChange', None)
 
 
 def _rule(shape):
@@ -71,28 +77,108 @@ class _PaletteStyled(QtWidgets.QWidget):
         raise NotImplementedError
 
 
+def _tool_tip(action):
+    """The design's hover tip for a tool: its name, then its shortcut key."""
+    key = action.shortcut().toString(QtGui.QKeySequence.NativeText)
+    return f"{action.text()}  {key}" if key else action.text()
+
+
+class _SelectorEntry(QtWidgets.QToolButton):
+    """One selector entry: a stroke icon over its short name.
+
+    Qt re-reads a default action's text, icon, and tip whenever that action
+    changes, and picking a tool changes one. The short name and the tip survive
+    that as the action's own icon text and tool tip, but the tinted icon has
+    nowhere on the action to live: the Canvas menu shows the same action and
+    would then carry the icon too. So the entry keeps its icon and puts it back
+    after Qt has taken it away.
+    """
+
+    def __init__(self, width, icon_px, parent=None):
+        super().__init__(parent)
+        self._icon = QtGui.QIcon()
+        self.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
+        self.setIconSize(QtCore.QSize(icon_px, icon_px))
+        self.setFixedWidth(width)
+
+    def set_entry_icon(self, icon):
+        self._icon = icon
+        self.setIcon(icon)
+
+    def actionEvent(self, event):
+        super().actionEvent(event)
+        # setIcon always invalidates the layout, so only pay for it when Qt
+        # has actually replaced the icon.
+        if self.icon().cacheKey() != self._icon.cacheKey():
+            self.setIcon(self._icon)
+
+
+class _SelectorRule(QtWidgets.QWidget):
+    """A hairline grouping divider in the draw tool selector.
+
+    The design's breathing room above and below the line lives inside the
+    divider's own height, so the column layout keeps one spacing for every
+    child.
+    """
+
+    _WIDTH = 36
+    _MARGIN = 6
+    _MIX = 0.2
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setFixedSize(self._WIDTH, 2 * self._MARGIN + 1)
+
+    def paintEvent(self, _event):
+        painter = QtGui.QPainter(self)
+        painter.fillRect(0, self._MARGIN, self.width(), 1,
+                         _shade(self, self._MIX))
+
+
 class _DrawToolSelector(_PaletteStyled):
     """The tool column: flat entries on a shade of the inspector panel.
 
     The shade is painted rather than written into the widget's palette, because
     a palette color set from a palette-change handler is overwritten again as
     Qt finishes propagating the new palette into this widget, while painting
-    always reads the color that is current. The entries lose their button
-    bezel and the active tool wears the accent pill the design gives it; the
-    icons and the 9px labels arrive with the tool box itself.
+    always reads the color that is current. The entries lose their button bezel
+    and the active tool wears the accent pill the design gives it. Every color,
+    the icon strokes included, comes from the palette, so the column follows a
+    light/dark switch.
     """
+
+    # A column slot the model cannot back yet, as ``{name: (label, what it
+    # waits for)}``: shown at its designed place and greyed out.
+    _PLACEHOLDERS = {
+        "text": ("Text", "the text shape"),
+        "grid": ("Grid", "grid and snap options"),
+    }
 
     # How far the column shade sits from the inspector panel color, and how
     # far a hovered entry sits from the column.
     _SHADE_MIX = 0.06
     _HOVER_MIX = 0.12
 
+    # How far an entry's label moves back toward the column.
+    _LABEL_MIX = 0.25
+    _MUTED_MIX = 0.55
+
     # Column and entry geometry from the design, in device-independent pixels.
     _WIDTH = 64
     _ENTRY_WIDTH = 52
+    _ICON_PX = 17
+    _FONT_PX = 9
     _RADIUS = 7
     _GAP = 2
     _PAD_Y = 8
+
+    # The icons rasterize for the screen they are on, so a move between screens
+    # of different scale has to re-render them just as a theme switch does.
+    # Where Qt cannot report that move, the icons keep the scale they were
+    # rendered at until the next palette change.
+    _RESTYLE_EVENTS = (
+        _PaletteStyled._RESTYLE_EVENTS
+        + ((_DPR_CHANGE_EVENT,) if _DPR_CHANGE_EVENT is not None else ()))
 
     def __init__(self, tool_actions, short_labels, parent=None):
         """
@@ -105,51 +191,96 @@ class _DrawToolSelector(_PaletteStyled):
         """
         super().__init__(parent)
         self.buttons = {}
+        self.placeholders = {}
         self.setFixedWidth(self._WIDTH)
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, self._PAD_Y, 0, self._PAD_Y)
         layout.setSpacing(self._GAP)
-        for tool, action in tool_actions.items():
-            button = QtWidgets.QToolButton(self)
-            # The default action drives the button and reflects its checked
-            # state, so a menu radio and a button stay one selection.
-            button.setDefaultAction(action)
-            # The action's menu text is too wide for the column, so the button
-            # shows the short name and keeps the menu text as its tip.
-            button.setText(short_labels.get(tool, action.text()))
-            button.setFixedWidth(self._ENTRY_WIDTH)
-            button.setCursor(QtCore.Qt.PointingHandCursor)
-            layout.addWidget(button, 0, QtCore.Qt.AlignHCenter)
-            self.buttons[tool] = button
+        for index, (tool, action) in enumerate(tool_actions.items()):
+            # The registry lists the select tool first and the shape tools
+            # after it, which is the grouping the design rules apart.
+            if index == 1:
+                self._add_rule(layout)
+            self.buttons[tool] = self._add_tool(
+                layout, tool, action, short_labels.get(tool))
 
+        self._add_rule(layout)
+        self.placeholders["text"] = self._add_placeholder(layout, "text")
         layout.addStretch(1)
+        self.placeholders["grid"] = self._add_placeholder(layout, "grid")
         self._apply_style()
 
     def paintEvent(self, _event):
         painter = QtGui.QPainter(self)
         painter.fillRect(self.rect(), _shade(self, self._SHADE_MIX))
 
+    def _new_entry(self):
+        return _SelectorEntry(self._ENTRY_WIDTH, self._ICON_PX, self)
+
+    def _add_rule(self, layout):
+        layout.addWidget(_SelectorRule(self), 0, QtCore.Qt.AlignHCenter)
+
+    def _add_tool(self, layout, tool, action, short_label):
+        """Add one entry as a view of the shared ``tool`` action."""
+        entry = self._new_entry()
+        if short_label:
+            action.setIconText(short_label)
+        action.setToolTip(_tool_tip(action))
+        entry.setDefaultAction(action)
+        entry.setCursor(QtCore.Qt.PointingHandCursor)
+        layout.addWidget(entry, 0, QtCore.Qt.AlignHCenter)
+        return entry
+
+    def _add_placeholder(self, layout, name):
+        label, waits_for = self._PLACEHOLDERS[name]
+        entry = self._new_entry()
+        entry.setText(label)
+        entry.setToolTip(f"{label}  (needs {waits_for})")
+        entry.setEnabled(False)
+        layout.addWidget(entry, 0, QtCore.Qt.AlignHCenter)
+        return entry
+
     def _apply_style(self):
-        """Color the entries from the current palette."""
+        """Color the entries and their icons from the current palette."""
         palette = self.palette()
-        accent = palette.color(QtGui.QPalette.Highlight)
+        text = palette.color(QtGui.QPalette.WindowText)
+        panel = palette.color(QtGui.QPalette.Window)
+        label = _blend(text, panel, self._LABEL_MIX)
+        muted = _blend(text, panel, self._MUTED_MIX)
         on_accent = palette.color(QtGui.QPalette.HighlightedText)
+        # The disabled rule comes last so a greyed entry keeps its color even
+        # under the pointer, where the hover rule would otherwise light it up.
         self.setStyleSheet(f"""
             QToolButton {{
                 border: none;
                 border-radius: {self._RADIUS}px;
-                padding: 4px 0;
+                padding: 7px 0 6px;
+                font-size: {self._FONT_PX}px;
                 background: transparent;
-                color: {palette.color(QtGui.QPalette.WindowText).name()};
+                color: {label.name()};
             }}
             QToolButton:hover {{
                 background: {_shade(self, self._HOVER_MIX).name()};
+                color: {text.name()};
             }}
             QToolButton:checked {{
-                background: {accent.name()};
+                background: {palette.color(QtGui.QPalette.Highlight).name()};
                 color: {on_accent.name()};
             }}
+            QToolButton:disabled {{
+                background: transparent;
+                color: {muted.name()};
+            }}
             """)
+        ratio = self.devicePixelRatioF()
+        for name, entry in self.buttons.items():
+            # A tool the icon set does not draw yet keeps its label alone.
+            if name in _painter_icons.ICONS:
+                entry.set_entry_icon(_painter_icons.tool_icon(
+                    name, self._ICON_PX, label, on_accent, ratio))
+        for name, entry in self.placeholders.items():
+            entry.set_entry_icon(_painter_icons.placeholder_icon(
+                name, self._ICON_PX, muted, ratio))
 
 
 class _SegmentedTabs(_PaletteStyled):
@@ -226,11 +357,12 @@ class PainterPanel(QtWidgets.QWidget):
     """The Painter dock body: the draw tool selector left of the inspector.
 
     The selector holds one button per draw tool, each a view of the shared
-    ``draw.tool`` action the Canvas menu also shows. The inspector stacks the
+    ``draw.tool`` action the Canvas menu also shows, plus the greyed-out Text
+    and Grid slots the model cannot back yet. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
-    among them. The frame is at its designed widths; the tool icons and the
-    page contents arrive with the later steps of the redesign, so every page
-    is a greyed-out placeholder naming what it will hold.
+    among them. The frame is at its designed widths; the page contents arrive
+    with the later steps of the redesign, so every page is a greyed-out
+    placeholder naming what it will hold.
     """
 
     # The design's inspector width, in device-independent pixels. It is the
@@ -271,6 +403,11 @@ class PainterPanel(QtWidgets.QWidget):
     def tool_buttons(self):
         """The selector buttons as ``{tool id: QToolButton}``."""
         return self._tools.buttons
+
+    @property
+    def tool_placeholders(self):
+        """The greyed-out entries as ``{slot name: QToolButton}``."""
+        return self._tools.placeholders
 
     @property
     def tabs(self):
@@ -328,7 +465,7 @@ class Painter(_gui_common.PilotFeature):
     # come from the C++ registry; this only supplies human-facing text.
     # A tool with no entry here falls back to its title-cased id.
     TOOL_LABELS = {
-        "pan": "Pan / Move",
+        "select": "Select",
         "line": "Line",
         "triangle": "Triangle",
         "rectangle": "Rectangle",
@@ -339,7 +476,6 @@ class Painter(_gui_common.PilotFeature):
     # Button text for a tool whose menu label overflows the 64px selector.
     # The names are the design's; a tool with no entry keeps its menu label.
     SHORT_LABELS = {
-        "pan": "Pan",
         "triangle": "Tri",
         "rectangle": "Rect",
     }

--- a/solvcon/pilot/canvas/_painter_icons.py
+++ b/solvcon/pilot/canvas/_painter_icons.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Stroke icons for the Painter draw tool selector.
+
+The sources are inline strings rather than files or Qt resources, so the
+selector needs no packaging step and an installed solvcon carries its icons.
+Each body draws on the design's 16x16 grid and strokes ``currentColor``;
+:func:`render` substitutes the wanted color, because Qt's SVG profile has no
+CSS cascade to resolve that keyword on its own.
+"""
+
+from PySide6 import QtCore, QtGui, QtSvg
+
+__all__ = [
+    'ICONS',
+    'render',
+    'tool_icon',
+    'placeholder_icon',
+]
+
+_DOCUMENT = ('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"'
+             ' fill="none" stroke="currentColor" stroke-width="1.3">'
+             '{body}</svg>')
+
+#: Icon body per selector entry, keyed by draw-tool id where one exists.
+ICONS = {
+    # The select tool pans the view on empty space as well, but a cursor
+    # arrow reads as selection where a hand would read as navigation only.
+    "select": ('<path d="M4 2.5l8 5.2-3.6.9-1.6 3.4z"'
+               ' stroke-linejoin="round"/>'),
+    "line": ('<path d="M3 13L13 3"/><circle cx="3" cy="13" r="1.4"/>'
+             '<circle cx="13" cy="3" r="1.4"/>'),
+    "triangle": '<path d="M8 3l5 9.5H3z" stroke-linejoin="round"/>',
+    "rectangle": '<rect x="2.8" y="4" width="10.4" height="8"/>',
+    "ellipse": '<ellipse cx="8" cy="8" rx="6" ry="4.2"/>',
+    "circle": '<circle cx="8" cy="8" r="5.2"/>',
+    "text": '<path d="M3 4V2.8h10V4M8 2.8v10.4M6 13.2h4"/>',
+    "grid": ('<path d="M2 2h12v12H2z"/>'
+             '<path d="M2 6h12M6 2v12" opacity="0.6"/>'),
+}
+
+
+def render(name, color, size, ratio=1.0):
+    """The icon named ``name`` as a ``size``-px pixmap stroked in ``color``.
+
+    ``ratio`` is the device pixel ratio to rasterize for, so the strokes stay
+    crisp on a scaled screen.
+    """
+    source = _DOCUMENT.format(body=ICONS[name])
+    source = source.replace("currentColor", color.name())
+    renderer = QtSvg.QSvgRenderer(QtCore.QByteArray(source.encode("ascii")))
+    pixmap = QtGui.QPixmap(round(size * ratio), round(size * ratio))
+    pixmap.setDevicePixelRatio(ratio)
+    pixmap.fill(QtCore.Qt.transparent)
+    painter = QtGui.QPainter(pixmap)
+    # The target rectangle is in logical pixels, not the pixmap's own. A
+    # painter on a scaled pixmap already carries the ratio in its transform,
+    # while the viewport QSvgRenderer would default to is in device pixels, so
+    # letting it default draws the icon ``ratio`` times too large and clips it.
+    renderer.render(painter, QtCore.QRectF(0, 0, size, size))
+    painter.end()
+    return pixmap
+
+
+def tool_icon(name, size, off, on, ratio=1.0):
+    """The icon named ``name`` in the two appearances a tool entry shows.
+
+    The entry strokes ``off`` while its tool is inactive and ``on`` over the
+    accent pill while it is active. Qt picks between them by icon state, so
+    one QIcon covers both and the entry needs no repaint logic of its own.
+    """
+    icon = QtGui.QIcon()
+    icon.addPixmap(render(name, off, size, ratio),
+                   QtGui.QIcon.Normal, QtGui.QIcon.Off)
+    icon.addPixmap(render(name, on, size, ratio),
+                   QtGui.QIcon.Normal, QtGui.QIcon.On)
+    return icon
+
+
+def placeholder_icon(name, size, disabled, ratio=1.0):
+    """The icon named ``name`` in the one appearance a placeholder shows."""
+    icon = QtGui.QIcon()
+    icon.addPixmap(render(name, disabled, size, ratio), QtGui.QIcon.Disabled)
+    return icon
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -222,21 +222,21 @@ class R2DWidgetWorldTC(unittest.TestCase):
     def test_draw_tool_round_trip(self):
         """setDrawTool selects the tool the Painter toolbox drives; every
         registered tool reads back through the drawTool property, the
-        default is pan, and an unknown name is rejected with ValueError.
+        default is select, and an unknown name is rejected with ValueError.
         """
         from solvcon.pilot import _pilot_core
         # The Painter toolbox exposes one button per registered shape tool.
         self.assertLessEqual(
-            {"pan", "line", "triangle", "rectangle", "ellipse", "circle"},
+            {"select", "line", "triangle", "rectangle", "ellipse", "circle"},
             set(_pilot_core.draw_tool_names()))
         for tool in _pilot_core.draw_tool_names():
             self.widget.setDrawTool(tool)
             self.assertEqual(self.widget.drawTool, tool)
-        self.widget.setDrawTool("pan")
+        self.widget.setDrawTool("select")
         with self.assertRaises(ValueError):
             self.widget.setDrawTool("no-such-tool")
         # An invalid request leaves the previous tool untouched.
-        self.assertEqual(self.widget.drawTool, "pan")
+        self.assertEqual(self.widget.drawTool, "select")
 
     def test_selected_shape_defaults_to_none(self):
         """A fresh canvas has nothing selected; selectedShape reads -1."""
@@ -356,8 +356,8 @@ class R2DWidgetWorldTC(unittest.TestCase):
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
                  "live-GUI interaction needs a real window surface")
-class R2DWidgetPanSelectTC(unittest.TestCase):
-    """Drive the pan tool through select, move, rotate, and deselect."""
+class R2DWidgetSelectToolTC(unittest.TestCase):
+    """Drive the select tool through select, move, rotate, and deselect."""
 
     @classmethod
     def setUpClass(cls):
@@ -366,7 +366,7 @@ class R2DWidgetPanSelectTC(unittest.TestCase):
     def setUp(self):
         from PySide6 import QtWidgets
         self.widget = self.mgr.add2DWidget()
-        self.widget.setDrawTool("pan")
+        self.widget.setDrawTool("select")
         self.world = solvcon.WorldFp64()
         # A rectangle centered on the origin.
         self.sid = self.world.add_rectangle(-2, -1, 2, 1)
@@ -1063,14 +1063,14 @@ class PainterToolboxTC(unittest.TestCase):
 
     def test_create_blank_canvas_shows_toolbox(self):
         """'Create blank 2D canvas' opens an empty, focused canvas on the
-        Pan tool and brings up the Painter toolbox.
+        select tool and brings up the Painter toolbox.
         """
         from solvcon.pilot.canvas import _canvas_gui, _painter_gui
         painter = _painter_gui.Painter(mgr=self.mgr)
         canvas = _canvas_gui.Canvas(mgr=self.mgr, painter=painter)
         widget = canvas._create_blank_2d_canvas()
         self.assertIsNotNone(painter._dock)
-        self.assertEqual(widget.drawTool, "pan")
+        self.assertEqual(widget.drawTool, "select")
 
     def test_draw_across_blank_canvases(self):
         """The PR's manual test: create two blank canvases and rubber-band a
@@ -1104,7 +1104,8 @@ class PainterToolboxTC(unittest.TestCase):
                 _send_mouse(target, 'move', 110, 100)
                 _send_mouse(target, 'release', 110, 100)
                 QtWidgets.QApplication.processEvents()
-        self.assertIn(self.mgr.currentR2DWidget().drawTool, ("pan", "circle"))
+        self.assertIn(self.mgr.currentR2DWidget().drawTool,
+                      ("select", "circle"))
 
     def test_press_then_repaint_with_circle_tool_does_not_crash(self):
         """The zero-radius preview used to crash because the painter's pen
@@ -1149,7 +1150,7 @@ class PainterToolboxTC(unittest.TestCase):
         self.mgr.mdiArea.setActiveSubWindow(sub)
         target = sub.widget()
         QtWidgets.QApplication.processEvents()
-        # The non-pan tools, paired with the shape type each one commits.
+        # The shape tools, paired with the shape type each one commits.
         shapes = [("line", "line"), ("triangle", "triangle"),
                   ("rectangle", "rectangle"), ("ellipse", "ellipse"),
                   ("circle", "circle")]

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -11,6 +11,8 @@ try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
     from solvcon.pilot._pilot_core import draw_tool_names
+    from solvcon.pilot.canvas import _painter_icons
+    from PySide6 import QtGui, QtWidgets
 except ImportError:
     pilot = None
 
@@ -18,6 +20,50 @@ except ImportError:
 # Windows CI runner, whose WARP software rasterizer faults on one.
 NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+def _drawn_pixels(image):
+    """The (x, y) of every pixel an icon actually painted."""
+    return [(x, y)
+            for x in range(image.width())
+            for y in range(image.height())
+            if image.pixelColor(x, y).alpha() > 0]
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PainterIconTC(unittest.TestCase):
+    """The tool icons rasterize to the box they are asked for.
+
+    An unscaled test screen reports ratio 1, which hides the viewport trap
+    ``render`` guards against, so the ratio is driven explicitly here rather
+    than taken from wherever the suite happens to run.
+    """
+
+    _SIZE = 17
+
+    def setUp(self):
+        # No window needed, only a live QGuiApplication to hold a QPixmap.
+        pilot.RManager.instance.setUp()
+
+    def _ink(self, name, ratio):
+        """The bounding box of an icon's drawn pixels as (x0, y0, x1, y1)."""
+        image = _painter_icons.render(
+            name, QtGui.QColor("black"), self._SIZE, ratio).toImage()
+        marks = _drawn_pixels(image)
+        return (min(x for x, _y in marks), min(y for _x, y in marks),
+                max(x for x, _y in marks), max(y for _x, y in marks))
+
+    def test_icon_scales_with_the_device_pixel_ratio(self):
+        for name in _painter_icons.ICONS:
+            with self.subTest(name=name):
+                plain = self._ink(name, 1.0)
+                scaled = self._ink(name, 2.0)
+                # An icon drawn too large loses its far side, so the edge
+                # checks below are the half that catches a bad viewport.
+                for flat, deep in zip(plain, scaled):
+                    self.assertAlmostEqual(deep, 2 * flat, delta=2)
+                self.assertLess(scaled[2], 2 * self._SIZE - 1)
+                self.assertLess(scaled[3], 2 * self._SIZE - 1)
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
@@ -55,7 +101,7 @@ class DrawToolTC(unittest.TestCase):
         self.assertTrue(
             panel.tool_buttons["line"].defaultAction().isChecked())
         self.assertFalse(
-            panel.tool_buttons["pan"].defaultAction().isChecked())
+            panel.tool_buttons["select"].defaultAction().isChecked())
 
     def test_console_set_draw_tool_checks_the_menu(self):
         self.mgr.setDrawTool("rectangle")
@@ -99,6 +145,85 @@ class DrawToolTC(unittest.TestCase):
         self.assertTrue(panel.tabs["Layers"].isChecked())
         # The panel outlives the test, so leave it on the default page.
         panel.show_page("Design")
+
+    def test_selector_entries_carry_a_tinted_icon_and_the_short_name(self):
+        panel = self._panel()
+        selector = panel._tools
+        for tool, button in panel.tool_buttons.items():
+            with self.subTest(tool=tool):
+                self.assertFalse(button.icon().isNull())
+                self.assertEqual(button.iconSize().width(), selector._ICON_PX)
+                self.assertEqual(button.width(), selector._ENTRY_WIDTH)
+        # Select keeps its menu label because it fits; Triangle does not, and
+        # that is what the short name is for.
+        self.assertEqual(panel.tool_buttons["select"].text(), "Select")
+        self.assertEqual(
+            self.model.action("draw.tool.select").text(), "Select")
+        self.assertEqual(panel.tool_buttons["triangle"].text(), "Tri")
+        self.assertEqual(
+            self.model.action("draw.tool.triangle").text(), "Triangle")
+
+    def test_selector_entry_survives_a_tool_switch(self):
+        # Pins the icon and short name that _SelectorEntry restores after Qt
+        # re-reads them from the action.
+        panel = self._panel()
+        button = panel.tool_buttons["rectangle"]
+        self.model.action("draw.tool.rectangle").trigger()
+        QtWidgets.QApplication.processEvents()
+        self.assertEqual(button.text(), "Rect")
+        self.assertFalse(button.icon().isNull())
+
+    def test_selector_tip_names_the_tool_and_its_key(self):
+        panel = self._panel()
+        for tool, key in (("line", "L"), ("circle", "C")):
+            with self.subTest(tool=tool):
+                action = panel.tool_buttons[tool].defaultAction()
+                self.assertEqual(
+                    action.shortcut().toString(QtGui.QKeySequence.NativeText),
+                    key)
+                self.assertEqual(action.toolTip(), f"{action.text()}  {key}")
+
+    def test_tool_placeholders_are_visible_but_greyed_out(self):
+        # The Text entry and the Grid toggle hold their designed places so the
+        # column matches the design; their contents wait on the model.
+        panel = self._panel()
+        self.assertEqual(set(panel.tool_placeholders), {"text", "grid"})
+        for name, button in panel.tool_placeholders.items():
+            with self.subTest(name=name):
+                self.assertFalse(button.isEnabled())
+                self.assertFalse(button.icon().isNull())
+                self.assertIn("needs", button.toolTip())
+        self.assertEqual(panel.tool_placeholders["text"].text(), "Text")
+        self.assertEqual(panel.tool_placeholders["grid"].text(), "Grid")
+
+    def test_grid_toggle_is_pinned_below_the_tools(self):
+        # The design parks the Grid toggle at the column bottom, away from the
+        # tools, so it sits after the layout's stretch rather than under Text.
+        panel = self._panel()
+        layout = panel._tools.layout()
+        items = [layout.itemAt(i) for i in range(layout.count())]
+        self.assertIs(items[-1].widget(), panel.tool_placeholders["grid"])
+        self.assertIsNone(items[-2].widget())
+
+    def test_selector_icons_retint_with_the_theme(self):
+        # A colour captured once would survive a theme switch as is.
+        panel = self._panel()
+        button = panel.tool_buttons["circle"]
+        size = panel._tools._ICON_PX
+
+        def stroke():
+            image = button.icon().pixmap(size, size).toImage()
+            return max(image.pixelColor(x, y).lightness()
+                       for x, y in _drawn_pixels(image))
+
+        try:
+            self.mgr.set_theme("light")
+            light = stroke()
+            self.mgr.set_theme("dark")
+            dark = stroke()
+        finally:
+            self.mgr.set_theme("system")
+        self.assertGreater(dark, light)
 
     def test_selector_shade_follows_the_theme(self):
         # The selector paints its own shade of the panel colour. Reading it

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -11,10 +11,20 @@ try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
     from solvcon.pilot.base import _gui_common
-    from PySide6 import QtCore, QtGui
+    from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pilot = None
     QtGui = None
+
+# QtTest is its own PySide6 extension, and the macOS CI job rewrites the Qt
+# rpath of QtCore, QtGui, and QtWidgets only, so importing it there fails.
+# Keeping it out of the block above stops that from unbinding pilot for the
+# whole module, which would fail every test in the file rather than skipping
+# the two that need live key delivery.
+try:
+    from PySide6.QtTest import QTest
+except ImportError:
+    QTest = None
 
 # The offscreen platform cannot back a live window; neither can the headless
 # Windows CI runner, whose WARP software rasterizer faults on one.
@@ -24,12 +34,21 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
 # KeyMod::Primary and Key::Z ordinals from keymap.hpp, passed to
 # shortcut_conflicts_rebinding; a static_assert in wrap_pilot.cpp pins them.
 _KEYMOD_PRIMARY = 1
-_KEY_Z = 11
+_KEY_Z = 17
 
 _PANEL_CHORDS = (
     ("panel.agent_console", ["Ctrl+Shift+A"]),
     ("panel.inspector", ["Ctrl+Shift+I"]),
     ("panel.painter", ["Ctrl+Shift+P"]),
+)
+
+_DRAW_TOOL_KEYS = (
+    ("select", "V"),
+    ("line", "L"),
+    ("triangle", "T"),
+    ("rectangle", "R"),
+    ("ellipse", "E"),
+    ("circle", "C"),
 )
 
 if QtGui is not None:
@@ -39,6 +58,20 @@ if QtGui is not None:
         "file.exit": QtGui.QKeySequence.StandardKey.Quit,
         "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
     }
+
+
+def _can_take_keyboard(widget):
+    """Whether the platform will hand ``widget`` the keyboard.
+
+    A run whose terminal stays frontmost never gets an active window, and
+    activateWindow cannot argue with that. Probe it so a test needing real key
+    delivery skips instead of failing for a reason unrelated to the code.
+    """
+    widget.window().activateWindow()
+    widget.window().raise_()
+    widget.setFocus()
+    QtWidgets.QApplication.processEvents()
+    return widget.hasFocus() and widget.isActiveWindow()
 
 
 def _live_sequences(action):
@@ -102,6 +135,16 @@ class ShortcutResolutionTC(unittest.TestCase):
                 self.assertTrue(r["known"])
                 self.assertTrue(r["bound"])
                 self.assertEqual(r["sequences"], sequences)
+
+    def test_draw_tools_resolve_to_unmodified_letters(self):
+        for tool, key in _DRAW_TOOL_KEYS:
+            with self.subTest(tool=tool):
+                r = self.mgr.resolve_shortcut("draw.tool." + tool)
+                self.assertTrue(r["known"])
+                self.assertTrue(r["bound"])
+                self.assertFalse(r["standard"])
+                self.assertEqual(r["sequences"], [key])
+                self.assertEqual(r["context"], "widget")
 
     def test_new_2d_canvas_resolves_to_new(self):
         r = self.mgr.resolve_shortcut("canvas.blank_2d")
@@ -221,6 +264,12 @@ class ShortcutTC(unittest.TestCase):
         self._assert_action_matches_resolved(
             "canvas.blank_2d", QtCore.Qt.WindowShortcut)
 
+    def test_draw_tool_actions_carry_the_resolved_bindings(self):
+        for tool, _key in _DRAW_TOOL_KEYS:
+            with self.subTest(tool=tool):
+                self._assert_action_matches_resolved(
+                    "draw.tool." + tool, QtCore.Qt.WidgetShortcut)
+
     def test_exit_action_carries_quit_and_platform_role(self):
         self._assert_action_matches_resolved(
             "file.exit", QtCore.Qt.ApplicationShortcut)
@@ -259,6 +308,56 @@ class ApplyShortcutHelperTC(unittest.TestCase):
         self.assertEqual(act.shortcutContext(),
                          QtCore.Qt.ApplicationShortcut)
         self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None,
+                 "live key delivery needs a real window surface and QtTest")
+class DrawToolShortcutTC(unittest.TestCase):
+    """The draw-tool letters reach a focused canvas and nothing else."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.mgr.add2DWidget()
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        self.target = self.sub.widget()
+        self.mgr.setDrawTool("select")
+        QtWidgets.QApplication.processEvents()
+
+    def _type(self, widget, key):
+        if not _can_take_keyboard(widget):
+            self.skipTest("the platform did not grant the keyboard")
+        QTest.keyClick(widget, key)
+        QtWidgets.QApplication.processEvents()
+
+    def test_canvas_carries_every_draw_tool_action(self):
+        names = {a.objectName() for a in self.target.actions()}
+        for tool, _key in _DRAW_TOOL_KEYS:
+            self.assertIn("draw.tool." + tool, names)
+
+    def test_letter_on_a_focused_canvas_picks_its_tool(self):
+        for tool, key in _DRAW_TOOL_KEYS:
+            with self.subTest(tool=tool):
+                # Start from a tool the letter is not for, so a key that never
+                # arrived cannot pass by leaving the choice as it was.
+                self.mgr.setDrawTool(
+                    "select" if "circle" == tool else "circle")
+                self._type(self.target, getattr(QtCore.Qt, "Key_" + key))
+                self.assertEqual(self.mgr.drawTool, tool)
+
+    def test_letter_typed_in_a_text_field_stays_in_the_field(self):
+        edit = QtWidgets.QLineEdit(self.mgr.mainWindow)
+        edit.show()
+        try:
+            self.mgr.setDrawTool("line")
+            self._type(edit, QtCore.Qt.Key_R)
+            self.assertEqual(self.mgr.drawTool, "line")
+            self.assertEqual(edit.text(), "r")
+        finally:
+            edit.setParent(None)
+            edit.deleteLater()
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Painter tool rail now looks the way the redesign draws it: 52px entries with a 17px stroke icon over a 9px label, an accent pill on the active tool, and rules grouping the select tool, the shape tools, and the text slot apart. Hover tips name the tool and its key. The Text entry and the Grid toggle sit in their designed places greyed out until the model can back them.

The icons are inline SVG strings in a new `_painter_icons` module, so nothing needs packaging. They take their colors from the application palette and are rasterized again on a palette or screen-scale change, so the rail follows a light/dark switch.

The six draw tools also get unmodified letter shortcuts: Select V, Line L, Tri T, Rect R, Ellipse E, Circle C. They use widget context and are attached to each canvas, so a letter reaches a tool only while a canvas holds the keyboard and never while the user is typing in a field or a console.

Finally, the first tool is renamed from pan to select. It has always both selected shapes and panned the view, and only its label said so, so the id, the class, the keymap command, the objectName, and the menu label now all say select. Panning keeps its name wherever it means moving the view. Anyone with scripts should note that `setDrawTool("pan")` must now say `setDrawTool("select")`.

Related to #1175.
