### PR TITLE
Show the selection on the Painter inspector's Design page

### DIFF
--- a/solvcon/pilot/canvas/_painter_design.py
+++ b/solvcon/pilot/canvas/_painter_design.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The Design page of the Painter inspector: what is selected and where it sits.
+"""
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from . import _painter_icons
+from ._painter_style import blend, shade, PaletteStyled
+
+__all__ = [
+    'DesignPage',
+]
+
+
+def _mono_font():
+    """The stand-in for the mono font the design gives every number."""
+    return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
+
+
+class DesignPage(PaletteStyled):
+    """The inspector's Design page: what the canvas has selected.
+
+    The page reads the canvas it is bound to on a timer, because the world
+    changes in C++ without a change signal. What the poll compares is the
+    selection itself, which is both what the page shows and cheap enough to
+    read every tick.
+    """
+
+    # Poll period in milliseconds, the cadence the entity tree already uses.
+    # The timer runs only while the page is on screen, so a hidden dock or
+    # another inspector tab costs nothing.
+    _POLL_MS = 500
+
+    #: The header text while nothing is selected.
+    EMPTY_TEXT = "Nothing selected"
+
+    _ICON_PX = 13
+    _MARGINS = (12, 11, 12, 11)
+    _GAP = 10
+    _HEADER_GAP = 8
+    _NAME_PX = 12
+    _SMALL_PX = 10
+
+    # How far the muted text and the badge sit from the panel color.
+    _MUTED_MIX = 0.35
+    _BADGE_MIX = 0.15
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._source = None
+        self._key = None
+        self._icon_name = None
+        self._build()
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self._POLL_MS)
+        self._timer.timeout.connect(self.refresh)
+        self._apply_style()
+        self._render()
+
+    def set_canvas_source(self, source):
+        """Bind the page to ``source``, a callable handing back the canvas.
+
+        The callable returns the 2D canvas to read, or ``None`` when none is
+        active. The canvas is asked for on every read rather than held,
+        because it is a C++ widget owned by its sub-window: a reference kept
+        across the window's close outlives the object behind it, and the next
+        read walks freed memory.
+        """
+        self._source = source
+        # Rendered rather than refreshed: a canvas with nothing selected and
+        # no canvas at all share a poll key, so a refresh would take the page
+        # for unchanged and leave the previous canvas's selection on screen.
+        self._key = self._state_key()
+        self._render()
+
+    def showEvent(self, event):
+        """Poll the bound canvas only while the page is on screen."""
+        super().showEvent(event)
+        self.refresh()
+        self._timer.start()
+
+    def hideEvent(self, event):
+        """Stop polling once the page leaves the screen."""
+        super().hideEvent(event)
+        self._timer.stop()
+
+    def refresh(self):
+        """Redraw the page when the canvas it is bound to has changed."""
+        key = self._state_key()
+        if key == self._key:
+            return
+        self._key = key
+        self._render()
+
+    def _build(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_selection())
+        layout.addStretch(1)
+
+    def _build_selection(self):
+        """The selection header: the shape's icon, name, and count badge."""
+        block = QtWidgets.QWidget(self)
+        self._icon = QtWidgets.QLabel(block)
+        self._name = QtWidgets.QLabel(block)
+        self._name.setObjectName("name")
+        self._badge = QtWidgets.QLabel("1 selected", block)
+        self._badge.setObjectName("badge")
+        self._badge.setFont(_mono_font())
+        header = QtWidgets.QHBoxLayout()
+        header.setSpacing(self._HEADER_GAP)
+        header.addWidget(self._icon)
+        header.addWidget(self._name)
+        header.addStretch(1)
+        header.addWidget(self._badge)
+        layout = QtWidgets.QVBoxLayout(block)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        layout.addLayout(header)
+        return block
+
+    def _canvas(self):
+        """The 2D canvas to read, or ``None`` when none is active."""
+        return None if self._source is None else self._source()
+
+    def _state_key(self):
+        """What the page shows, as a value the poll can compare.
+
+        The key is read from the selection alone, which is all the page
+        shows. A world-wide fingerprint would cost a full serialization every
+        tick and still miss a plain selection click, which moves no geometry.
+        """
+        _widget, world, shape = self._selection()
+        return None if world is None else (shape, world.shape_type_of(shape))
+
+    def _selection(self):
+        """The active canvas, its world, and its live selection.
+
+        ``selectedShape`` hands back the stored id without checking it, so a
+        shape that was removed or undone away leaves a stale id behind and the
+        queries the page runs on it would throw. Such a selection reads here
+        as none at all.
+        """
+        widget = self._canvas()
+        world = None if widget is None else widget.world
+        if world is None or not world.shape_is_live(widget.selectedShape):
+            return widget, None, -1
+        return widget, world, widget.selectedShape
+
+    def _render(self):
+        _widget, world, shape = self._selection()
+        if world is None:
+            self._icon_name = None
+            self._name.setText(self.EMPTY_TEXT)
+            self._badge.setVisible(False)
+        else:
+            kind = world.shape_type_of(shape)
+            self._icon_name = kind if kind in _painter_icons.ICONS else None
+            self._name.setText(f"{kind.title()} {shape}")
+            self._badge.setVisible(True)
+        self._show_icon()
+
+    def _show_icon(self):
+        """Draw the selection's shape icon in the accent color."""
+        if self._icon_name is None:
+            self._icon.clear()
+            self._icon.setVisible(False)
+            return
+        self._icon.setPixmap(_painter_icons.render(
+            self._icon_name, self.palette().color(QtGui.QPalette.Highlight),
+            self._ICON_PX, self.devicePixelRatioF()))
+        self._icon.setVisible(True)
+
+    def _apply_style(self):
+        """Color the header and the badge from the palette."""
+        palette = self.palette()
+        muted = blend(palette.color(QtGui.QPalette.WindowText),
+                      palette.color(QtGui.QPalette.Window), self._MUTED_MIX)
+        self.setStyleSheet(f"""
+            QLabel#name {{
+                font-size: {self._NAME_PX}px;
+            }}
+            QLabel#badge {{
+                border-radius: 4px;
+                padding: 2px 6px;
+                font-size: {self._SMALL_PX}px;
+                background: {shade(self, self._BADGE_MIX).name()};
+                color: {muted.name()};
+            }}
+            """)
+        self._show_icon()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/canvas/_painter_gui.py
+++ b/solvcon/pilot/canvas/_painter_gui.py
@@ -8,6 +8,8 @@ Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
+from ._painter_design import DesignPage
+from ._painter_style import blend, rule, shade, PaletteStyled
 from ..base import _gui_common
 from .._pilot_core import draw_tool_names, default_draw_tool_name
 
@@ -15,66 +17,6 @@ __all__ = [
     'PainterPanel',
     'Painter',
 ]
-
-
-# Qt 6.6 added this event, and the theme backends still guard for older Qt.
-# Naming it in a class body would fail the import of the whole pilot there.
-_DPR_CHANGE_EVENT = getattr(QtCore.QEvent, 'DevicePixelRatioChange', None)
-
-
-def _rule(shape):
-    """A hairline divider between two areas of the panel."""
-    line = QtWidgets.QFrame()
-    line.setFrameShape(shape)
-    line.setFrameShadow(QtWidgets.QFrame.Sunken)
-    return line
-
-
-def _blend(color, other, ratio):
-    """Mix ``ratio`` of ``other`` into ``color``."""
-    keep = 1.0 - ratio
-    return QtGui.QColor(
-        round(color.red() * keep + other.red() * ratio),
-        round(color.green() * keep + other.green() * ratio),
-        round(color.blue() * keep + other.blue() * ratio))
-
-
-def _shade(widget, ratio):
-    """The panel color of ``widget`` moved ``ratio`` toward its text color.
-
-    Blending toward the text is what makes a shade follow the theme: it steps
-    darker under a light palette and lighter under a dark one, which is how the
-    design separates the selector from the inspector and the checked tab from
-    both.
-    """
-    palette = widget.palette()
-    return _blend(palette.color(QtGui.QPalette.Window),
-                  palette.color(QtGui.QPalette.WindowText), ratio)
-
-
-class _PaletteStyled(QtWidgets.QWidget):
-    """A widget whose child controls are styled from the palette.
-
-    A subclass builds its style sheet in :meth:`_apply_style` and calls it once
-    its children exist; the base re-applies it whenever the application palette
-    changes, so the piece follows a light/dark switch.
-    """
-
-    # Both palette events matter. The theme manager pairs a new application
-    # palette with a fresh global style sheet, whose re-polish arrives here as
-    # PaletteChange; under the system look it sets the palette alone, and
-    # ApplicationPaletteChange is what carries that.
-    _RESTYLE_EVENTS = (QtCore.QEvent.PaletteChange,
-                       QtCore.QEvent.ApplicationPaletteChange)
-
-    def event(self, event):
-        if event.type() in self._RESTYLE_EVENTS:
-            self._apply_style()
-            self.update()
-        return super().event(event)
-
-    def _apply_style(self):
-        raise NotImplementedError
 
 
 def _tool_tip(action):
@@ -132,10 +74,10 @@ class _SelectorRule(QtWidgets.QWidget):
     def paintEvent(self, _event):
         painter = QtGui.QPainter(self)
         painter.fillRect(0, self._MARGIN, self.width(), 1,
-                         _shade(self, self._MIX))
+                         shade(self, self._MIX))
 
 
-class _DrawToolSelector(_PaletteStyled):
+class _DrawToolSelector(PaletteStyled):
     """The tool column: flat entries on a shade of the inspector panel.
 
     The shade is painted rather than written into the widget's palette, because
@@ -172,14 +114,6 @@ class _DrawToolSelector(_PaletteStyled):
     _GAP = 2
     _PAD_Y = 8
 
-    # The icons rasterize for the screen they are on, so a move between screens
-    # of different scale has to re-render them just as a theme switch does.
-    # Where Qt cannot report that move, the icons keep the scale they were
-    # rendered at until the next palette change.
-    _RESTYLE_EVENTS = (
-        _PaletteStyled._RESTYLE_EVENTS
-        + ((_DPR_CHANGE_EVENT,) if _DPR_CHANGE_EVENT is not None else ()))
-
     def __init__(self, tool_actions, short_labels, parent=None):
         """
         :param tool_actions: The draw tools as ``{tool id: QAction}`` in
@@ -212,7 +146,7 @@ class _DrawToolSelector(_PaletteStyled):
 
     def paintEvent(self, _event):
         painter = QtGui.QPainter(self)
-        painter.fillRect(self.rect(), _shade(self, self._SHADE_MIX))
+        painter.fillRect(self.rect(), shade(self, self._SHADE_MIX))
 
     def _new_entry(self):
         return _SelectorEntry(self._ENTRY_WIDTH, self._ICON_PX, self)
@@ -245,8 +179,8 @@ class _DrawToolSelector(_PaletteStyled):
         palette = self.palette()
         text = palette.color(QtGui.QPalette.WindowText)
         panel = palette.color(QtGui.QPalette.Window)
-        label = _blend(text, panel, self._LABEL_MIX)
-        muted = _blend(text, panel, self._MUTED_MIX)
+        label = blend(text, panel, self._LABEL_MIX)
+        muted = blend(text, panel, self._MUTED_MIX)
         on_accent = palette.color(QtGui.QPalette.HighlightedText)
         # The disabled rule comes last so a greyed entry keeps its color even
         # under the pointer, where the hover rule would otherwise light it up.
@@ -260,7 +194,7 @@ class _DrawToolSelector(_PaletteStyled):
                 color: {label.name()};
             }}
             QToolButton:hover {{
-                background: {_shade(self, self._HOVER_MIX).name()};
+                background: {shade(self, self._HOVER_MIX).name()};
                 color: {text.name()};
             }}
             QToolButton:checked {{
@@ -283,7 +217,7 @@ class _DrawToolSelector(_PaletteStyled):
                 name, self._ICON_PX, muted, ratio))
 
 
-class _SegmentedTabs(_PaletteStyled):
+class _SegmentedTabs(PaletteStyled):
     """The Design / Layers / Canvas selector as one segmented control.
 
     Qt has no segmented control, so the row is flat checkable buttons styled
@@ -332,7 +266,7 @@ class _SegmentedTabs(_PaletteStyled):
         palette = self.palette()
         panel = palette.color(QtGui.QPalette.Window)
         text = palette.color(QtGui.QPalette.WindowText)
-        pill = _shade(self, self._PILL_MIX)
+        pill = shade(self, self._PILL_MIX)
         self.setStyleSheet(f"""
             QPushButton {{
                 border: none;
@@ -340,7 +274,7 @@ class _SegmentedTabs(_PaletteStyled):
                 padding: 5px 0;
                 font-size: {self._FONT_PX}px;
                 background: transparent;
-                color: {_blend(text, panel, self._LABEL_MIX).name()};
+                color: {blend(text, panel, self._LABEL_MIX).name()};
             }}
             QPushButton:hover {{
                 color: {text.name()};
@@ -360,9 +294,9 @@ class PainterPanel(QtWidgets.QWidget):
     ``draw.tool`` action the Canvas menu also shows, plus the greyed-out Text
     and Grid slots the model cannot back yet. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
-    among them. The frame is at its designed widths; the page contents arrive
-    with the later steps of the redesign, so every page is a greyed-out
-    placeholder naming what it will hold.
+    among them, and hands the active canvas to whichever page reads one. The
+    Layers and Canvas pages arrive with the later steps of the redesign, so
+    each is still a greyed-out placeholder naming what it will hold.
     """
 
     # The design's inspector width, in device-independent pixels. It is the
@@ -370,12 +304,14 @@ class PainterPanel(QtWidgets.QWidget):
     # room to the inspector instead of leaving bands beside the panel.
     _INSPECTOR_WIDTH = 264
 
-    #: Inspector pages as ``(name, placeholder)``, in tab order.
-    PAGES = (
-        ("Design", "Selection, position, stroke, fill, and grid controls"),
-        ("Layers", "Object list, filters, and visibility"),
-        ("Canvas", "View, grid, axes, background, and units"),
-    )
+    #: Inspector page names, in tab order.
+    PAGES = ("Design", "Layers", "Canvas")
+
+    # What a page yet to be built says it will hold.
+    _PLACEHOLDERS = {
+        "Layers": "Object list, filters, and visibility",
+        "Canvas": "View, grid, axes, background, and units",
+    }
 
     def __init__(self, tool_actions, short_labels=None, parent=None):
         """
@@ -389,14 +325,15 @@ class PainterPanel(QtWidgets.QWidget):
         super().__init__(parent)
         self._tools = _DrawToolSelector(tool_actions, short_labels or {}, self)
         self._stack = QtWidgets.QStackedWidget()
-        self._tabs = _SegmentedTabs([name for name, _text in self.PAGES])
+        self._design = DesignPage(self._stack)
+        self._tabs = _SegmentedTabs(self.PAGES)
         self._tabs.selected.connect(self.show_page)
         self._inspector = self._build_inspector()
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self._tools)
-        layout.addWidget(_rule(QtWidgets.QFrame.VLine))
+        layout.addWidget(rule(QtWidgets.QFrame.VLine))
         layout.addWidget(self._inspector, 1)
 
     @property
@@ -414,17 +351,32 @@ class PainterPanel(QtWidgets.QWidget):
         """The inspector tab buttons as ``{page name: QPushButton}``."""
         return self._tabs.buttons
 
+    @property
+    def design(self):
+        """The Design page."""
+        return self._design
+
+    def set_canvas_source(self, source):
+        """Tell the inspector how to reach the active 2D canvas."""
+        self._design.set_canvas_source(source)
+
+    def refresh(self):
+        """Re-read the active canvas now, without waiting for a poll."""
+        self._design.refresh()
+
     def _build_inspector(self):
         """Build the tab row over the stack of pages."""
-        for _name, placeholder in self.PAGES:
-            self._stack.addWidget(self._build_page(placeholder))
+        for name in self.PAGES:
+            waiting = self._PLACEHOLDERS.get(name)
+            self._stack.addWidget(self._design if waiting is None
+                                  else self._build_page(waiting))
         inspector = QtWidgets.QWidget(self)
         inspector.setMinimumWidth(self._INSPECTOR_WIDTH)
         layout = QtWidgets.QVBoxLayout(inspector)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self._tabs)
-        layout.addWidget(_rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(rule(QtWidgets.QFrame.HLine))
         layout.addWidget(self._stack, 1)
         return inspector
 
@@ -442,12 +394,11 @@ class PainterPanel(QtWidgets.QWidget):
 
     def current_page(self):
         """The name of the page the inspector shows."""
-        return self.PAGES[self._stack.currentIndex()][0]
+        return self.PAGES[self._stack.currentIndex()]
 
     def show_page(self, name):
         """Show the page named ``name`` and check its tab."""
-        names = [page for page, _text in self.PAGES]
-        self._stack.setCurrentIndex(names.index(name))
+        self._stack.setCurrentIndex(self.PAGES.index(name))
         self.tabs[name].setChecked(True)
 
 
@@ -560,6 +511,17 @@ class Painter(_gui_common.PilotFeature):
         if self._action is not None:
             dock.visibilityChanged.connect(self._action.setChecked)
         self._dock = dock
+        self._panel.set_canvas_source(self._mgr.currentR2DWidget)
+        mdi = self._mgr.mdiArea
+        if mdi is not None:
+            mdi.subWindowActivated.connect(self._on_subwindow_activated)
+
+    def _on_subwindow_activated(self, _subwin):
+        """Show the newly active canvas without waiting for the next poll."""
+        if self._panel is not None:
+            # The manager reports the active canvas once Qt has finished
+            # switching, which is after this signal.
+            QtCore.QTimer.singleShot(0, self._panel.refresh)
 
     def present(self):
         """Show the Painter dock and reset the focused canvas to the default

--- a/solvcon/pilot/canvas/_painter_style.py
+++ b/solvcon/pilot/canvas/_painter_style.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Palette-derived styling shared by the pieces of the Painter panel.
+
+The design's greys are all a step from the panel color toward the text color,
+so a piece that mixes its own shades follows a light/dark switch without
+naming a single hex value.
+"""
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+__all__ = [
+    'blend',
+    'shade',
+    'rule',
+    'PaletteStyled',
+]
+
+
+# Qt 6.6 added this event, and the theme backends still guard for older Qt.
+# Naming it in a class body would fail the import of the whole pilot there.
+_DPR_CHANGE_EVENT = getattr(QtCore.QEvent, 'DevicePixelRatioChange', None)
+
+
+def rule(shape):
+    """A hairline divider between two areas of the panel."""
+    line = QtWidgets.QFrame()
+    line.setFrameShape(shape)
+    line.setFrameShadow(QtWidgets.QFrame.Sunken)
+    return line
+
+
+def blend(color, other, ratio):
+    """Mix ``ratio`` of ``other`` into ``color``."""
+    keep = 1.0 - ratio
+    return QtGui.QColor(
+        round(color.red() * keep + other.red() * ratio),
+        round(color.green() * keep + other.green() * ratio),
+        round(color.blue() * keep + other.blue() * ratio))
+
+
+def shade(widget, ratio):
+    """The panel color of ``widget`` moved ``ratio`` toward its text color.
+
+    Blending toward the text is what makes a shade follow the theme: it steps
+    darker under a light palette and lighter under a dark one, which is how the
+    design separates the selector from the inspector and the checked tab from
+    both.
+    """
+    palette = widget.palette()
+    return blend(palette.color(QtGui.QPalette.Window),
+                 palette.color(QtGui.QPalette.WindowText), ratio)
+
+
+class PaletteStyled(QtWidgets.QWidget):
+    """A widget whose child controls are styled from the palette.
+
+    A subclass builds its style sheet in :meth:`_apply_style` and calls it once
+    its children exist; the base re-applies it whenever the application palette
+    changes, so the piece follows a light/dark switch.
+    """
+
+    # Both palette events matter. The theme manager pairs a new application
+    # palette with a fresh global style sheet, whose re-polish arrives here as
+    # PaletteChange; under the system look it sets the palette alone, and
+    # ApplicationPaletteChange is what carries that.
+    #
+    # The icons rasterize for the screen they are on, so a move between screens
+    # of different scale has to re-render them just as a theme switch does.
+    # Where Qt cannot report that move, the icons keep the scale they were
+    # rendered at until the next palette change.
+    _RESTYLE_EVENTS = (
+        (QtCore.QEvent.PaletteChange, QtCore.QEvent.ApplicationPaletteChange)
+        + ((_DPR_CHANGE_EVENT,) if _DPR_CHANGE_EVENT is not None else ()))
+
+    def event(self, event):
+        if event.type() in self._RESTYLE_EVENTS:
+            self._apply_style()
+            self.update()
+        return super().event(event)
+
+    def _apply_style(self):
+        raise NotImplementedError
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_painter_design.py
+++ b/tests/test_pilot_painter_design.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the Design page of the Painter inspector.
+"""
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.base import _gui
+    from solvcon.pilot.canvas import _painter_design
+    from PySide6 import QtCore, QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+def _click(widget, x, y):
+    """Post a synthetic left-button press and release to ``widget``."""
+    pos = QtCore.QPointF(x, y)
+    glob = QtCore.QPointF(widget.mapToGlobal(pos.toPoint()))
+    for etype, button, buttons in (
+            (QtCore.QEvent.Type.MouseButtonPress,
+             QtCore.Qt.LeftButton, QtCore.Qt.LeftButton),
+            (QtCore.QEvent.Type.MouseButtonRelease,
+             QtCore.Qt.LeftButton, QtCore.Qt.NoButton)):
+        QtWidgets.QApplication.sendEvent(
+            widget,
+            QtGui.QMouseEvent(etype, pos, glob, button, buttons,
+                              QtCore.Qt.NoModifier))
+
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas, so a test can set the selection directly.
+
+    The real canvas only changes it through a mouse gesture on a live window,
+    which :class:`PainterDesignCanvasTC` covers.
+    """
+
+    def __init__(self, world):
+        self.world = world
+        self.selectedShape = -1
+        self.repaints = 0
+
+    def requestRepaint(self):
+        self.repaints += 1
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PainterDesignPageTC(unittest.TestCase):
+    """What the page shows for the canvas's selection."""
+
+    @classmethod
+    def setUpClass(cls):
+        # No window needed, only a live QGuiApplication to hold a widget.
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        # A rectangle centered on the origin, 4 wide and 2 tall.
+        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.canvas = _StubCanvas(self.world)
+        self.page = _painter_design.DesignPage()
+        self.page.set_canvas_source(lambda: self.canvas)
+
+    def _select(self, shape_id):
+        self.canvas.selectedShape = shape_id
+        self.page.refresh()
+
+    def _header(self):
+        return self.page._name.text()
+
+    def test_nothing_selected_leaves_the_page_empty(self):
+        self.assertEqual(self._header(),
+                         _painter_design.DesignPage.EMPTY_TEXT)
+        self.assertTrue(self.page._badge.isHidden())
+        self.assertTrue(self.page._icon.isHidden())
+
+    def test_selection_fills_the_header(self):
+        self._select(self.sid)
+        self.assertEqual(self._header(), f"Rectangle {self.sid}")
+        self.assertFalse(self.page._badge.isHidden())
+        self.assertFalse(self.page._icon.pixmap().isNull())
+
+    def test_picking_another_shape_refreshes_the_page(self):
+        # A pick moves no geometry, so a poll watching the world would miss it.
+        other = self.world.add_circle(10, 10, 3)
+        self._select(self.sid)
+        self._select(other)
+        self.assertEqual(self._header(), f"Circle {other}")
+
+    def test_a_dead_selection_leaves_the_page_empty(self):
+        # The canvas keeps the id it stored, and a query on a dead one throws.
+        self._select(self.sid)
+        self.world.remove_shape(self.sid)
+        self.page.refresh()
+        self.assertEqual(self._header(),
+                         _painter_design.DesignPage.EMPTY_TEXT)
+
+    def test_closing_the_canvas_clears_the_page(self):
+        # The page asks for the canvas again on every read.
+        self._select(self.sid)
+        self.canvas = None
+        self.page.refresh()
+        self.assertEqual(self._header(),
+                         _painter_design.DesignPage.EMPTY_TEXT)
+
+    def test_the_page_restyles_with_the_palette(self):
+        # A color captured once would survive a theme switch as is.
+        self._select(self.sid)
+        before = self.page.styleSheet()
+        icon = self.page._icon.pixmap().toImage()
+        palette = QtGui.QPalette(self.page.palette())
+        palette.setColor(QtGui.QPalette.Window, QtGui.QColor("black"))
+        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
+        palette.setColor(QtGui.QPalette.Highlight, QtGui.QColor("red"))
+        self.page.setPalette(palette)
+        self.assertNotEqual(self.page.styleSheet(), before)
+        self.assertNotEqual(self.page._icon.pixmap().toImage(), icon)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class PainterDesignCanvasTC(unittest.TestCase):
+    """The page against a real canvas, bound by the Painter dock."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.painter = _gui.controller.painter
+        self.painter._ensure_dock()
+        self.widget = self.mgr.add2DWidget()
+        self.widget.setDrawTool("select")
+        self.world = solvcon.WorldFp64()
+        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(self.world)
+        view = solvcon.ViewTransform2dFp64()
+        view.pan(100.0, 100.0)
+        view.zoom = 20.0
+        # Set the view before showing so the resize auto-centering, which a
+        # well-formed transform disables, leaves the mapping deterministic.
+        self.widget.setViewTransform(view)
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        QtWidgets.QApplication.processEvents()
+
+    def test_the_page_follows_the_active_canvas(self):
+        page = self.painter.panel.design
+        # Activation is delivered through a zero timer, so let it run.
+        QtWidgets.QApplication.processEvents()
+        _click(self.sub.widget(), 100, 100)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        page.refresh()
+        self.assertEqual(page._name.text(), f"Rectangle {self.sid}")
+
+    def test_closing_the_canvas_leaves_the_page_standing(self):
+        # The sub-window deletes the canvas on close, and a page that held it
+        # would read freed memory on its next poll.
+        page = self.painter.panel.design
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual(page._name.text(),
+                         _painter_design.DesignPage.EMPTY_TEXT)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Painter dock's Design tab has been a greyed-out summary of what it would eventually hold. This gives it a real page: a header naming what the active canvas has selected, with the shape's icon in the accent color, a type-derived name, and the "1 selected" badge, and an empty state when nothing is picked.

The world changes in C++ without a change signal, so the page re-reads it on the entity tree's 500 ms poll, and only while it is on screen. What the poll compares is the selection itself rather than a serialized world: that is all the page shows, it costs no serialization, and a plain selection click moves no geometry for a world-wide fingerprint to notice. A selection whose shape was removed or undone away reads as no selection at all, because the canvas keeps the id it stored and every query on a dead one throws.

The canvas is resolved through a callable on every read rather than held. R2DWidget is a C++ widget its sub-window owns, so a Python reference kept across that window's close outlives the object behind it; the dock hands the page the manager's own accessor instead, and refreshes it when the active sub-window changes.

One part of the diff is a verbatim move worth reading as such: the palette helpers the tool selector introduced go to a module of their own, unchanged but for the names losing their underscore, because a page importing them from the panel that imports the page back would close an import cycle.

The X/Y/W/H position grid and the greyed Stroke, Fill, Grid & snap, and Layers sections follow in a stacked pull request.

Related to #1175.
