### PR TITLE
Drop the echo backend from the agent selector

### DIFF
--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -8,9 +8,9 @@ Pluggable AI backend abstraction for the Agent.
 A backend turns a prompt (plus context and a command tool surface) into a
 :class:`BackendResponse`: prose and a list of command dicts.
 Backends register in a process-wide registry so a caller can list the usable
-ones and let the user pick.  The module imports no Qt.  The offline
-:class:`EchoBackend` keeps the registry non-empty so there is always a working
-default.
+ones and let the user pick.  The first registration is what a selector starts
+on.  The module imports no Qt.  The offline :class:`EchoBackend` stays out of
+the registry: it is a test and demo double, not a backend to offer a user.
 """
 
 import abc
@@ -136,7 +136,8 @@ def all_backends():
 
 
 def available_backends():
-    """Registered backends whose ``available()`` returns True."""
+    """Registered backends whose ``available()`` returns True, in registration
+    order, so the first entry is what a selector defaults to."""
     return [b for b in _REGISTRY if b.available()]
 
 
@@ -151,9 +152,10 @@ def get_backend(name):
 class EchoBackend(AgentBackend):
     """Offline backend that proposes no commands and echoes the prompt.
 
-    It is always :meth:`available` and fully deterministic, so a caller, the
-    tests, and a no-key demo always have a backend that exercises the whole
-    pipeline without any external process.
+    It is always :meth:`available` and fully deterministic, so the tests and a
+    no-key demo can exercise the whole pipeline without any external process.
+    It does not register itself: a user picks a real backend, and a caller that
+    wants this one instantiates or registers it explicitly.
     """
 
     name = "echo (offline)"
@@ -163,8 +165,5 @@ class EchoBackend(AgentBackend):
 
     def send(self, prompt, scene_context, tool_surface):
         return BackendResponse(text="echo: %s" % prompt, commands=[])
-
-
-register(EchoBackend())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -33,7 +33,7 @@ class AgentBackendABCTC(unittest.TestCase):
 
 class EchoBackendTC(unittest.TestCase):
     def test_available_true_without_config(self):
-        # Needs no key or process, so it is the guaranteed default backend.
+        # Needs no key or process, so a test can always drive it.
         self.assertTrue(agent.EchoBackend().available())
 
     def test_send_is_deterministic_and_safe(self):
@@ -47,34 +47,39 @@ class EchoBackendTC(unittest.TestCase):
 
 
 class RegistryTC(unittest.TestCase):
-    def test_echo_is_always_available(self):
-        # EchoBackend registers on import, so the selector always has an
-        # entry.
-        names = [b.name for b in agent.available_backends()]
-        self.assertIn(agent.EchoBackend().name, names)
+    def test_echo_is_not_offered(self):
+        # The offline double stays a test tool, out of the user's selector.
+        names = [b.name for b in agent.all_backends()]
+        self.assertNotIn(agent.EchoBackend().name, names)
+
+    def test_claude_cli_is_the_first_entry(self):
+        # Registration order is selector order, so the Claude CLI is what a
+        # selector starts on.
+        self.assertEqual(agent.all_backends()[0].name,
+                         agent.ClaudeCliBackend().name)
 
     def test_get_backend_by_name(self):
-        backend = agent.get_backend(agent.EchoBackend().name)
+        name = agent.ClaudeCliBackend().name
+        backend = agent.get_backend(name)
         self.assertIsNotNone(backend)
-        self.assertEqual(backend.name, agent.EchoBackend().name)
+        self.assertEqual(backend.name, name)
 
     def test_register_replaces_same_name(self):
         # Re-registering a name swaps the instance, so a re-import cannot grow
         # the registry.
         before = len(agent.all_backends())
 
-        class Echo2(agent.EchoBackend):
+        class Claude2(agent.ClaudeCliBackend):
             pass
 
-        replacement = Echo2()
+        replacement = Claude2()
         try:
             agent.register(replacement)
             self.assertEqual(len(agent.all_backends()), before)
-            self.assertIs(agent.get_backend(agent.EchoBackend().name),
-                          replacement)
+            self.assertIs(agent.get_backend(replacement.name), replacement)
         finally:
             # Restore the default for other tests.
-            agent.register(agent.EchoBackend())
+            agent.register(agent.ClaudeCliBackend())
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -68,12 +68,9 @@ class AgentPanelTC(unittest.TestCase):
         return feature
 
     def _select_echo(self, widget):
-        combo = widget._backend_combo
-        for i in range(combo.count()):
-            if combo.itemText(i).startswith("echo"):
-                combo.setCurrentIndex(i)
-                return
-        self.fail("echo backend is not in the selector")
+        """Add the offline echo double and pick it: the selector itself lists
+        only real backends, none of which a test may run."""
+        self._select_backend(widget, agent.EchoBackend())
 
     def _select_backend(self, panel, backend):
         panel._backend_combo.addItem(backend.name, backend)


### PR DESCRIPTION
The offline echo backend registered itself on import, so the pilot's Agent panel listed it first and opened on it. It answers by repeating the prompt and proposes no commands, which makes it a test double rather than something to offer a user.

This stops registering it. The class, its availability check, and its send() stay in place, and the tests that exercise the console pipeline now instantiate it explicitly. With it out of the registry the first entry is the Claude CLI backend, so that is what the selector defaults to.

Related to #966.
