### PR TITLE
Keep the pilot GUI test windows off the screen

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -224,6 +224,8 @@ jobs:
           install_name_tool -add_rpath $(qtpaths --install-prefix)/lib ${PYSIDE6_PATH}/QtCore.abi3.so
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
+        # Left at the default so one job runs the GUI tests with their windows
+        # off the screen; run_pilot_pytest below maps its windows.
         make pytest ${JOB_MAKE_ARGS}
         echo "::endgroup::"
 
@@ -242,6 +244,9 @@ jobs:
       run: |
         echo "::group::make run_pilot_pytest"
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+        # A runner has no desktop to take over, so let this job map its windows
+        # and keep the tests that need a live surface out of the skips.
+        export SOLVCON_TEST_SHOW_WINDOWS=ON
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
 
@@ -430,6 +435,9 @@ jobs:
       - name: cmake run_pilot_pytest
         run: |
           echo "::group::cmake run_pilot_pytest"
+          # A runner has no desktop to take over, so let this job map its
+          # windows, the way it has always run them.
+          $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
           cmake --build ${{ github.workspace }}/build `
             --target run_pilot_pytest
           echo "::endgroup::"
@@ -695,6 +703,9 @@ jobs:
     - name: cmake run_pilot_pytest
       run: |
         echo "::group::cmake run_pilot_pytest"
+        # A runner has no desktop to take over, so let this job map its
+        # windows, the way it has always run them.
+        $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
         cmake --build ${{ github.workspace }}/build --target run_pilot_pytest
         echo "::endgroup::"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -151,6 +151,9 @@ jobs:
       run: |
         echo "::group::make run_pilot_pytest"
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+        # A runner has no desktop to take over, so let this job map its windows
+        # and keep the tests that need a live surface out of the skips.
+        export SOLVCON_TEST_SHOW_WINDOWS=ON
         make run_pilot_pytest \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
   pytest.
 - `make run_pilot_pytest` -- Python tests that require the pilot GUI;
   accepts `PYTEST_OPTS` the same way.
+- The GUI tests build real windows but keep them off the screen, so a test run
+  does not take over the desktop (`tests/conftest.py`). Export
+  `SOLVCON_TEST_SHOW_WINDOWS=ON` to watch the windows instead, which hands
+  them the desktop and the keyboard for the length of the run.
 - `make gtest` -- build and run the full C++ test suite.
 - `./build/rel<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test` -- run a
   single gtest after `make gtest` has built the binary

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ install: cmake
 #   make pytest PYTEST_OPTS='-k test_buffer.py'
 # Example for one class:
 #   make pytest PYTEST_OPTS='-v -k SimpleArrayBasicTC'
+# The GUI tests keep their windows off the screen (tests/conftest.py); export
+# SOLVCON_TEST_SHOW_WINDOWS=ON to watch them.
 .PHONY: pytest
 pytest: buildext
 	env $(RUNENV) \
@@ -187,6 +189,8 @@ run_pilot: pilot
 #   make run_pilot_pytest PYTEST_OPTS='-k test_buffer.py'
 # Example for one class:
 #   make run_pilot_pytest PYTEST_OPTS='-v -k SimpleArrayBasicTC'
+# The GUI tests keep their windows off the screen (tests/conftest.py); export
+# SOLVCON_TEST_SHOW_WINDOWS=ON to watch them.
 .PHONY: run_pilot_pytest
 run_pilot_pytest: pilot
 	env $(RUNENV) PYTEST_OPTS="$(PYTEST_OPTS)" \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Keep the pilot GUI tests off the screen.
+
+The GUI tests drive real top-level windows, and every one that maps takes the
+desktop and the keyboard away from whoever is running the suite. Marking a
+window Qt::WA_DontShowOnScreen as it is shown leaves it created, laid out, and
+painted into its backing store while it never reaches the screen, so the tests
+keep running against a live window surface. That is what the offscreen QPA
+platform cannot offer: the suite skips its window tests there. Export
+``SOLVCON_TEST_SHOW_WINDOWS=ON`` to watch the windows instead, which hands them
+the desktop and the keyboard for the length of the run.
+"""
+
+
+import os
+
+try:
+    from PySide6 import QtCore, QtWidgets
+except ImportError:
+    QtCore = QtWidgets = None
+
+SHOW_WINDOWS = (os.getenv('SOLVCON_TEST_SHOW_WINDOWS') or '').upper() in (
+    '1', 'ON', 'YES', 'TRUE')
+
+_hider = None
+
+
+def _build_hider():
+    class WindowHider(QtCore.QObject):
+        def eventFilter(self, obj, event):
+            if (QtCore.QEvent.Type.Show == event.type()
+                    and isinstance(obj, QtWidgets.QWidget)
+                    and obj.isWindow()):
+                obj.setAttribute(
+                    QtCore.Qt.WidgetAttribute.WA_DontShowOnScreen, True)
+            return False
+
+    return WindowHider()
+
+
+def _hide_windows():
+    """Install the window hider on the Qt application once it exists.
+
+    Importing the pilot test modules is what creates the application, so the
+    earliest hook this can run from is the end of collection. Retry from every
+    test setup to cover an application that first appears later.
+    """
+    global _hider
+    if _hider is not None or SHOW_WINDOWS or QtCore is None:
+        return
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        return
+    _hider = _build_hider()
+    app.installEventFilter(_hider)
+
+
+def pytest_collection_finish(session):
+    _hide_windows()
+
+
+def pytest_runtest_setup(item):
+    _hide_windows()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_agent_control.py
+++ b/tests/test_pilot_agent_control.py
@@ -5,7 +5,7 @@
 """The Agent Window and Agent View real-target suite: the command families
 driving live pilot windows and the active canvas view through the pilot
 RManager, its QMdiArea, and the R2DWidget. Skipped where no GUI is available;
-run with ``make run_pilot_pytest HEADLESS=1``."""
+run with ``make run_pilot_pytest``."""
 
 import os
 import tempfile


### PR DESCRIPTION
The pilot GUI tests build real top-level windows, and every one that maps takes the desktop and the keyboard from whoever is running the suite. This adds tests/conftest.py, which marks each top-level widget WA_DontShowOnScreen as it is shown: the window is still created, laid out, and painted into its backing store, and it never reaches the screen. The tests therefore keep running against a live window surface, which is what QT_QPA_PLATFORM=offscreen cannot give them, since their own NO_LIVE_WINDOW guards skip 217 of the 398 pilot tests there.

Exporting SOLVCON_TEST_SHOW_WINDOWS=ON maps the windows again, for watching a GUI test that is misbehaving. The CI jobs that run the GUI tests export it so their coverage is unchanged, except the Linux make pytest job, which stays at the default so one job runs them off the screen. Nothing else in the Makefile changes: the environment variable already passes through both pytest targets, so the diff there is comments only.

One result changes: a window that never maps is never activated, so the keyboard probe already in test_pilot_shortcut.py skips its two live key-delivery tests in a default local run. They still run in CI and under SOLVCON_TEST_SHOW_WINDOWS=ON.

Locally, make pytest and make run_pilot_pytest each report 1790 passed, 13 skipped, 3 xfailed, and make lint is clean.
