### PR TITLE
Painter Layers 3: give the page its search, filters, and footer

### DIFF
--- a/solvcon/pilot/canvas/_painter_icons.py
+++ b/solvcon/pilot/canvas/_painter_icons.py
@@ -39,6 +39,9 @@ ICONS = {
     "text": '<path d="M3 4V2.8h10V4M8 2.8v10.4M6 13.2h4"/>',
     "grid": ('<path d="M2 2h12v12H2z"/>'
              '<path d="M2 6h12M6 2v12" opacity="0.6"/>'),
+    "search": '<circle cx="7" cy="7" r="4.5"/><path d="M10.4 10.4L14 14"/>',
+    "plus": '<path d="M8 3.5v9M3.5 8h9"/>',
+    "minus": '<path d="M3.5 8h9"/>',
 }
 
 

--- a/solvcon/pilot/canvas/_painter_layers.py
+++ b/solvcon/pilot/canvas/_painter_layers.py
@@ -11,11 +11,127 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _painter_icons
 from . import _painter_rows
-from ._painter_style import blend, obb_metrics, PaletteStyled
+from ._painter_style import (blend, mono_font, obb_metrics, rule, shade,
+                             PaletteStyled)
 
 __all__ = [
     'LayersPage',
 ]
+
+
+class _Filters(QtWidgets.QWidget):
+    """The greyed-out search field over the filter chips.
+
+    Both wait on the same follow-ups, object names and guides, and the design
+    draws them as one block above the list, so they are built together.
+    """
+
+    _SEARCH_MARGINS = (10, 10, 10, 8)
+    _SEARCH_HEIGHT = 28
+    _SEARCH_PADDING = (8, 0, 8, 0)
+    _SEARCH_GAP = 8
+    _CHIP_MARGINS = (10, 0, 10, 8)
+    _CHIP_GAP = 6
+    _ICON_PX = 12
+
+    #: The filter chips, in design order; the first is the one shown active.
+    CHIPS = ("All", "Shapes", "Guides")
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.chips = {}
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addLayout(self._build_search())
+        layout.addLayout(self._build_chips())
+        self.setEnabled(False)
+
+    def set_icon(self, icon):
+        """Draw the search glass in ``icon``."""
+        self._glass.setPixmap(icon)
+
+    def _build_search(self):
+        self.search = QtWidgets.QFrame(self)
+        self.search.setObjectName("search")
+        self.search.setFixedHeight(self._SEARCH_HEIGHT)
+        self.search.setToolTip("Search objects  (needs object names)")
+        self._glass = QtWidgets.QLabel(self.search)
+        self._glass.setFixedWidth(self._ICON_PX)
+        edit = QtWidgets.QLineEdit(self.search)
+        edit.setObjectName("query")
+        edit.setPlaceholderText("Search objects")
+        inside = QtWidgets.QHBoxLayout(self.search)
+        inside.setContentsMargins(*self._SEARCH_PADDING)
+        inside.setSpacing(self._SEARCH_GAP)
+        inside.addWidget(self._glass)
+        inside.addWidget(edit, 1)
+        layout = QtWidgets.QHBoxLayout()
+        layout.setContentsMargins(*self._SEARCH_MARGINS)
+        layout.addWidget(self.search)
+        return layout
+
+    def _build_chips(self):
+        layout = QtWidgets.QHBoxLayout()
+        layout.setContentsMargins(*self._CHIP_MARGINS)
+        layout.setSpacing(self._CHIP_GAP)
+        for index, name in enumerate(self.CHIPS):
+            chip = QtWidgets.QPushButton(name, self)
+            chip.setObjectName("chip")
+            chip.setCheckable(True)
+            chip.setChecked(0 == index)
+            chip.setToolTip(f"{name}  (needs guides and object names)")
+            layout.addWidget(chip)
+            self.chips[name] = chip
+        layout.addStretch(1)
+        return layout
+
+
+class _Footer(QtWidgets.QWidget):
+    """The list footer: the greyed-out add and remove buttons, then a count."""
+
+    _MARGINS = (10, 8, 12, 8)
+    _GAP = 6
+    _BUTTON_SIZE = (26, 24)
+    _ICON_PX = 12
+
+    #: The greyed-out buttons, as ``(icon name, what the button does)``.
+    BUTTONS = (("plus", "Add object"), ("minus", "Remove object"))
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.buttons = {}
+        self.count = QtWidgets.QLabel(self)
+        self.count.setObjectName("count")
+        self.count.setFont(mono_font())
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        for name, what in self.BUTTONS:
+            layout.addWidget(self._build_button(name, what))
+        layout.addStretch(1)
+        layout.addWidget(self.count)
+
+    def set_icons(self, ratio, color):
+        """Draw each button in ``color``, rasterized for ``ratio``.
+
+        The buttons are greyed out for good, so the icon is offered for the
+        disabled state alone and carries the greyed color the page mixed,
+        rather than whatever fade the style would apply to a normal one.
+        """
+        for name, button in self.buttons.items():
+            button.setIcon(_painter_icons.placeholder_icon(
+                name, self._ICON_PX, color, ratio))
+
+    def _build_button(self, name, what):
+        button = QtWidgets.QToolButton(self)
+        button.setObjectName("footer")
+        button.setFixedSize(*self._BUTTON_SIZE)
+        button.setIconSize(QtCore.QSize(self._ICON_PX, self._ICON_PX))
+        button.setToolTip(f"{what}  (needs editing from the list)")
+        button.setEnabled(False)
+        self.buttons[name] = button
+        return button
 
 
 class LayersPage(PaletteStyled):
@@ -41,12 +157,21 @@ class LayersPage(PaletteStyled):
     #: What the list says while the world holds nothing.
     EMPTY_TEXT = "No objects"
 
-    _LIST_MARGINS = (6, 8, 6, 8)
+    _LIST_MARGINS = (6, 0, 6, 0)
     _EMPTY_MARGINS = (12, 4, 12, 4)
     _EMPTY_PX = 12
+    _COUNT_PX = 10
+    _CHIP_PX = 10
+    _SEARCH_PX = 11
+    _RADIUS = 5
+    _CHIP_RADIUS = 11
+    _ICON_PX = 12
 
-    # How far the empty note sits from the panel color.
+    # How far each of these sits from the panel color.
+    _MUTED_MIX = 0.35
     _GREYED_MIX = 0.6
+    _CHIP_MIX = 0.15
+    _BORDER_MIX = 0.25
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -60,6 +185,20 @@ class LayersPage(PaletteStyled):
         self._timer.timeout.connect(self.refresh)
         self._apply_style()
         self._render(())
+
+    @property
+    def placeholders(self):
+        """The greyed-out controls as ``{name: widget}``."""
+        entries = {"Search": self._filters.search}
+        entries.update(self._filters.chips)
+        entries.update({what: self._footer.buttons[name]
+                        for name, what in _Footer.BUTTONS})
+        return entries
+
+    @property
+    def count(self):
+        """The footer's object count, as the footer words it."""
+        return self._footer.count.text()
 
     @property
     def shown_rows(self):
@@ -107,18 +246,23 @@ class LayersPage(PaletteStyled):
         self._render(content)
 
     def _build(self):
+        self._filters = _Filters(self)
         self._empty = QtWidgets.QLabel(self.EMPTY_TEXT, self)
         self._empty.setObjectName("empty")
+        self._footer = _Footer(self)
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
+        layout.addWidget(self._filters)
         layout.addWidget(self._build_list(), 1)
+        layout.addWidget(rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(self._footer)
 
     def _build_list(self):
         """The scrolling column of rows, with the empty note above it.
 
-        A world of many objects would otherwise grow the page past the dock,
-        so the column scrolls inside the page rather than stretching it.
+        A world of many objects would otherwise push the footer off the dock,
+        so the column scrolls inside the page rather than growing it.
         """
         body = QtWidgets.QWidget()
         self._rows_layout = QtWidgets.QVBoxLayout(body)
@@ -185,6 +329,8 @@ class LayersPage(PaletteStyled):
         for row in self.rows[len(content):]:
             row.hide()
         self._empty.setVisible(not content)
+        self._footer.count.setText(
+            "1 shape" if 1 == len(content) else f"{len(content)} shapes")
 
     def _row(self, index):
         """The row at ``index``, built and shown if it is a new one."""
@@ -238,16 +384,52 @@ class LayersPage(PaletteStyled):
         return self._pixmaps[key]
 
     def _apply_style(self):
-        """Color the rows and the empty note from the palette."""
+        """Color the rows, the placeholders, and the footer from the
+        palette."""
         palette = self.palette()
         text = palette.color(QtGui.QPalette.WindowText)
         panel = palette.color(QtGui.QPalette.Window)
+        greyed = blend(text, panel, self._GREYED_MIX)
         self.setStyleSheet(_painter_rows.rules(self) + f"""
             QLabel#empty {{
                 font-size: {self._EMPTY_PX}px;
-                color: {blend(text, panel, self._GREYED_MIX).name()};
+                color: {greyed.name()};
+            }}
+            QLabel#count {{
+                font-size: {self._COUNT_PX}px;
+                color: {blend(text, panel, self._MUTED_MIX).name()};
+            }}
+            QFrame#search {{
+                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border-radius: {self._RADIUS}px;
+                background: {palette.color(QtGui.QPalette.Base).name()};
+            }}
+            QLineEdit#query {{
+                border: none;
+                background: transparent;
+                font-size: {self._SEARCH_PX}px;
+            }}
+            QPushButton#chip {{
+                border: none;
+                border-radius: {self._CHIP_RADIUS}px;
+                padding: 3px 8px;
+                font-size: {self._CHIP_PX}px;
+                background: transparent;
+                color: {greyed.name()};
+            }}
+            QPushButton#chip:checked {{
+                background: {shade(self, self._CHIP_MIX).name()};
+            }}
+            QToolButton#footer {{
+                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border-radius: {self._RADIUS}px;
+                background: {palette.color(QtGui.QPalette.Base).name()};
             }}
             """)
+        ratio = self.devicePixelRatioF()
+        self._filters.set_icon(
+            _painter_icons.render("search", greyed, self._ICON_PX, ratio))
+        self._footer.set_icons(ratio, greyed)
         self._pixmaps.clear()
         # The rows hold the icons the cleared cache handed out, and a stale
         # one keeps the color it was rendered in through the theme switch.

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -84,6 +84,7 @@ class PainterLayersPageTC(unittest.TestCase):
         # one on top of the canvas and the first the list names.
         self.assertEqual(self._names(),
                          [f"Circle {self.cid}", f"Rectangle {self.rid}"])
+        self.assertEqual(self.page.count, "2 shapes")
         self.assertTrue(self.page._empty.isHidden())
 
     def test_the_metric_is_the_radius_or_the_size(self):
@@ -147,14 +148,17 @@ class PainterLayersPageTC(unittest.TestCase):
         third = self.world.add_circle(0, 0, 1)
         self.page.refresh()
         self.assertEqual(self._names()[0], f"Circle {third}")
+        self.assertEqual(self.page.count, "3 shapes")
 
         self.world.remove_shape(self.rid)
         self.page.refresh()
         self.assertNotIn(f"Rectangle {self.rid}", self._names())
+        self.assertEqual(self.page.count, "2 shapes")
 
         self.world.undo()
         self.page.refresh()
         self.assertIn(f"Rectangle {self.rid}", self._names())
+        self.assertEqual(self.page.count, "3 shapes")
 
     def test_an_object_with_no_icon_still_gets_a_row(self):
         # The icon set draws the tools; the world holds shapes beyond them.
@@ -167,6 +171,7 @@ class PainterLayersPageTC(unittest.TestCase):
         self.canvas = _StubCanvas(solvcon.WorldFp64())
         self.page.refresh()
         self.assertEqual(self._names(), [])
+        self.assertEqual(self.page.count, "0 shapes")
         self.assertFalse(self.page._empty.isHidden())
 
     def test_closing_the_canvas_clears_the_list(self):
@@ -174,6 +179,16 @@ class PainterLayersPageTC(unittest.TestCase):
         self.canvas = None
         self.page.refresh()
         self.assertEqual(self._names(), [])
+        self.assertEqual(self.page.count, "0 shapes")
+
+    def test_controls_the_model_cannot_fill_are_greyed_out(self):
+        self.assertEqual(list(self.page.placeholders),
+                         ["Search", "All", "Shapes", "Guides",
+                          "Add object", "Remove object"])
+        for name, control in self.page.placeholders.items():
+            with self.subTest(name=name):
+                self.assertFalse(control.isEnabled())
+                self.assertIn("needs", control.toolTip())
 
     def test_the_page_fits_the_designed_inspector(self):
         self.assertLessEqual(self.page.sizeHint().width(),


### PR DESCRIPTION
The Layers page listed and measured the objects on the active canvas, but stood alone above an empty page. This adds the rest of the design's Layers tab: a search field over the All/Shapes/Guides chips, and a footer that counts the objects the world holds between the add and remove buttons.

Everything but the count is greyed out and names what it waits for. The search field and the chips need object names and guides, neither of which the world has; the buttons need editing from the list, which waits on the selection the list does not own yet. They take their designed places now so the page keeps its shape and the follow-ups only fill them in.

The footer buttons carry their icon in the disabled state alone, wearing the greyed color the page mixed rather than whatever fade the style would otherwise apply. The search glass, plus, and minus join the icon set the tool box already draws from, and the rules that color the search field name it rather than every line edit the page may come to hold, so a later editor does not inherit a borderless field by accident.

Last of the three stacked changes for step 4 of the Painter redesign plan, after #1211 and #1212. With this the page matches the design's Layers tab; picking a shape from the list, object names, guides, and visibility remain follow-ups.

Tests: make lint is clean and make pytest passes (1826 passed, 13 skipped, 3 xfailed).

Related to #1175

<img width="1130" height="799" alt="Screenshot 2026-07-30 at 1 50 50 AM" src="https://github.com/user-attachments/assets/f4cfb51e-4f4c-4177-bbd1-a6db9a09a170" />
