### PR TITLE
Painter Layers 1: give the Painter inspector its Layers page

### DIFF
--- a/solvcon/pilot/canvas/_painter_gui.py
+++ b/solvcon/pilot/canvas/_painter_gui.py
@@ -9,6 +9,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
 from ._painter_design import DesignPage
+from ._painter_layers import LayersPage
 from ._painter_style import blend, rule, shade, PaletteStyled
 from ..base import _gui_common
 from .._pilot_core import draw_tool_names, default_draw_tool_name
@@ -295,8 +296,8 @@ class PainterPanel(QtWidgets.QWidget):
     and Grid slots the model cannot back yet. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
     among them, and hands the active canvas to whichever page reads one. The
-    Layers and Canvas pages arrive with the later steps of the redesign, so
-    each is still a greyed-out placeholder naming what it will hold.
+    Canvas page arrives with a later step of the redesign, so it is still a
+    greyed-out placeholder naming what it will hold.
     """
 
     # The design's inspector width, in device-independent pixels. It is the
@@ -309,7 +310,6 @@ class PainterPanel(QtWidgets.QWidget):
 
     # What a page yet to be built says it will hold.
     _PLACEHOLDERS = {
-        "Layers": "Object list, filters, and visibility",
         "Canvas": "View, grid, axes, background, and units",
     }
 
@@ -326,6 +326,7 @@ class PainterPanel(QtWidgets.QWidget):
         self._tools = _DrawToolSelector(tool_actions, short_labels or {}, self)
         self._stack = QtWidgets.QStackedWidget()
         self._design = DesignPage(self._stack)
+        self._layers = LayersPage(self._stack)
         self._tabs = _SegmentedTabs(self.PAGES)
         self._tabs.selected.connect(self.show_page)
         self._inspector = self._build_inspector()
@@ -356,20 +357,35 @@ class PainterPanel(QtWidgets.QWidget):
         """The Design page."""
         return self._design
 
+    @property
+    def layers(self):
+        """The Layers page."""
+        return self._layers
+
     def set_canvas_source(self, source):
         """Tell the inspector how to reach the active 2D canvas."""
-        self._design.set_canvas_source(source)
+        for page in (self._design, self._layers):
+            page.set_canvas_source(source)
 
     def refresh(self):
-        """Re-read the active canvas now, without waiting for a poll."""
-        self._design.refresh()
+        """Re-read the active canvas now, without waiting for a poll.
+
+        Only the page on show is re-read; a hidden one reads the canvas as it
+        comes back into view, so a canvas switch does not pay for pages the
+        user is not looking at.
+        """
+        for page in (self._design, self._layers):
+            if page.isVisible():
+                page.refresh()
 
     def _build_inspector(self):
         """Build the tab row over the stack of pages."""
+        pages = {"Design": self._design, "Layers": self._layers}
         for name in self.PAGES:
-            waiting = self._PLACEHOLDERS.get(name)
-            self._stack.addWidget(self._design if waiting is None
-                                  else self._build_page(waiting))
+            page = pages.get(name)
+            self._stack.addWidget(
+                self._build_page(self._PLACEHOLDERS[name])
+                if page is None else page)
         inspector = QtWidgets.QWidget(self)
         inspector.setMinimumWidth(self._INSPECTOR_WIDTH)
         layout = QtWidgets.QVBoxLayout(inspector)

--- a/solvcon/pilot/canvas/_painter_layers.py
+++ b/solvcon/pilot/canvas/_painter_layers.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The Layers page of the Painter inspector: every object the world holds.
+"""
+
+import json
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from . import _painter_icons
+from . import _painter_rows
+from ._painter_style import blend, PaletteStyled
+
+__all__ = [
+    'LayersPage',
+]
+
+
+class LayersPage(PaletteStyled):
+    """The inspector's Layers page: one row per object the world holds.
+
+    Like the Design page, the page reads the canvas it is bound to on a timer,
+    because the world changes in C++ without a change signal. What the poll
+    compares is the row content itself, which is both what the page shows and
+    the only fingerprint that cannot go stale as the rows grow what they say.
+
+    The rows are read-only: what a row shows comes from the world, and picking
+    an object stays the canvas's job until the list grows selection of its own.
+    """
+
+    # Poll period in milliseconds. Between the entity tree's half second and
+    # the Design page's 60ms: the whole world is serialized per tick, which is
+    # too much to pay at the faster rate, while the half second reads as lag
+    # against a canvas the user is drawing on.
+    _POLL_MS = 250
+
+    #: What the list says while the world holds nothing.
+    EMPTY_TEXT = "No objects"
+
+    _LIST_MARGINS = (6, 8, 6, 8)
+    _EMPTY_MARGINS = (12, 4, 12, 4)
+    _EMPTY_PX = 12
+
+    # How far the empty note sits from the panel color.
+    _GREYED_MIX = 0.6
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._source = None
+        self._key = None
+        self._pixmaps = {}
+        self.rows = []
+        self._build()
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self._POLL_MS)
+        self._timer.timeout.connect(self.refresh)
+        self._apply_style()
+        self._render(())
+
+    @property
+    def shown_rows(self):
+        """The rows standing for an object right now.
+
+        A row outlives the object it showed: the list keeps the rows it has
+        built and hides the surplus, so a world that shrinks and grows again
+        costs no widgets.
+        """
+        return [row for row in self.rows if not row.isHidden()]
+
+    def set_canvas_source(self, source):
+        """Bind the page to ``source``, a callable handing back the canvas.
+
+        The callable returns the 2D canvas to read, or ``None`` when none is
+        active. The canvas is asked for on every read rather than held,
+        because it is a C++ widget owned by its sub-window: a reference kept
+        across the window's close outlives the object behind it, and the next
+        read walks freed memory.
+        """
+        self._source = source
+        # Rendered rather than refreshed: two blank canvases show the same
+        # nothing, so a refresh would take the page for unchanged and leave
+        # the previous canvas's objects on screen.
+        self._key = self._content()
+        self._render(self._key)
+
+    def showEvent(self, event):
+        """Poll the bound canvas only while the page is on screen."""
+        super().showEvent(event)
+        self.refresh()
+        self._timer.start()
+
+    def hideEvent(self, event):
+        """Stop polling once the page leaves the screen."""
+        super().hideEvent(event)
+        self._timer.stop()
+
+    def refresh(self):
+        """Redraw the list when the canvas it is bound to has changed."""
+        content = self._content()
+        if content == self._key:
+            return
+        self._key = content
+        self._render(content)
+
+    def _build(self):
+        self._empty = QtWidgets.QLabel(self.EMPTY_TEXT, self)
+        self._empty.setObjectName("empty")
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_list(), 1)
+
+    def _build_list(self):
+        """The scrolling column of rows, with the empty note above it.
+
+        A world of many objects would otherwise grow the page past the dock,
+        so the column scrolls inside the page rather than stretching it.
+        """
+        body = QtWidgets.QWidget()
+        self._rows_layout = QtWidgets.QVBoxLayout(body)
+        self._rows_layout.setContentsMargins(*self._LIST_MARGINS)
+        self._rows_layout.setSpacing(0)
+        self._empty.setContentsMargins(*self._EMPTY_MARGINS)
+        self._rows_layout.addWidget(self._empty)
+        self._rows_layout.addStretch(1)
+        area = QtWidgets.QScrollArea(self)
+        area.setWidget(body)
+        area.setWidgetResizable(True)
+        area.setFrameShape(QtWidgets.QFrame.NoFrame)
+        area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        return area
+
+    def _canvas(self):
+        """The 2D canvas to read, or ``None`` when none is active."""
+        return None if self._source is None else self._source()
+
+    def _world(self):
+        """The active canvas's world, or ``None`` when it has none."""
+        widget = self._canvas()
+        return None if widget is None else widget.world
+
+    @staticmethod
+    def _objects(world):
+        """Every live shape the world holds, as the world describes it.
+
+        Newest first, which is the order the design lists: the world draws in
+        registry order, so the last shape added is the one on top of the
+        canvas and the one the list names first.
+        """
+        return json.loads(world.describe_state())["shapes"][::-1]
+
+    def _content(self):
+        """One entry per row, in list order, as the rows will show it.
+
+        This is what the poll compares and what :meth:`_render` draws, so the
+        world is read once per tick rather than once to decide and again to
+        draw.
+        """
+        world = self._world()
+        if world is None:
+            return ()
+        return tuple((shape["type"], self._name_of(shape))
+                     for shape in self._objects(world))
+
+    def _render(self, content):
+        for index, (kind, name) in enumerate(content):
+            self._row(index).show_object(name, self._icon_of(kind))
+        for row in self.rows[len(content):]:
+            row.hide()
+        self._empty.setVisible(not content)
+
+    def _row(self, index):
+        """The row at ``index``, built and shown if it is a new one."""
+        while len(self.rows) <= index:
+            row = _painter_rows.ObjectRow(self)
+            # Above the trailing stretch, so the rows stay packed at the top.
+            self._rows_layout.insertWidget(len(self.rows) + 1, row)
+            self.rows.append(row)
+        self.rows[index].show()
+        return self.rows[index]
+
+    @staticmethod
+    def _name_of(shape):
+        """The row label for ``shape``, its type and its id.
+
+        The world has no names yet, so the type carries the row until it does.
+        """
+        return f"{shape['type'].title()} {shape['id']}"
+
+    def _icon_of(self, name):
+        """The icon for the shape type ``name``, or ``None`` for a type the
+        icon set does not draw yet.
+
+        The pixmaps are cached per type: a world of many objects would
+        otherwise rasterize the same handful of icons on every change. The
+        cache is dropped when the palette changes, and keyed by the scale it
+        rasterized for, because the move to a screen of another scale is not
+        reported on every Qt the pilot builds against.
+        """
+        if name not in _painter_icons.ICONS:
+            return None
+        ratio = self.devicePixelRatioF()
+        key = (name, ratio)
+        if key not in self._pixmaps:
+            self._pixmaps[key] = _painter_icons.render(
+                name, _painter_rows.icon_color(self), _painter_rows.ICON_PX,
+                ratio)
+        return self._pixmaps[key]
+
+    def _apply_style(self):
+        """Color the rows and the empty note from the palette."""
+        palette = self.palette()
+        text = palette.color(QtGui.QPalette.WindowText)
+        panel = palette.color(QtGui.QPalette.Window)
+        self.setStyleSheet(_painter_rows.rules() + f"""
+            QLabel#empty {{
+                font-size: {self._EMPTY_PX}px;
+                color: {blend(text, panel, self._GREYED_MIX).name()};
+            }}
+            """)
+        self._pixmaps.clear()
+        # The rows hold the icons the cleared cache handed out, and a stale
+        # one keeps the color it was rendered in through the theme switch.
+        self._key = None
+        self.refresh()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/canvas/_painter_rows.py
+++ b/solvcon/pilot/canvas/_painter_rows.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The object row the Painter inspector lists.
+
+The design draws the same row twice, filling the Layers page and the short
+list at the foot of the Design page, so the widget and the rules that color it
+live together here rather than in either page.
+"""
+
+from PySide6 import QtGui, QtWidgets
+
+from ._painter_style import blend
+
+__all__ = [
+    'ICON_PX',
+    'HEIGHT',
+    'ObjectRow',
+    'icon_color',
+    'rules',
+]
+
+#: The type icon's size and the row's own, in device-independent pixels.
+ICON_PX = 13
+HEIGHT = 30
+
+_MARGINS = (8, 0, 8, 0)
+_GAP = 8
+_NAME_PX = 12
+_RADIUS = 5
+
+# How far the type icon sits from the panel color.
+_MUTED_MIX = 0.35
+
+
+class ObjectRow(QtWidgets.QFrame):
+    """One object row: a type icon, then the object's name."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("row")
+        self.setFixedHeight(HEIGHT)
+        self._icon = QtWidgets.QLabel(self)
+        self._icon.setFixedWidth(ICON_PX)
+        self._name = QtWidgets.QLabel(self)
+        self._name.setObjectName("name")
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*_MARGINS)
+        layout.setSpacing(_GAP)
+        layout.addWidget(self._icon)
+        layout.addWidget(self._name)
+        layout.addStretch(1)
+
+    @property
+    def name(self):
+        """The object name the row shows."""
+        return self._name.text()
+
+    @property
+    def icon(self):
+        """The type icon the row shows."""
+        return self._icon.pixmap()
+
+    def show_object(self, name, icon):
+        """Show one object, ``icon`` being its pixmap or ``None`` for a type
+        the icon set does not draw."""
+        self._name.setText(name)
+        if icon is None:
+            self._icon.clear()
+        else:
+            self._icon.setPixmap(icon)
+
+
+def icon_color(widget):
+    """The color a row on ``widget`` strokes its type icon in."""
+    palette = widget.palette()
+    return blend(palette.color(QtGui.QPalette.WindowText),
+                 palette.color(QtGui.QPalette.Window), _MUTED_MIX)
+
+
+def rules():
+    """The style rules a page carries for the rows it holds.
+
+    They travel with the row rather than sitting in each page's own sheet, so
+    the two lists the design draws cannot drift apart. A page appends them to
+    its sheet, which keeps one sheet covering every row it holds.
+    """
+    return f"""
+        QFrame#row {{
+            border-radius: {_RADIUS}px;
+        }}
+        QLabel#name {{
+            font-size: {_NAME_PX}px;
+        }}
+        """
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the Layers page of the Painter inspector.
+"""
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.base import _gui
+    from solvcon.pilot.canvas import _painter_gui, _painter_layers
+    from PySide6 import QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas, so a test can hand the page a world.
+
+    The real canvas reaches the page through the manager, which
+    :class:`PainterLayersCanvasTC` covers.
+    """
+
+    def __init__(self, world):
+        self.world = world
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PainterLayersPageTC(unittest.TestCase):
+    """What the list shows for the objects a world holds."""
+
+    @classmethod
+    def setUpClass(cls):
+        # No window needed, only a live QGuiApplication to hold a widget.
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        self.rid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.cid = self.world.add_circle(10, 10, 3)
+        self.canvas = _StubCanvas(self.world)
+        self.page = _painter_layers.LayersPage()
+        self.page.set_canvas_source(lambda: self.canvas)
+
+    def _names(self):
+        return [row.name for row in self.page.shown_rows]
+
+    def test_every_object_gets_a_row_newest_first(self):
+        # The world draws in registry order, so the last shape added is the
+        # one on top of the canvas and the first the list names.
+        self.assertEqual(self._names(),
+                         [f"Circle {self.cid}", f"Rectangle {self.rid}"])
+        self.assertTrue(self.page._empty.isHidden())
+
+    def test_rows_track_adding_removing_and_undo(self):
+        third = self.world.add_circle(0, 0, 1)
+        self.page.refresh()
+        self.assertEqual(self._names()[0], f"Circle {third}")
+
+        self.world.remove_shape(self.rid)
+        self.page.refresh()
+        self.assertNotIn(f"Rectangle {self.rid}", self._names())
+
+        self.world.undo()
+        self.page.refresh()
+        self.assertIn(f"Rectangle {self.rid}", self._names())
+
+    def test_an_object_with_no_icon_still_gets_a_row(self):
+        # The icon set draws the tools; the world holds shapes beyond them.
+        line = self.world.add_polyline([(0, 0), (1, 1), (2, 0)])
+        self.page.refresh()
+        self.assertEqual(self._names()[0], f"Polyline {line}")
+        self.assertTrue(self.page.shown_rows[0].icon.isNull())
+
+    def test_an_empty_world_shows_the_empty_note(self):
+        self.canvas = _StubCanvas(solvcon.WorldFp64())
+        self.page.refresh()
+        self.assertEqual(self._names(), [])
+        self.assertFalse(self.page._empty.isHidden())
+
+    def test_closing_the_canvas_clears_the_list(self):
+        # The page asks for the canvas again on every read.
+        self.canvas = None
+        self.page.refresh()
+        self.assertEqual(self._names(), [])
+
+    def test_the_page_fits_the_designed_inspector(self):
+        self.assertLessEqual(self.page.sizeHint().width(),
+                             _painter_gui.PainterPanel._INSPECTOR_WIDTH)
+
+    def test_the_page_restyles_with_the_palette(self):
+        # A color captured once would survive a theme switch as is, and the
+        # rows hold the icons the page handed them.
+        before = self.page.styleSheet()
+        icon = self.page.shown_rows[0].icon.toImage()
+        palette = QtGui.QPalette(self.page.palette())
+        palette.setColor(QtGui.QPalette.Window, QtGui.QColor("black"))
+        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
+        self.page.setPalette(palette)
+        self.assertNotEqual(self.page.styleSheet(), before)
+        self.assertNotEqual(self.page.shown_rows[0].icon.toImage(), icon)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class PainterLayersCanvasTC(unittest.TestCase):
+    """The page against a real canvas, bound by the Painter dock."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.painter = _gui.controller.painter
+        self.painter._ensure_dock()
+        # The manager is shared with every other pilot suite, and a canvas one
+        # of them left open would answer for this one's once it closes.
+        for subwin in self.mgr.mdiArea.subWindowList():
+            subwin.close()
+        QtWidgets.QApplication.processEvents()
+        self.widget = self.mgr.add2DWidget()
+        self.world = solvcon.WorldFp64()
+        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(self.world)
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        # The manager and its Painter dock outlive this class, so a canvas
+        # left open would answer for the tests that follow.
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+
+    def test_the_list_follows_the_active_canvas(self):
+        page = self.painter.panel.layers
+        # Activation is delivered through a zero timer, so let it run.
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual([row.name for row in page.shown_rows],
+                         [f"Rectangle {self.sid}"])
+
+    def test_closing_the_canvas_leaves_the_list_standing(self):
+        # The sub-window deletes the canvas on close, and a page that held it
+        # would read freed memory on its next poll.
+        page = self.painter.panel.layers
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual(page.shown_rows, [])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Layers tab in the Painter inspector was a greyed-out summary of what it would hold. This fills it with the list itself: one row per live shape on the active canvas, carrying the type icon the tool box already draws and a name made of the type and the shape id, since the world has no names of its own yet. Rows run newest first, the order the design lists and the order the canvas stacks them in, and a shape type the icon set does not draw keeps its row with an empty icon slot so the names stay in one column.

The row lands in its own module rather than as the page's private class, because the design draws it twice: this list, and the short list at the foot of the Design page that follows once the world can name a shape. The rules that color it travel with it, so the two lists cannot drift apart, and a page appends them to its own sheet rather than repeating them.

The page polls the bound canvas the way the Design page does, because the world changes in C++ without a change signal. What the poll compares is the row content itself, which is both what the page shows and the read the redraw needs, so the world is serialized once a tick rather than once to decide and again to draw. The rows scroll inside the page so a crowded world cannot stretch it past the dock, and surplus rows are hidden rather than destroyed.

This is the first of three stacked changes for step 4 of the Painter redesign plan. The measurements each row carries and the selection tint come next, then the search field, filter chips, and footer. Each was split out to keep every diff reviewable.

Tests: tests/test_pilot_painter_layers.py covers the rows against a stub canvas and against a real one bound by the Painter dock. make lint is clean and make pytest passes (1818 passed, 13 skipped, 3 xfailed).

Related to #1175