### PR TITLE
Painter Layers 2: measure and mark the selection

### DIFF
--- a/solvcon/pilot/canvas/_painter_design.py
+++ b/solvcon/pilot/canvas/_painter_design.py
@@ -10,37 +10,17 @@ import math
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
-from ._painter_style import blend, rule, shade, PaletteStyled
+from ._painter_style import (blend, mono_font, obb_metrics, rule, shade,
+                             PaletteStyled)
 
 __all__ = [
     'DesignPage',
 ]
 
 
-def _mono_font():
-    """The stand-in for the mono font the design gives every number."""
-    return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
-
-
 def _format(value):
     """Return a world coordinate or length as the fields show it."""
     return f"{value:g}"
-
-
-def _obb_metrics(obb):
-    """Return the center, width, and height of an oriented bounding box.
-
-    The corners run top-left, top-right, bottom-right, bottom-left, so the two
-    sides give the shape's own width and height rather than the wider span a
-    rotated shape covers along the axes.
-    """
-    xs = obb[0::2]
-    ys = obb[1::2]
-    # Divided before summed: four corners far enough out add up past the
-    # double range, and the center would come back infinite.
-    return (sum(x / 4 for x in xs), sum(y / 4 for y in ys),
-            math.hypot(xs[1] - xs[0], ys[1] - ys[0]),
-            math.hypot(xs[3] - xs[0], ys[3] - ys[0]))
 
 
 def _lands_finite(obb, delta):
@@ -80,7 +60,7 @@ class _Field(QtWidgets.QFrame):
         label.setObjectName("axis")
         label.setFixedWidth(self._LETTER_WIDTH)
         self._edit = QtWidgets.QLineEdit(self)
-        self._edit.setFont(_mono_font())
+        self._edit.setFont(mono_font())
         self._edit.setReadOnly(not editable)
         # An editor asks for room for a line of text, and four of them would
         # open the dock wider than the inspector the design draws. The grid
@@ -310,7 +290,7 @@ class DesignPage(PaletteStyled):
         self._name.setObjectName("name")
         self._badge = QtWidgets.QLabel("1 selected", block)
         self._badge.setObjectName("badge")
-        self._badge.setFont(_mono_font())
+        self._badge.setFont(mono_font())
         layout = QtWidgets.QHBoxLayout()
         layout.setSpacing(self._HEADER_GAP)
         layout.addWidget(self._icon)
@@ -378,7 +358,7 @@ class DesignPage(PaletteStyled):
             self._icon_name = kind if kind in _painter_icons.ICONS else None
             self._name.setText(f"{kind.title()} {shape}")
             self._badge.setVisible(True)
-            metrics = _obb_metrics(world.shape_obb(shape))
+            metrics = obb_metrics(world.shape_obb(shape))
             for (letter, _editable), value in zip(self._POSITION, metrics):
                 self.fields[letter].setEnabled(True)
                 self.fields[letter].set_value(value)
@@ -401,7 +381,7 @@ class DesignPage(PaletteStyled):
         if world is None:
             return
         obb = world.shape_obb(shape)
-        center_x, center_y = _obb_metrics(obb)[:2]
+        center_x, center_y = obb_metrics(obb)[:2]
         if "X" == axis:
             delta = (value - center_x, 0.0)
         else:

--- a/solvcon/pilot/canvas/_painter_layers.py
+++ b/solvcon/pilot/canvas/_painter_layers.py
@@ -11,7 +11,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
 from . import _painter_rows
-from ._painter_style import blend, PaletteStyled
+from ._painter_style import blend, obb_metrics, PaletteStyled
 
 __all__ = [
     'LayersPage',
@@ -24,7 +24,9 @@ class LayersPage(PaletteStyled):
     Like the Design page, the page reads the canvas it is bound to on a timer,
     because the world changes in C++ without a change signal. What the poll
     compares is the row content itself, which is both what the page shows and
-    the only fingerprint that cannot go stale as the rows grow what they say.
+    the only fingerprint that cannot go stale: a coarser one, such as the
+    world's serialized boxes, reads the same for a shape lying along the axes
+    and one of the other proportions turned onto them.
 
     The rows are read-only: what a row shows comes from the world, and picking
     an object stays the canvas's job until the list grows selection of its own.
@@ -33,7 +35,7 @@ class LayersPage(PaletteStyled):
     # Poll period in milliseconds. Between the entity tree's half second and
     # the Design page's 60ms: the whole world is serialized per tick, which is
     # too much to pay at the faster rate, while the half second reads as lag
-    # against a canvas the user is drawing on.
+    # when a click moves the highlight from row to row.
     _POLL_MS = 250
 
     #: What the list says while the world holds nothing.
@@ -136,10 +138,20 @@ class LayersPage(PaletteStyled):
         """The 2D canvas to read, or ``None`` when none is active."""
         return None if self._source is None else self._source()
 
-    def _world(self):
-        """The active canvas's world, or ``None`` when it has none."""
+    def _selection(self):
+        """The active canvas's world and its live selection.
+
+        ``selectedShape`` hands back the stored id without checking it, so a
+        shape that was removed or undone away leaves a stale id behind and the
+        queries the page runs on it would throw. Such a selection reads here
+        as none at all.
+        """
         widget = self._canvas()
-        return None if widget is None else widget.world
+        world = None if widget is None else widget.world
+        if world is None:
+            return None, -1
+        selected = widget.selectedShape
+        return world, selected if world.shape_is_live(selected) else -1
 
     @staticmethod
     def _objects(world):
@@ -158,15 +170,18 @@ class LayersPage(PaletteStyled):
         world is read once per tick rather than once to decide and again to
         draw.
         """
-        world = self._world()
+        world, selected = self._selection()
         if world is None:
             return ()
-        return tuple((shape["type"], self._name_of(shape))
+        return tuple((shape["type"], self._name_of(shape),
+                      self._metric_of(world, shape),
+                      shape["id"] == selected)
                      for shape in self._objects(world))
 
     def _render(self, content):
-        for index, (kind, name) in enumerate(content):
-            self._row(index).show_object(name, self._icon_of(kind))
+        for index, (kind, name, metric, picked) in enumerate(content):
+            self._row(index).show_object(
+                name, metric, self._icon_of(kind, picked), picked)
         for row in self.rows[len(content):]:
             row.hide()
         self._empty.setVisible(not content)
@@ -189,24 +204,37 @@ class LayersPage(PaletteStyled):
         """
         return f"{shape['type'].title()} {shape['id']}"
 
-    def _icon_of(self, name):
+    @staticmethod
+    def _metric_of(world, shape):
+        """The one measurement the row shows: a circle's radius, or the
+        width and height of anything else.
+
+        Both come from the shape's own oriented box, because the serialized
+        box is axis-aligned and reads wider than a rotated shape really is.
+        """
+        width, height = obb_metrics(world.shape_obb(shape["id"]))[2:]
+        if "circle" == shape["type"]:
+            return f"r {0.5 * width:g}"
+        return f"{width:g} x {height:g}"
+
+    def _icon_of(self, name, selected):
         """The icon for the shape type ``name``, or ``None`` for a type the
         icon set does not draw yet.
 
-        The pixmaps are cached per type: a world of many objects would
-        otherwise rasterize the same handful of icons on every change. The
-        cache is dropped when the palette changes, and keyed by the scale it
-        rasterized for, because the move to a screen of another scale is not
-        reported on every Qt the pilot builds against.
+        The pixmaps are cached per type and appearance: a world of many
+        objects would otherwise rasterize the same handful of icons on every
+        change. The cache is dropped when the palette changes, and keyed by
+        the scale it rasterized for, because the move to a screen of another
+        scale is not reported on every Qt the pilot builds against.
         """
         if name not in _painter_icons.ICONS:
             return None
         ratio = self.devicePixelRatioF()
-        key = (name, ratio)
+        key = (name, selected, ratio)
         if key not in self._pixmaps:
             self._pixmaps[key] = _painter_icons.render(
-                name, _painter_rows.icon_color(self), _painter_rows.ICON_PX,
-                ratio)
+                name, _painter_rows.icon_color(self, selected),
+                _painter_rows.ICON_PX, ratio)
         return self._pixmaps[key]
 
     def _apply_style(self):
@@ -214,7 +242,7 @@ class LayersPage(PaletteStyled):
         palette = self.palette()
         text = palette.color(QtGui.QPalette.WindowText)
         panel = palette.color(QtGui.QPalette.Window)
-        self.setStyleSheet(_painter_rows.rules() + f"""
+        self.setStyleSheet(_painter_rows.rules(self) + f"""
             QLabel#empty {{
                 font-size: {self._EMPTY_PX}px;
                 color: {blend(text, panel, self._GREYED_MIX).name()};

--- a/solvcon/pilot/canvas/_painter_rows.py
+++ b/solvcon/pilot/canvas/_painter_rows.py
@@ -11,7 +11,7 @@ live together here rather than in either page.
 
 from PySide6 import QtGui, QtWidgets
 
-from ._painter_style import blend
+from ._painter_style import blend, mono_font
 
 __all__ = [
     'ICON_PX',
@@ -28,14 +28,22 @@ HEIGHT = 30
 _MARGINS = (8, 0, 8, 0)
 _GAP = 8
 _NAME_PX = 12
+_METRIC_PX = 10
 _RADIUS = 5
 
-# How far the type icon sits from the panel color.
+# How far the type icon and the metric sit from the panel color, and how far
+# the selected row's tint sits from it.
 _MUTED_MIX = 0.35
+_SELECTED_MIX = 0.15
 
 
 class ObjectRow(QtWidgets.QFrame):
-    """One object row: a type icon, then the object's name."""
+    """One object row: a type icon, the object's name, and its key metric.
+
+    The row wears the accent tint while the canvas has its object selected.
+    That state is a Qt property rather than a second style sheet, so a page
+    writes one sheet for every row and Qt re-reads it as the selection moves.
+    """
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -45,12 +53,16 @@ class ObjectRow(QtWidgets.QFrame):
         self._icon.setFixedWidth(ICON_PX)
         self._name = QtWidgets.QLabel(self)
         self._name.setObjectName("name")
+        self._metric = QtWidgets.QLabel(self)
+        self._metric.setObjectName("metric")
+        self._metric.setFont(mono_font())
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(*_MARGINS)
         layout.setSpacing(_GAP)
         layout.addWidget(self._icon)
         layout.addWidget(self._name)
         layout.addStretch(1)
+        layout.addWidget(self._metric)
 
     @property
     def name(self):
@@ -58,40 +70,81 @@ class ObjectRow(QtWidgets.QFrame):
         return self._name.text()
 
     @property
+    def metric(self):
+        """The measurement the row shows."""
+        return self._metric.text()
+
+    @property
     def icon(self):
         """The type icon the row shows."""
         return self._icon.pixmap()
 
-    def show_object(self, name, icon):
+    @property
+    def metric_color(self):
+        """The color the metric reads in, as the style sheet resolved it."""
+        return self._metric.palette().color(QtGui.QPalette.WindowText)
+
+    def selected(self):
+        """Whether the row stands for the canvas's selection."""
+        return bool(self.property("selected"))
+
+    def show_object(self, name, metric, icon, selected):
         """Show one object, ``icon`` being its pixmap or ``None`` for a type
         the icon set does not draw."""
         self._name.setText(name)
+        self._metric.setText(metric)
         if icon is None:
             self._icon.clear()
         else:
             self._icon.setPixmap(icon)
+        if selected != self.selected():
+            self.setProperty("selected", selected)
+            # A property the style sheet selects on only reaches the paint
+            # after the widget is polished against the sheet again. The metric
+            # is colored by a rule that reads the property off the row, and Qt
+            # resolves a widget's rules against its own cache, so the label
+            # has to be polished alongside the row it hangs from.
+            for widget in (self, self._metric):
+                widget.style().unpolish(widget)
+                widget.style().polish(widget)
 
 
-def icon_color(widget):
+def icon_color(widget, selected):
     """The color a row on ``widget`` strokes its type icon in."""
     palette = widget.palette()
+    if selected:
+        return palette.color(QtGui.QPalette.Highlight)
     return blend(palette.color(QtGui.QPalette.WindowText),
                  palette.color(QtGui.QPalette.Window), _MUTED_MIX)
 
 
-def rules():
-    """The style rules a page carries for the rows it holds.
+def rules(widget):
+    """The style rules ``widget`` carries for the rows it holds.
 
     They travel with the row rather than sitting in each page's own sheet, so
     the two lists the design draws cannot drift apart. A page appends them to
     its sheet, which keeps one sheet covering every row it holds.
     """
+    palette = widget.palette()
+    text = palette.color(QtGui.QPalette.WindowText)
+    panel = palette.color(QtGui.QPalette.Window)
+    accent = palette.color(QtGui.QPalette.Highlight)
     return f"""
         QFrame#row {{
             border-radius: {_RADIUS}px;
         }}
+        QFrame#row[selected="true"] {{
+            background: {blend(panel, accent, _SELECTED_MIX).name()};
+        }}
         QLabel#name {{
             font-size: {_NAME_PX}px;
+        }}
+        QLabel#metric {{
+            font-size: {_METRIC_PX}px;
+            color: {blend(text, panel, _MUTED_MIX).name()};
+        }}
+        QFrame#row[selected="true"] QLabel#metric {{
+            color: {accent.name()};
         }}
         """
 

--- a/solvcon/pilot/canvas/_painter_style.py
+++ b/solvcon/pilot/canvas/_painter_style.py
@@ -2,12 +2,15 @@
 # BSD 3-Clause License, see COPYING
 
 """
-Palette-derived styling shared by the pieces of the Painter panel.
+Palette-derived styling shared by the pieces of the Painter panel, with the
+small conversions its pages share.
 
 The design's greys are all a step from the panel color toward the text color,
 so a piece that mixes its own shades follows a light/dark switch without
 naming a single hex value.
 """
+
+import math
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -15,6 +18,8 @@ __all__ = [
     'blend',
     'shade',
     'rule',
+    'mono_font',
+    'obb_metrics',
     'PaletteStyled',
 ]
 
@@ -30,6 +35,27 @@ def rule(shape):
     line.setFrameShape(shape)
     line.setFrameShadow(QtWidgets.QFrame.Sunken)
     return line
+
+
+def mono_font():
+    """The stand-in for the mono font the design gives every number."""
+    return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
+
+
+def obb_metrics(obb):
+    """Return the center, width, and height of an oriented bounding box.
+
+    The corners run top-left, top-right, bottom-right, bottom-left, so the two
+    sides give the shape's own width and height rather than the wider span a
+    rotated shape covers along the axes.
+    """
+    xs = obb[0::2]
+    ys = obb[1::2]
+    # Divided before summed: four corners far enough out add up past the
+    # double range, and the center would come back infinite.
+    return (sum(x / 4 for x in xs), sum(y / 4 for y in ys),
+            math.hypot(xs[1] - xs[0], ys[1] - ys[0]),
+            math.hypot(xs[3] - xs[0], ys[3] - ys[0]))
 
 
 def blend(color, other, ratio):

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -5,6 +5,7 @@
 Tests for the Layers page of the Painter inspector.
 """
 
+import math
 import os
 import unittest
 
@@ -14,7 +15,7 @@ try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
     from solvcon.pilot.canvas import _painter_gui, _painter_layers
-    from PySide6 import QtGui, QtWidgets
+    from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pilot = None
 
@@ -24,15 +25,31 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-class _StubCanvas:
-    """Stand-in for the 2D canvas, so a test can hand the page a world.
+def _click(widget, x, y):
+    """Post a synthetic left-button press and release to ``widget``."""
+    pos = QtCore.QPointF(x, y)
+    glob = QtCore.QPointF(widget.mapToGlobal(pos.toPoint()))
+    for etype, button, buttons in (
+            (QtCore.QEvent.Type.MouseButtonPress,
+             QtCore.Qt.LeftButton, QtCore.Qt.LeftButton),
+            (QtCore.QEvent.Type.MouseButtonRelease,
+             QtCore.Qt.LeftButton, QtCore.Qt.NoButton)):
+        QtWidgets.QApplication.sendEvent(
+            widget,
+            QtGui.QMouseEvent(etype, pos, glob, button, buttons,
+                              QtCore.Qt.NoModifier))
 
-    The real canvas reaches the page through the manager, which
-    :class:`PainterLayersCanvasTC` covers.
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas, so a test can set the selection directly.
+
+    The real canvas only changes it through a mouse gesture on a live window,
+    which :class:`PainterLayersCanvasTC` covers.
     """
 
     def __init__(self, world):
         self.world = world
+        self.selectedShape = -1
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
@@ -52,8 +69,15 @@ class PainterLayersPageTC(unittest.TestCase):
         self.page = _painter_layers.LayersPage()
         self.page.set_canvas_source(lambda: self.canvas)
 
+    def _select(self, shape_id):
+        self.canvas.selectedShape = shape_id
+        self.page.refresh()
+
     def _names(self):
         return [row.name for row in self.page.shown_rows]
+
+    def _selected(self):
+        return [row.name for row in self.page.shown_rows if row.selected()]
 
     def test_every_object_gets_a_row_newest_first(self):
         # The world draws in registry order, so the last shape added is the
@@ -61,6 +85,63 @@ class PainterLayersPageTC(unittest.TestCase):
         self.assertEqual(self._names(),
                          [f"Circle {self.cid}", f"Rectangle {self.rid}"])
         self.assertTrue(self.page._empty.isHidden())
+
+    def test_the_metric_is_the_radius_or_the_size(self):
+        self.assertEqual([row.metric for row in self.page.shown_rows],
+                         ["r 3", "4 x 2"])
+
+    def test_a_rotated_shape_reports_its_own_size(self):
+        # A quarter turn leaves the rectangle 4 by 2; only the axis-aligned
+        # span it covers swaps, and that is not what the row shows.
+        self.world.rotate_shape(self.rid, 0.5 * math.pi, 0.0, 0.0)
+        self.page.refresh()
+        self.assertEqual(self.page.shown_rows[1].metric, "4 x 2")
+
+    def test_the_highlight_follows_the_selection(self):
+        # A pick moves no geometry, so a poll watching the world alone would
+        # miss it.
+        self.assertEqual(self._selected(), [])
+        self._select(self.cid)
+        self.assertEqual(self._selected(), [f"Circle {self.cid}"])
+        self._select(self.rid)
+        self.assertEqual(self._selected(), [f"Rectangle {self.rid}"])
+
+    def test_the_selected_row_is_drawn_apart(self):
+        self._select(self.cid)
+        selected, plain = self.page.shown_rows
+        self.assertNotEqual(selected.icon.toImage(), plain.icon.toImage())
+        # The metric is colored by a rule reading the row's own property, and
+        # a label Qt was not asked to polish again keeps the color it had.
+        self.assertNotEqual(selected.metric_color, plain.metric_color)
+        self._select(self.rid)
+        selected, plain = self.page.shown_rows[1], self.page.shown_rows[0]
+        self.assertNotEqual(selected.metric_color, plain.metric_color)
+
+    def test_a_dead_selection_highlights_nothing(self):
+        # The canvas keeps the id it stored, and a query on a dead one throws.
+        self._select(self.rid)
+        self.world.remove_shape(self.rid)
+        self.page.refresh()
+        self.assertEqual(self._selected(), [])
+        self.assertEqual(self._names(), [f"Circle {self.cid}"])
+
+    def test_a_canvas_of_the_same_boxes_still_redraws(self):
+        # A rotated shape covers a wider span than it measures, so a second
+        # canvas can serialize the very boxes of the first while its rows read
+        # differently. The poll compares the rows, not the boxes, or the page
+        # would keep showing the canvas it left.
+        other = solvcon.WorldFp64()
+        turned = other.add_rectangle(-1, -2, 1, 2)
+        other.rotate_shape(turned, 0.5 * math.pi, 0.0, 0.0)
+        other.add_circle(10, 10, 3)
+        for mine, theirs in zip(self.world.shape_bbox(self.rid),
+                                other.shape_bbox(turned)):
+            self.assertAlmostEqual(mine, theirs)
+
+        self.canvas = _StubCanvas(other)
+        self.page.refresh()
+        self.assertEqual([row.metric for row in self.page.shown_rows],
+                         ["r 3", "2 x 4"])
 
     def test_rows_track_adding_removing_and_undo(self):
         third = self.world.add_circle(0, 0, 1)
@@ -101,11 +182,13 @@ class PainterLayersPageTC(unittest.TestCase):
     def test_the_page_restyles_with_the_palette(self):
         # A color captured once would survive a theme switch as is, and the
         # rows hold the icons the page handed them.
+        self._select(self.cid)
         before = self.page.styleSheet()
         icon = self.page.shown_rows[0].icon.toImage()
         palette = QtGui.QPalette(self.page.palette())
         palette.setColor(QtGui.QPalette.Window, QtGui.QColor("black"))
         palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
+        palette.setColor(QtGui.QPalette.Highlight, QtGui.QColor("red"))
         self.page.setPalette(palette)
         self.assertNotEqual(self.page.styleSheet(), before)
         self.assertNotEqual(self.page.shown_rows[0].icon.toImage(), icon)
@@ -126,9 +209,16 @@ class PainterLayersCanvasTC(unittest.TestCase):
             subwin.close()
         QtWidgets.QApplication.processEvents()
         self.widget = self.mgr.add2DWidget()
+        self.widget.setDrawTool("select")
         self.world = solvcon.WorldFp64()
         self.sid = self.world.add_rectangle(-2, -1, 2, 1)
         self.widget.updateWorld(self.world)
+        view = solvcon.ViewTransform2dFp64()
+        view.pan(100.0, 100.0)
+        view.zoom = 20.0
+        # Set the view before showing so the resize auto-centering, which a
+        # well-formed transform disables, leaves the mapping deterministic.
+        self.widget.setViewTransform(view)
         self.mgr.show()
         self.sub = self.mgr.mdiArea.subWindowList()[-1]
         self.sub.show()
@@ -148,6 +238,15 @@ class PainterLayersCanvasTC(unittest.TestCase):
         page.refresh()
         self.assertEqual([row.name for row in page.shown_rows],
                          [f"Rectangle {self.sid}"])
+
+    def test_the_highlight_follows_a_pick_on_the_canvas(self):
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        _click(self.sub.widget(), 100, 100)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        page.refresh()
+        selected = [row.name for row in page.shown_rows if row.selected()]
+        self.assertEqual(selected, [f"Rectangle {self.sid}"])
 
     def test_closing_the_canvas_leaves_the_list_standing(self):
         # The sub-window deletes the canvas on close, and a page that held it


### PR DESCRIPTION
The Layers page listed the objects on the active canvas but said nothing about their size or which one the canvas had picked. Each row now carries the one measurement the design gives it, a circle's radius or the width and height of anything else, both read from the shape's own oriented box so a rotated shape reports the size it was drawn with rather than the wider span it covers along the axes.

The row the canvas has selected wears the accent tint and strokes its icon and metric in the accent. The sync is one way, canvas to list; picking from the list waits for the follow-up that gives it a selection of its own. A selection the world has since removed or undone away reads as no selection, because the canvas hands back the stored id without checking it and every query on a dead one throws.

Marking the row means polishing the metric with it: the rule that colors the metric reads the selected property off the row, and Qt resolves each widget's style rules against its own cache, so a label left unpolished keeps the color it had under the previous selection. A test covers it, and it fails without the fix.

Measuring the shape rather than its serialized box is also what keeps the poll honest. The world serializes an axis-aligned box, and a shape lying along the axes covers the very box of one of the other proportions turned onto them, so a fingerprint taken from those boxes reads the same for two canvases the page must tell apart.

The metric and the tint land on the shared row module, so the Design page's short list inherits them when it arrives. The font and oriented-box helpers move from the Design page into the shared style module for the same reason.

Second of three stacked changes for step 4 of the Painter redesign plan, on top of #1211. The search field, filter chips, and footer follow.

Tests: make lint is clean and make pytest passes (1825 passed, 13 skipped, 3 xfailed).

Related to #1175