### PR TITLE
Painter Layers 4: pick a shape on the canvas from the list

### DIFF
--- a/cpp/solvcon/pilot/canvas/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.cpp
@@ -132,6 +132,34 @@ void R2DWidget::setDrawTool(std::string const & name)
     update();
 }
 
+void R2DWidget::setSelectedShape(int32_t shape_id)
+{
+    // A draw tool paints no selection; accepting one would leave a rotate
+    // handle answering for a selection nothing draws.
+    if (m_tool->can_draw_shape())
+    {
+        return;
+    }
+    if (shape_id >= 0 && (!m_world || !m_world->shape_is_live(shape_id)))
+    {
+        return;
+    }
+    // Normalize every negative to the sentinel picking itself writes.
+    if (shape_id < 0)
+    {
+        shape_id = -1;
+    }
+    if (shape_id == m_selected)
+    {
+        return;
+    }
+    // End a gesture before the selection moves out from under its undo bracket.
+    endEditDrag();
+
+    m_selected = shape_id;
+    update();
+}
+
 void R2DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
 {
     // Close any edit gesture on the outgoing world before swapping it out.
@@ -339,6 +367,17 @@ void R2DWidget::finishEdit()
     }
 }
 
+void R2DWidget::endEditDrag()
+{
+    if (m_drag == EditDrag::None)
+    {
+        return;
+    }
+    finishEdit();
+    m_drag = EditDrag::None;
+    unsetCursor();
+}
+
 void R2DWidget::wheelEvent(QWheelEvent * event)
 {
     QPointF const pos = event->position();
@@ -487,10 +526,7 @@ void R2DWidget::mouseReleaseEvent(QMouseEvent * event)
     }
     if (event->button() == Qt::LeftButton && m_drag != EditDrag::None)
     {
-        // A move or rotate gesture ends here; commit it as one undo step.
-        finishEdit();
-        m_drag = EditDrag::None;
-        unsetCursor();
+        endEditDrag();
         update();
         event->accept();
         return;

--- a/cpp/solvcon/pilot/canvas/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.hpp
@@ -74,6 +74,9 @@ public:
      */
     int32_t selectedShape() const { return m_selected; }
 
+    /// Select a shape from outside the canvas, such as a list that names it, or a negative id to drop the selection.
+    void setSelectedShape(int32_t shape_id);
+
     /**
      * Screen position [x, y] of the selection's rotate handle, or [-1, -1]
      * when nothing is selected. Exposed for tests and tooling.
@@ -199,6 +202,12 @@ private:
      * such drag is active; a no-op then.
      */
     void finishEdit();
+
+    /**
+     * End an active move or rotate drag the way a mouse release ends it:
+     * commit the undo bracket, clear the gesture, and restore the cursor.
+     */
+    void endEditDrag();
 
     /// Which gesture the current select-tool left-drag performs.
     enum class EditDrag

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -676,7 +676,10 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                 "Follows the application theme.")
             .def("setDrawTool", &wrapped_type::setDrawTool, py::arg("name"))
             .def_property_readonly("drawTool", &wrapped_type::drawTool)
-            .def_property_readonly("selectedShape", &wrapped_type::selectedShape)
+            .def_property(
+                "selectedShape",
+                &wrapped_type::selectedShape,
+                &wrapped_type::setSelectedShape)
             .def_property_readonly(
                 "rotateHandleScreen",
                 [](wrapped_type & self)

--- a/solvcon/pilot/canvas/_painter_gui.py
+++ b/solvcon/pilot/canvas/_painter_gui.py
@@ -323,10 +323,13 @@ class PainterPanel(QtWidgets.QWidget):
         :type short_labels: dict or None
         """
         super().__init__(parent)
+        self._tool_actions = tool_actions
+        self._source = None
         self._tools = _DrawToolSelector(tool_actions, short_labels or {}, self)
         self._stack = QtWidgets.QStackedWidget()
         self._design = DesignPage(self._stack)
         self._layers = LayersPage(self._stack)
+        self._layers.picked.connect(self._on_picked)
         self._tabs = _SegmentedTabs(self.PAGES)
         self._tabs.selected.connect(self.show_page)
         self._inspector = self._build_inspector()
@@ -364,8 +367,31 @@ class PainterPanel(QtWidgets.QWidget):
 
     def set_canvas_source(self, source):
         """Tell the inspector how to reach the active 2D canvas."""
+        self._source = source
         for page in (self._design, self._layers):
             page.set_canvas_source(source)
+
+    def _on_picked(self, shape_id):
+        """Select on the canvas the shape a Layers row names."""
+        widget = None if self._source is None else self._source()
+        select = self._tool_actions.get("select")
+        if widget is None or select is None:
+            return
+        world = widget.world
+        # The list polls, so a row can lag the active canvas by one tick; ids
+        # start over per world, and a stale row can name an unrelated live id.
+        if (world is None
+                or not self._layers.draws_world(world)
+                or not world.shape_is_live(shape_id)):
+            self._layers.refresh()
+            return
+        # Arm select through the shared action so the menu and rail follow;
+        # the canvas paints no selection under a draw tool.
+        select.trigger()
+        widget.selectedShape = shape_id
+        # Catch both pages up on this click rather than waiting on their polls.
+        for page in (self._design, self._layers):
+            page.refresh()
 
     def refresh(self):
         """Re-read the active canvas now, without waiting for a poll.

--- a/solvcon/pilot/canvas/_painter_layers.py
+++ b/solvcon/pilot/canvas/_painter_layers.py
@@ -138,15 +138,17 @@ class LayersPage(PaletteStyled):
     """The inspector's Layers page: one row per object the world holds.
 
     Like the Design page, the page reads the canvas it is bound to on a timer,
-    because the world changes in C++ without a change signal. What the poll
-    compares is the row content itself, which is both what the page shows and
-    the only fingerprint that cannot go stale: a coarser one, such as the
-    world's serialized boxes, reads the same for a shape lying along the axes
-    and one of the other proportions turned onto them.
+    because the world changes in C++ without a change signal. The poll
+    compares the world identity, the selection, and the world's state string;
+    segment coordinates ride in that string, so a rotate rebuilds the list,
+    while an unchanged tick skips the per-shape oriented boxes the rows show.
 
-    The rows are read-only: what a row shows comes from the world, and picking
-    an object stays the canvas's job until the list grows selection of its own.
+    What a row shows comes from the world alone. A press on one is reported
+    through :attr:`picked` rather than acted on here, so the page keeps
+    showing the selection the canvas reports and never one of its own.
     """
+
+    picked = QtCore.Signal(int)
 
     # Poll period in milliseconds. Between the entity tree's half second and
     # the Design page's 60ms: the whole world is serialized per tick, which is
@@ -176,7 +178,8 @@ class LayersPage(PaletteStyled):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._source = None
-        self._key = None
+        self._fingerprint = None
+        self._world_id = None
         self._pixmaps = {}
         self.rows = []
         self._build()
@@ -210,6 +213,10 @@ class LayersPage(PaletteStyled):
         """
         return [row for row in self.rows if not row.isHidden()]
 
+    def draws_world(self, world):
+        """Whether the rows were last drawn for ``world``."""
+        return world is not None and id(world) == self._world_id
+
     def set_canvas_source(self, source):
         """Bind the page to ``source``, a callable handing back the canvas.
 
@@ -223,8 +230,10 @@ class LayersPage(PaletteStyled):
         # Rendered rather than refreshed: two blank canvases show the same
         # nothing, so a refresh would take the page for unchanged and leave
         # the previous canvas's objects on screen.
-        self._key = self._content()
-        self._render(self._key)
+        fingerprint, content = self._snapshot()
+        self._fingerprint = fingerprint
+        self._world_id = None if fingerprint is None else fingerprint[0]
+        self._render(content)
 
     def showEvent(self, event):
         """Poll the bound canvas only while the page is on screen."""
@@ -239,10 +248,11 @@ class LayersPage(PaletteStyled):
 
     def refresh(self):
         """Redraw the list when the canvas it is bound to has changed."""
-        content = self._content()
-        if content == self._key:
+        fingerprint, content = self._snapshot()
+        if fingerprint == self._fingerprint:
             return
-        self._key = content
+        self._fingerprint = fingerprint
+        self._world_id = None if fingerprint is None else fingerprint[0]
         self._render(content)
 
     def _build(self):
@@ -297,35 +307,32 @@ class LayersPage(PaletteStyled):
         selected = widget.selectedShape
         return world, selected if world.shape_is_live(selected) else -1
 
-    @staticmethod
-    def _objects(world):
-        """Every live shape the world holds, as the world describes it.
+    def _snapshot(self):
+        """Fingerprint and row content for the bound canvas, one world read.
 
-        Newest first, which is the order the design lists: the world draws in
-        registry order, so the last shape added is the one on top of the
-        canvas and the one the list names first.
-        """
-        return json.loads(world.describe_state())["shapes"][::-1]
-
-    def _content(self):
-        """One entry per row, in list order, as the rows will show it.
-
-        This is what the poll compares and what :meth:`_render` draws, so the
-        world is read once per tick rather than once to decide and again to
-        draw.
+        The fingerprint is what the poll compares: the world identity, the
+        selection, and the world's own state string. Segment coordinates ride
+        in that string, so a rotate changes it and the list rebuilds; an
+        unchanged tick skips the per-shape oriented boxes the rows show.
         """
         world, selected = self._selection()
         if world is None:
-            return ()
-        return tuple((shape["type"], self._name_of(shape),
-                      self._metric_of(world, shape),
-                      shape["id"] == selected)
-                     for shape in self._objects(world))
+            return None, ()
+        state = world.describe_state()
+        # Newest first: the world draws in registry order, so the last shape
+        # added is on top of the canvas and the one the list names first.
+        shapes = json.loads(state)["shapes"][::-1]
+        content = tuple(
+            (shape["id"], shape["type"], self._name_of(shape),
+             self._metric_of(world, shape), shape["id"] == selected)
+            for shape in shapes)
+        return (id(world), selected, state), content
 
     def _render(self, content):
-        for index, (kind, name, metric, picked) in enumerate(content):
+        for index, entry in enumerate(content):
+            shape_id, kind, name, metric, chosen = entry
             self._row(index).show_object(
-                name, metric, self._icon_of(kind, picked), picked)
+                shape_id, name, metric, self._icon_of(kind, chosen), chosen)
         for row in self.rows[len(content):]:
             row.hide()
         self._empty.setVisible(not content)
@@ -336,6 +343,7 @@ class LayersPage(PaletteStyled):
         """The row at ``index``, built and shown if it is a new one."""
         while len(self.rows) <= index:
             row = _painter_rows.ObjectRow(self)
+            row.picked.connect(self.picked)
             # Above the trailing stretch, so the rows stay packed at the top.
             self._rows_layout.insertWidget(len(self.rows) + 1, row)
             self.rows.append(row)
@@ -433,7 +441,7 @@ class LayersPage(PaletteStyled):
         self._pixmaps.clear()
         # The rows hold the icons the cleared cache handed out, and a stale
         # one keeps the color it was rendered in through the theme switch.
-        self._key = None
+        self._fingerprint = None
         self.refresh()
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/canvas/_painter_rows.py
+++ b/solvcon/pilot/canvas/_painter_rows.py
@@ -9,7 +9,7 @@ list at the foot of the Design page, so the widget and the rules that color it
 live together here rather than in either page.
 """
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from ._painter_style import blend, mono_font
 
@@ -43,12 +43,20 @@ class ObjectRow(QtWidgets.QFrame):
     The row wears the accent tint while the canvas has its object selected.
     That state is a Qt property rather than a second style sheet, so a page
     writes one sheet for every row and Qt re-reads it as the selection moves.
+
+    A press hands the shape it stands for to whoever owns the list; the row
+    neither reaches the canvas nor marks itself, so the selection it shows
+    stays the one the canvas reports.
     """
+
+    picked = QtCore.Signal(int)
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("row")
         self.setFixedHeight(HEIGHT)
+        self.setCursor(QtCore.Qt.PointingHandCursor)
+        self._shape_id = -1
         self._icon = QtWidgets.QLabel(self)
         self._icon.setFixedWidth(ICON_PX)
         self._name = QtWidgets.QLabel(self)
@@ -88,9 +96,10 @@ class ObjectRow(QtWidgets.QFrame):
         """Whether the row stands for the canvas's selection."""
         return bool(self.property("selected"))
 
-    def show_object(self, name, metric, icon, selected):
-        """Show one object, ``icon`` being its pixmap or ``None`` for a type
-        the icon set does not draw."""
+    def show_object(self, shape_id, name, metric, icon, selected):
+        """Show the shape ``shape_id``, ``icon`` being its pixmap or ``None``
+        for a type the icon set does not draw."""
+        self._shape_id = shape_id
         self._name.setText(name)
         self._metric.setText(metric)
         if icon is None:
@@ -107,6 +116,11 @@ class ObjectRow(QtWidgets.QFrame):
             for widget in (self, self._metric):
                 widget.style().unpolish(widget)
                 widget.style().polish(widget)
+
+    def mousePressEvent(self, event):
+        super().mousePressEvent(event)
+        if QtCore.Qt.LeftButton == event.button():
+            self.picked.emit(self._shape_id)
 
 
 def icon_color(widget, selected):

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -243,6 +243,41 @@ class R2DWidgetWorldTC(unittest.TestCase):
         self.widget.updateWorld(solvcon.WorldFp64())
         self.assertEqual(self.widget.selectedShape, -1)
 
+    def test_selecting_a_shape_from_outside_the_canvas(self):
+        """A list that names a shape can select it; the canvas turns away an
+        id it cannot draw a selection for."""
+        world = solvcon.WorldFp64()
+        sid = world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(world)
+        self.widget.setDrawTool("select")
+
+        self.widget.selectedShape = sid
+        self.assertEqual(self.widget.selectedShape, sid)
+        # Neither an id the world never held nor one it has buried moves the
+        # selection, because nothing would be drawn for either.
+        self.widget.selectedShape = sid + 100
+        self.assertEqual(self.widget.selectedShape, sid)
+
+        self.widget.selectedShape = -1
+        self.assertEqual(self.widget.selectedShape, -1)
+        # Any negative stands for no selection, and reads back as the one the
+        # canvas's own picking writes.
+        self.widget.selectedShape = -7
+        self.assertEqual(self.widget.selectedShape, -1)
+        world.remove_shape(sid)
+        self.widget.selectedShape = sid
+        self.assertEqual(self.widget.selectedShape, -1)
+
+        # Switching tools drops it, as a pick on the canvas would.
+        world.undo()
+        self.widget.selectedShape = sid
+        self.widget.setDrawTool("circle")
+        self.assertEqual(self.widget.selectedShape, -1)
+        # A draw tool paints no selection, so it accepts none either; an id
+        # written here would sit invisible until the next tool switch.
+        self.widget.selectedShape = sid
+        self.assertEqual(self.widget.selectedShape, -1)
+
     def _render_world(self, world, pan_x, pan_y, zoom):
         """Render world under an explicit view; return (geometry_mask,
         to_pixel).
@@ -384,6 +419,27 @@ class R2DWidgetSelectToolTC(unittest.TestCase):
         # The PySide6 widget wraps the same C++ object the handle above does.
         self.target = self.sub.widget()
         QtWidgets.QApplication.processEvents()
+
+    def test_selecting_from_outside_ends_an_active_drag(self):
+        """A caller that moves the selection mid-gesture leaves the canvas
+        holding a drag on a shape it no longer selects; the gesture ends the
+        way a release ends it."""
+        from PySide6 import QtCore
+        other = self.world.add_circle(20, 20, 2)
+        _send_mouse(self.target, 'press', 100, 100)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        held = self.world.segment(0).x0
+
+        self.widget.selectedShape = other
+        _send_mouse(self.target, 'move', 160, 100)
+        # The shape the gesture had hold of stays where the drag left it, and
+        # the cursor the drag put on comes off.
+        self.assertAlmostEqual(self.world.segment(0).x0, held)
+        self.assertEqual(self.target.cursor().shape(), QtCore.Qt.ArrowCursor)
+        _send_mouse(self.target, 'release', 160, 100)
+        # The undo bracket the press opened closed with the gesture, so the
+        # move is one step and the world is not left mid-operation.
+        self.assertTrue(self.world.can_undo)
 
     def test_select_move_rotate_run_through(self):
         orig_x0 = self.world.segment(0).x0

--- a/tests/test_pilot_painter_design.py
+++ b/tests/test_pilot_painter_design.py
@@ -43,8 +43,8 @@ def _click(widget, x, y):
 class _StubCanvas:
     """Stand-in for the 2D canvas, so a test can set the selection directly.
 
-    The real canvas only changes it through a mouse gesture on a live window,
-    which :class:`PainterDesignCanvasTC` covers.
+    :class:`PainterDesignCanvasTC` covers the live canvas path, including
+    selection written from outside a mouse gesture.
     """
 
     def __init__(self, world):

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -43,8 +43,8 @@ def _click(widget, x, y):
 class _StubCanvas:
     """Stand-in for the 2D canvas, so a test can set the selection directly.
 
-    The real canvas only changes it through a mouse gesture on a live window,
-    which :class:`PainterLayersCanvasTC` covers.
+    :class:`PainterLayersCanvasTC` covers the live canvas path, including
+    selection written from outside a mouse gesture.
     """
 
     def __init__(self, world):
@@ -190,6 +190,17 @@ class PainterLayersPageTC(unittest.TestCase):
                 self.assertFalse(control.isEnabled())
                 self.assertIn("needs", control.toolTip())
 
+    def test_pressing_a_row_reports_the_shape_it_names(self):
+        # The row reaches nobody itself: the press is reported, and whoever
+        # owns the list decides what a pick means.
+        picks = []
+        self.page.picked.connect(picks.append)
+        _click(self.page.shown_rows[0], 10, 10)
+        self.assertEqual(picks, [self.cid])
+        self.assertEqual(self.canvas.selectedShape, -1)
+        _click(self.page.shown_rows[1], 10, 10)
+        self.assertEqual(picks, [self.cid, self.rid])
+
     def test_the_page_fits_the_designed_inspector(self):
         self.assertLessEqual(self.page.sizeHint().width(),
                              _painter_gui.PainterPanel._INSPECTOR_WIDTH)
@@ -262,6 +273,65 @@ class PainterLayersCanvasTC(unittest.TestCase):
         page.refresh()
         selected = [row.name for row in page.shown_rows if row.selected()]
         self.assertEqual(selected, [f"Rectangle {self.sid}"])
+
+    def test_pressing_a_row_selects_the_shape_on_the_canvas(self):
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        _click(page.shown_rows[0], 10, 10)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        self.assertEqual([row.name for row in page.shown_rows
+                          if row.selected()], [f"Rectangle {self.sid}"])
+
+    def test_a_pick_arms_the_select_tool_first(self):
+        # The canvas draws no selection while a shape tool is armed, and
+        # switching tools drops the selection, so a pick that only wrote the
+        # id would leave nothing marked.
+        page = self.painter.panel.layers
+        self.widget.setDrawTool("circle")
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        _click(page.shown_rows[0], 10, 10)
+        self.assertEqual(self.widget.drawTool, "select")
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        # The rail and the Canvas menu share the action the pick triggered.
+        self.assertTrue(self.painter.panel.tool_buttons["select"].isChecked())
+
+    def test_a_pick_on_a_row_the_world_has_dropped_selects_nothing(self):
+        # The list polls, so a row can outlive its shape by one tick; the pick
+        # drops a dead id and heals the list without waiting for the next poll.
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        row = page.shown_rows[0]
+        self.world.remove_shape(self.sid)
+        _click(row, 10, 10)
+        self.assertEqual(self.widget.selectedShape, -1)
+        self.assertEqual(page.shown_rows, [])
+
+    def test_a_pick_on_a_stale_row_from_another_world_selects_nothing(self):
+        # Ids start over per world. A list that still names the previous
+        # canvas can match a live id on the one in front; the pick drops
+        # rather than selecting a shape the row never stood for.
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        row = page.shown_rows[0]
+        other = self.mgr.add2DWidget()
+        other_world = solvcon.WorldFp64()
+        other_sid = other_world.add_circle(0, 0, 1)
+        self.assertEqual(other_sid, self.sid)
+        other.updateWorld(other_world)
+        other.setDrawTool("select")
+        other_sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.mgr.mdiArea.setActiveSubWindow(other_sub)
+        # Leave the activation refresh on the timer; the list still names
+        # the first canvas while the active one is already the second.
+        _click(row, 10, 10)
+        self.assertEqual(other.selectedShape, -1)
+        self.assertEqual(self.widget.selectedShape, -1)
+        other_sub.close()
+        QtWidgets.QApplication.processEvents()
 
     def test_closing_the_canvas_leaves_the_list_standing(self):
         # The sub-window deletes the canvas on close, and a page that held it


### PR DESCRIPTION
A press on a Layers row now selects that shape on the canvas. The canvas exposes a settable `selectedShape` for the list to write, rejecting unknown ids and any pick while a draw tool is armed; the panel arms the select tool first and refreshes the list so a stale row cannot name a shape from another world.

Follows #1211, #1212, and #1213. Object names, guides, visibility, and footer editing remain follow-ups.

Related to #1175.
