### PR TITLE
Give the Painter Design page its position grid

### DIFF
--- a/solvcon/pilot/canvas/_painter_design.py
+++ b/solvcon/pilot/canvas/_painter_design.py
@@ -5,10 +5,12 @@
 The Design page of the Painter inspector: what is selected and where it sits.
 """
 
+import math
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
-from ._painter_style import blend, shade, PaletteStyled
+from ._painter_style import blend, rule, shade, PaletteStyled
 
 __all__ = [
     'DesignPage',
@@ -20,39 +22,218 @@ def _mono_font():
     return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
 
 
+def _format(value):
+    """Return a world coordinate or length as the fields show it."""
+    return f"{value:g}"
+
+
+def _obb_metrics(obb):
+    """Return the center, width, and height of an oriented bounding box.
+
+    The corners run top-left, top-right, bottom-right, bottom-left, so the two
+    sides give the shape's own width and height rather than the wider span a
+    rotated shape covers along the axes.
+    """
+    xs = obb[0::2]
+    ys = obb[1::2]
+    # Divided before summed: four corners far enough out add up past the
+    # double range, and the center would come back infinite.
+    return (sum(x / 4 for x in xs), sum(y / 4 for y in ys),
+            math.hypot(xs[1] - xs[0], ys[1] - ys[0]),
+            math.hypot(xs[3] - xs[0], ys[3] - ys[0]))
+
+
+def _lands_finite(obb, delta):
+    """Return whether moving ``obb`` by ``delta`` keeps its corners finite.
+
+    The shape lies inside its own box, so corners that survive the step bound
+    the geometry that follows them.
+    """
+    dx, dy = delta
+    return all(math.isfinite(x + dx) and math.isfinite(y + dy)
+               for x, y in zip(obb[0::2], obb[1::2]))
+
+
+class _Field(QtWidgets.QFrame):
+    """One box of the position grid: an axis letter, then its value.
+
+    An editable field commits on ``editingFinished``, which is Enter or a
+    focus change, and only when the text parses to another number; text that
+    does not parse falls back to the value the field was showing.
+    """
+
+    #: The edited value, once it parses to a number the shape does not hold.
+    committed = QtCore.Signal(float)
+
+    _HEIGHT = 28
+    _MARGINS = (8, 0, 8, 0)
+    _GAP = 6
+    _LETTER_WIDTH = 10
+
+    def __init__(self, letter, editable, parent=None):
+        super().__init__(parent)
+        self._value = None
+        self._typed = False
+        self.setObjectName("field")
+        self.setFixedHeight(self._HEIGHT)
+        label = QtWidgets.QLabel(letter, self)
+        label.setObjectName("axis")
+        label.setFixedWidth(self._LETTER_WIDTH)
+        self._edit = QtWidgets.QLineEdit(self)
+        self._edit.setFont(_mono_font())
+        self._edit.setReadOnly(not editable)
+        # An editor asks for room for a line of text, and four of them would
+        # open the dock wider than the inspector the design draws. The grid
+        # column decides the width here.
+        self._edit.setSizePolicy(QtWidgets.QSizePolicy.Ignored,
+                                 QtWidgets.QSizePolicy.Fixed)
+        self._edit.textEdited.connect(self._on_typed)
+        self._edit.editingFinished.connect(self._on_edited)
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        layout.addWidget(label)
+        layout.addWidget(self._edit, 1)
+
+    @property
+    def edit(self):
+        """The value editor, for a caller that drives or reads its text."""
+        return self._edit
+
+    def value(self):
+        """Return the value the field stands for, or ``None`` for none."""
+        return self._value
+
+    def set_value(self, value):
+        """Show ``value``, which is ``None`` for an empty field."""
+        self._value = value
+        # A field the user is typing in keeps its text: the page refreshes on
+        # a poll, which would otherwise overwrite the entry mid-edit.
+        if not self._edit.hasFocus():
+            self._show()
+
+    def revert(self):
+        """Show the value again, dropping whatever the field holds."""
+        self._show()
+
+    def _show(self):
+        self._typed = False
+        self._edit.blockSignals(True)
+        try:
+            self._edit.setText(
+                "" if self._value is None else _format(self._value))
+        finally:
+            self._edit.blockSignals(False)
+
+    def _on_typed(self, _text):
+        self._typed = True
+
+    def _on_edited(self):
+        # editingFinished fires on a focus change as well, and the text is a
+        # rounded view of the value, so a field nobody typed in would commit
+        # its own rounding error as a move.
+        if not self._typed:
+            return
+        # One finished edit consumes the typing. Enter leaves the field
+        # focused with its text as typed, and a poll may move the value on
+        # underneath it; the focus change that follows must not write the old
+        # text back over that.
+        self._typed = False
+        try:
+            value = float(self._edit.text())
+        except ValueError:
+            self._show()
+            return
+        # "nan" and "inf" parse, and a shape moved to either is not brought
+        # back by undo: the inverse translation stays non-finite too.
+        if not math.isfinite(value):
+            self._show()
+            return
+        if self._value is not None and value != self._value:
+            self.committed.emit(value)
+
+
+class _Placeholder(QtWidgets.QWidget):
+    """A greyed-out stand-in for a section the model cannot fill yet.
+
+    It carries the design's own title, so the page keeps its designed shape.
+    """
+
+    _ARROW = chr(0x25b8)
+    _MARGINS = (12, 11, 12, 11)
+    _FONT_PX = 10
+    _LETTER_SPACING = 110
+
+    def __init__(self, title, waits_for, folded=True, parent=None):
+        super().__init__(parent)
+        text = f"{self._ARROW}  {title.upper()}" if folded else title.upper()
+        label = QtWidgets.QLabel(text, self)
+        label.setObjectName("section")
+        font = label.font()
+        font.setPixelSize(self._FONT_PX)
+        font.setLetterSpacing(QtGui.QFont.PercentageSpacing,
+                              self._LETTER_SPACING)
+        label.setFont(font)
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.addWidget(label)
+        self.setToolTip(f"{title}  (needs {waits_for})")
+        self.setEnabled(False)
+
+
 class DesignPage(PaletteStyled):
-    """The inspector's Design page: what the canvas has selected.
+    """The inspector's Design page: the selected shape and its position.
 
     The page reads the canvas it is bound to on a timer, because the world
     changes in C++ without a change signal. What the poll compares is the
-    selection itself, which is both what the page shows and cheap enough to
-    read every tick.
+    selection itself, id and type and box, which is both what the page shows
+    and cheap enough to read every tick.
+
+    X and Y are the selection's center and are editable; W and H come from the
+    same oriented box and stay read-only until the world grows a scale
+    operation.
     """
 
-    # Poll period in milliseconds, the cadence the entity tree already uses.
-    # The timer runs only while the page is on screen, so a hidden dock or
-    # another inspector tab costs nothing.
-    _POLL_MS = 500
+    # Poll period in milliseconds. The fields are read while a drag moves the
+    # shape under them, so the entity tree's half second reads as lag, and one
+    # shape's box is cheap enough to re-read this often.
+    _POLL_MS = 60
+
+    #: The greyed-out sections, as ``(title, what the section waits for)``.
+    PLACEHOLDERS = (
+        ("Stroke", "per-shape stroke style"),
+        ("Fill", "per-shape fill color"),
+        ("Grid & snap", "grid and snap options"),
+    )
 
     #: The header text while nothing is selected.
     EMPTY_TEXT = "Nothing selected"
+
+    _POSITION = (("X", True), ("Y", True), ("W", False), ("H", False))
 
     _ICON_PX = 13
     _MARGINS = (12, 11, 12, 11)
     _GAP = 10
     _HEADER_GAP = 8
+    _GRID_GAP = 6
     _NAME_PX = 12
     _SMALL_PX = 10
+    _VALUE_PX = 11
+    _RADIUS = 5
 
-    # How far the muted text and the badge sit from the panel color.
+    # How far each of these sits from the panel color.
     _MUTED_MIX = 0.35
+    _GREYED_MIX = 0.6
     _BADGE_MIX = 0.15
+    _BORDER_MIX = 0.25
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._source = None
         self._key = None
         self._icon_name = None
+        self.fields = {}
+        self.placeholders = {}
         self._build()
         self._timer = QtCore.QTimer(self)
         self._timer.setInterval(self._POLL_MS)
@@ -100,28 +281,57 @@ class DesignPage(PaletteStyled):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self._build_selection())
+        for title, waits_for in self.PLACEHOLDERS:
+            layout.addWidget(rule(QtWidgets.QFrame.HLine))
+            layout.addWidget(self._add_placeholder(title, waits_for))
+
+        layout.addWidget(rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(
+            self._add_placeholder("Layers", "shape names", folded=False))
         layout.addStretch(1)
 
+    def _add_placeholder(self, title, waits_for, folded=True):
+        self.placeholders[title] = _Placeholder(title, waits_for, folded, self)
+        return self.placeholders[title]
+
     def _build_selection(self):
-        """The selection header: the shape's icon, name, and count badge."""
+        """Build the selection header over the position grid."""
         block = QtWidgets.QWidget(self)
+        layout = QtWidgets.QVBoxLayout(block)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        layout.addLayout(self._build_header(block))
+        layout.addLayout(self._build_grid(block))
+        return block
+
+    def _build_header(self, block):
         self._icon = QtWidgets.QLabel(block)
         self._name = QtWidgets.QLabel(block)
         self._name.setObjectName("name")
         self._badge = QtWidgets.QLabel("1 selected", block)
         self._badge.setObjectName("badge")
         self._badge.setFont(_mono_font())
-        header = QtWidgets.QHBoxLayout()
-        header.setSpacing(self._HEADER_GAP)
-        header.addWidget(self._icon)
-        header.addWidget(self._name)
-        header.addStretch(1)
-        header.addWidget(self._badge)
-        layout = QtWidgets.QVBoxLayout(block)
-        layout.setContentsMargins(*self._MARGINS)
-        layout.setSpacing(self._GAP)
-        layout.addLayout(header)
-        return block
+        layout = QtWidgets.QHBoxLayout()
+        layout.setSpacing(self._HEADER_GAP)
+        layout.addWidget(self._icon)
+        layout.addWidget(self._name)
+        layout.addStretch(1)
+        layout.addWidget(self._badge)
+        return layout
+
+    def _build_grid(self, block):
+        layout = QtWidgets.QGridLayout()
+        layout.setSpacing(self._GRID_GAP)
+        for index, (letter, editable) in enumerate(self._POSITION):
+            field = _Field(letter, editable, block)
+            if editable:
+                field.committed.connect(
+                    lambda value, at=letter: self._on_committed(at, value))
+            else:
+                field.setToolTip(f"{letter}  (needs the scale operation)")
+            layout.addWidget(field, index // 2, index % 2)
+            self.fields[letter] = field
+        return layout
 
     def _canvas(self):
         """The 2D canvas to read, or ``None`` when none is active."""
@@ -135,7 +345,10 @@ class DesignPage(PaletteStyled):
         tick and still miss a plain selection click, which moves no geometry.
         """
         _widget, world, shape = self._selection()
-        return None if world is None else (shape, world.shape_type_of(shape))
+        if world is None:
+            return None
+        return (shape, world.shape_type_of(shape),
+                tuple(world.shape_obb(shape)))
 
     def _selection(self):
         """The active canvas, its world, and its live selection.
@@ -157,11 +370,18 @@ class DesignPage(PaletteStyled):
             self._icon_name = None
             self._name.setText(self.EMPTY_TEXT)
             self._badge.setVisible(False)
+            for field in self.fields.values():
+                field.setEnabled(False)
+                field.set_value(None)
         else:
             kind = world.shape_type_of(shape)
             self._icon_name = kind if kind in _painter_icons.ICONS else None
             self._name.setText(f"{kind.title()} {shape}")
             self._badge.setVisible(True)
+            metrics = _obb_metrics(world.shape_obb(shape))
+            for (letter, _editable), value in zip(self._POSITION, metrics):
+                self.fields[letter].setEnabled(True)
+                self.fields[letter].set_value(value)
         self._show_icon()
 
     def _show_icon(self):
@@ -175,20 +395,69 @@ class DesignPage(PaletteStyled):
             self._ICON_PX, self.devicePixelRatioF()))
         self._icon.setVisible(True)
 
+    def _on_committed(self, axis, value):
+        """Move the selection so its center reads ``value`` on ``axis``."""
+        widget, world, shape = self._selection()
+        if world is None:
+            return
+        obb = world.shape_obb(shape)
+        center_x, center_y = _obb_metrics(obb)[:2]
+        if "X" == axis:
+            delta = (value - center_x, 0.0)
+        else:
+            delta = (0.0, value - center_y)
+        # The step between two finite coordinates can overflow, and so can a
+        # wide shape's far corner once a finite step lands on it, so the box
+        # is checked where it would end up rather than the step alone.
+        if not _lands_finite(obb, delta):
+            self.fields[axis].revert()
+            return
+
+        world.begin_operation()
+        try:
+            world.translate_shape(shape, *delta)
+        finally:
+            world.end_operation()
+
+        widget.requestRepaint()
+        self.refresh()
+
     def _apply_style(self):
-        """Color the header and the badge from the palette."""
+        """Color the header, the badge, and the fields from the palette."""
         palette = self.palette()
-        muted = blend(palette.color(QtGui.QPalette.WindowText),
-                      palette.color(QtGui.QPalette.Window), self._MUTED_MIX)
+        text = palette.color(QtGui.QPalette.WindowText)
+        panel = palette.color(QtGui.QPalette.Window)
+        muted = blend(text, panel, self._MUTED_MIX)
+        greyed = blend(text, panel, self._GREYED_MIX)
         self.setStyleSheet(f"""
             QLabel#name {{
                 font-size: {self._NAME_PX}px;
+            }}
+            QLabel#axis {{
+                font-size: {self._SMALL_PX}px;
+                color: {muted.name()};
+            }}
+            QLabel#axis:disabled {{
+                color: {greyed.name()};
             }}
             QLabel#badge {{
                 border-radius: 4px;
                 padding: 2px 6px;
                 font-size: {self._SMALL_PX}px;
                 background: {shade(self, self._BADGE_MIX).name()};
+                color: {muted.name()};
+            }}
+            QFrame#field {{
+                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border-radius: {self._RADIUS}px;
+                background: {palette.color(QtGui.QPalette.Base).name()};
+            }}
+            QLineEdit {{
+                border: none;
+                background: transparent;
+                font-size: {self._VALUE_PX}px;
+            }}
+            QLineEdit:read-only {{
                 color: {muted.name()};
             }}
             """)

--- a/tests/test_pilot_painter_design.py
+++ b/tests/test_pilot_painter_design.py
@@ -5,6 +5,7 @@
 Tests for the Design page of the Painter inspector.
 """
 
+import math
 import os
 import unittest
 
@@ -13,7 +14,7 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
-    from solvcon.pilot.canvas import _painter_design
+    from solvcon.pilot.canvas import _painter_design, _painter_gui
     from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pilot = None
@@ -57,7 +58,7 @@ class _StubCanvas:
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class PainterDesignPageTC(unittest.TestCase):
-    """What the page shows for the canvas's selection."""
+    """What the page shows for a selection, and what an edit writes back."""
 
     @classmethod
     def setUpClass(cls):
@@ -79,17 +80,44 @@ class PainterDesignPageTC(unittest.TestCase):
     def _header(self):
         return self.page._name.text()
 
+    def _values(self):
+        return {letter: field.value()
+                for letter, field in self.page.fields.items()}
+
+    def _commit(self, letter, text):
+        """Type ``text`` into a field and finish the edit, as Enter does."""
+        field = self.page.fields[letter]
+        field.edit.setText(text)
+        field.edit.textEdited.emit(text)
+        field.edit.editingFinished.emit()
+
     def test_nothing_selected_leaves_the_page_empty(self):
         self.assertEqual(self._header(),
                          _painter_design.DesignPage.EMPTY_TEXT)
         self.assertTrue(self.page._badge.isHidden())
         self.assertTrue(self.page._icon.isHidden())
+        for letter, field in self.page.fields.items():
+            with self.subTest(letter=letter):
+                self.assertFalse(field.isEnabled())
+                self.assertEqual(field.edit.text(), "")
 
-    def test_selection_fills_the_header(self):
+    def test_selection_fills_the_header_and_the_position(self):
         self._select(self.sid)
         self.assertEqual(self._header(), f"Rectangle {self.sid}")
         self.assertFalse(self.page._badge.isHidden())
         self.assertFalse(self.page._icon.pixmap().isNull())
+        self.assertEqual(self._values(), {"X": 0, "Y": 0, "W": 4, "H": 2})
+        # W and H wait on the scale operation the world does not have.
+        self.assertFalse(self.page.fields["X"].edit.isReadOnly())
+        self.assertTrue(self.page.fields["W"].edit.isReadOnly())
+
+    def test_the_size_is_the_shape_own_box(self):
+        # A quarter turn leaves the rectangle 4 by 2; only the axis-aligned
+        # span it covers swaps, and that is not what the fields show.
+        self.world.rotate_shape(self.sid, 0.5 * math.pi, 0.0, 0.0)
+        self._select(self.sid)
+        self.assertAlmostEqual(self.page.fields["W"].value(), 4)
+        self.assertAlmostEqual(self.page.fields["H"].value(), 2)
 
     def test_picking_another_shape_refreshes_the_page(self):
         # A pick moves no geometry, so a poll watching the world would miss it.
@@ -97,6 +125,80 @@ class PainterDesignPageTC(unittest.TestCase):
         self._select(self.sid)
         self._select(other)
         self.assertEqual(self._header(), f"Circle {other}")
+        self.assertEqual(self._values(), {"X": 10, "Y": 10, "W": 6, "H": 6})
+
+    def test_editing_x_moves_the_shape_and_repaints(self):
+        self._select(self.sid)
+        self._commit("X", "5")
+        self.assertAlmostEqual(self.page.fields["X"].value(), 5)
+        self.assertAlmostEqual(self.world.shape_obb(self.sid)[0], 3)
+        self.assertEqual(self.canvas.repaints, 1)
+        # The whole edit is a single undo step, and the fields follow it back.
+        self.world.undo()
+        self.page.refresh()
+        self.assertAlmostEqual(self.page.fields["X"].value(), 0)
+
+    def test_an_edit_that_changes_nothing_writes_nothing(self):
+        # Text that parses to the value already shown, and text that does
+        # not parse at all.
+        self._select(self.sid)
+        self._commit("Y", "0")
+        self._commit("X", "not a number")
+        self.assertEqual(self.canvas.repaints, 0)
+        self.assertEqual(self.page.fields["X"].edit.text(), "0")
+
+    def test_a_finished_edit_does_not_commit_again(self):
+        # Enter leaves the field focused and its text as typed, so the value
+        # can move on underneath it; the next focus change must not write the
+        # old text back over that. Nothing maps a window here, so the focus
+        # the sequence turns on is stubbed.
+        field = self.page.fields["X"]
+        field.edit.hasFocus = lambda: True
+        self._select(self.sid)
+        self._commit("X", "5")
+        self.world.undo()
+        self.page.refresh()
+        field.edit.editingFinished.emit()
+        self.assertEqual(self.canvas.repaints, 1)
+        self.assertAlmostEqual(self.world.shape_obb(self.sid)[0], -2)
+
+    def test_the_page_fits_the_designed_inspector(self):
+        # Four editors asking for a line of text each would open the dock
+        # wider than the inspector the design draws.
+        self.assertLessEqual(self.page.sizeHint().width(),
+                             _painter_gui.PainterPanel._INSPECTOR_WIDTH)
+
+    def test_leaving_a_field_untouched_moves_nothing(self):
+        # The field shows a rounded value, so a focus change on a field nobody
+        # typed in would otherwise commit the rounding error as a move.
+        self.world.translate_shape(self.sid, 1.0 / 3.0, 0.0)
+        self._select(self.sid)
+        self.page.fields["X"].edit.editingFinished.emit()
+        self.assertEqual(self.canvas.repaints, 0)
+        self.assertAlmostEqual(self.page.fields["X"].value(), 1.0 / 3.0)
+
+    def test_a_non_finite_edit_never_reaches_the_shape(self):
+        # A shape moved to nan or inf is not brought back by undo.
+        self._select(self.sid)
+        for text in ("nan", "1e400"):
+            with self.subTest(text=text):
+                self._commit("X", text)
+                self.assertEqual(self.canvas.repaints, 0)
+                self.assertAlmostEqual(self.world.shape_obb(self.sid)[0], -2)
+
+    def test_extreme_coordinates_never_break_the_shape(self):
+        # A shape this far out still reports a finite center, and a move is
+        # turned away whether the step itself overflows or only the far corner
+        # does once a finite step lands on it.
+        far = self.world.add_rectangle(4e307, -1, 6e307, 1)
+        self._select(far)
+        self.assertTrue(math.isfinite(self.page.fields["X"].value()))
+        for text in ("1.7e308", "-1.6e308"):
+            with self.subTest(text=text):
+                self._commit("X", text)
+                self.assertEqual(self.canvas.repaints, 0)
+                self.assertTrue(all(math.isfinite(value) for value
+                                    in self.world.shape_obb(far)))
 
     def test_a_dead_selection_leaves_the_page_empty(self):
         # The canvas keeps the id it stored, and a query on a dead one throws.
@@ -105,6 +207,7 @@ class PainterDesignPageTC(unittest.TestCase):
         self.page.refresh()
         self.assertEqual(self._header(),
                          _painter_design.DesignPage.EMPTY_TEXT)
+        self.assertFalse(self.page.fields["X"].isEnabled())
 
     def test_closing_the_canvas_clears_the_page(self):
         # The page asks for the canvas again on every read.
@@ -113,6 +216,14 @@ class PainterDesignPageTC(unittest.TestCase):
         self.page.refresh()
         self.assertEqual(self._header(),
                          _painter_design.DesignPage.EMPTY_TEXT)
+
+    def test_sections_the_model_cannot_fill_are_greyed_out(self):
+        self.assertEqual(list(self.page.placeholders),
+                         ["Stroke", "Fill", "Grid & snap", "Layers"])
+        for title, section in self.page.placeholders.items():
+            with self.subTest(title=title):
+                self.assertFalse(section.isEnabled())
+                self.assertIn("needs", section.toolTip())
 
     def test_the_page_restyles_with_the_palette(self):
         # A color captured once would survive a theme switch as is.
@@ -162,6 +273,7 @@ class PainterDesignCanvasTC(unittest.TestCase):
         self.assertEqual(self.widget.selectedShape, self.sid)
         page.refresh()
         self.assertEqual(page._name.text(), f"Rectangle {self.sid}")
+        self.assertAlmostEqual(page.fields["W"].value(), 4)
 
     def test_closing_the_canvas_leaves_the_page_standing(self):
         # The sub-window deletes the canvas on close, and a page that held it


### PR DESCRIPTION
The Design page names the selection but says nothing about where it sits. This adds the design's X/Y/W/H grid, read from the selection's oriented bounding box: X and Y are its center, W and H the box's own sides, so a rotated shape reports the size it was drawn with rather than the wider span it covers along the axes. The editors ask for no width of their own, so opening the Painter no longer widens the dock past the inspector the design draws.

X and Y are editable. A field commits when the user has typed in it and the text parses to a number the shape does not already hold: the text is a rounded view of the value, so a focus change on an untouched field would otherwise write that rounding back as a move. One finished edit consumes the typing, so the text Enter leaves behind is not committed a second time over whatever moved since. The edit goes through translate_shape inside one begin_operation bracket, so undo takes it back in a single step. W and H stay read-only until the world grows a scale operation.

Arithmetic that leaves the double range is turned away rather than written to the world, since a shape with a non-finite coordinate is not brought back by an inverse translation that is non-finite too. That covers input that is not finite, a step between two finite coordinates that overflows, and a finite step that carries a wide shape's far corner past the range; the center is averaged corner by corner for the same reason.

Stroke, Fill, Grid & snap, and the mini Layers list take their designed places on the page, greyed out and naming what each one waits for.

Related to #1175.
