### PR TITLE
 Build and test through the presets, and drive the Windows CI jobs from them (cmake preset steps 2, 3)

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -403,43 +403,21 @@ jobs:
           Get-Command flake8
           echo "::endgroup::"
 
-      - name: cmake ALL_BUILD
+      - name: cmake workflow
         run: |
-          echo "::group::cmake ALL_BUILD"
-          # Use the Ninja generator: CMAKE_<LANG>_COMPILER_LAUNCHER (the
-          # sccache hook) is honored only by Ninja/Makefile generators, not
-          # the Visual Studio (MSBuild) generator, which silently ignores it.
-          # No vcpkg toolchain: SOLVCON_USE_MKL makes solvcon link mkl_rt for
-          # both CBLAS and LAPACK, found via the CMAKE_*_PATH dirs above.
-          cmake -GNinja `
-            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
-            -DSOLVCON_USE_MKL=ON `
-            -DCMAKE_INCLUDE_PATH="$env:MKL_INCLUDE_DIR" `
-            -DCMAKE_LIBRARY_PATH="$env:MKL_LIBRARY_DIR" `
-            -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-            -S${{ github.workspace }} `
-            -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build
-          echo "::endgroup::"
-
-      - name: cmake run_gtest
-        run: |
-          echo "::group::cmake run_gtest"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_gtest
-          echo "::endgroup::"
-
-      - name: cmake run_pilot_pytest
-        run: |
-          echo "::group::cmake run_pilot_pytest"
+          echo "::group::cmake workflow"
+          # The ci-win-* presets in CMakePresets.json state the whole
+          # configure.
+          $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
           # A runner has no desktop to take over, so let this job map its
           # windows, the way it has always run them.
           $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_pilot_pytest
+          $preset = if ('${{ matrix.cmake_build_type }}' -eq 'Debug') {
+            'ci-win-dbg'
+          } else {
+            'ci-win-rel'
+          }
+          cmake --workflow --preset $preset
           echo "::endgroup::"
 
       - name: generate portable
@@ -483,14 +461,14 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the pilot. The build dir is already
-          # configured with the Ninja single-config generator above, so reuse
-          # it without --config and read pilot.exe from the non-config path.
-          cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --target pilot
+          # The workflow preset above already configured and built this tree
+          # with the Ninja single-config generator, so rebuild the pilot in
+          # place and read pilot.exe from the runtime output directory the
+          # preset names.
+          cmake --build --preset ci-win-rel --target pilot
 
           # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\pilot\pilot.exe" -Destination $destination
+          Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
           # Also include potential thirdparty
@@ -674,39 +652,19 @@ jobs:
         echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "::endgroup::"
 
-    - name: cmake ALL_BUILD USE_SANITIZER=ON
+    - name: cmake workflow USE_SANITIZER=ON
       run: |
-        echo "::group::cmake ALL_BUILD USE_SANITIZER=ON"
-        # Instrument both the gtest binary and the Qt pilot: BUILD_QT=ON and
-        # USE_GOOGLETEST=ON build both, USE_SANITIZER=ON adds /fsanitize=address.
+        echo "::group::cmake workflow USE_SANITIZER=ON"
+        # The ci-win-asan preset instruments both the gtest binary and the Qt
+        # pilot: BUILD_QT and USE_GOOGLETEST build both, USE_SANITIZER adds
+        # /fsanitize=address, and the vcpkg toolchain supplies BLAS and LAPACK.
         # The MSVC toolset bin dir that setup-msvc-dev puts on PATH also carries
         # the ASan runtime DLL the instrumented binaries load at start.
-        cmake -GNinja `
-          -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-          -DVCPKG_TARGET_TRIPLET="x64-windows" `
-          -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-          -DBUILD_QT=ON `
-          -DUSE_GOOGLETEST=ON `
-          -DUSE_SANITIZER=ON `
-          -S${{ github.workspace }} `
-          -B${{ github.workspace }}/build
-        cmake --build ${{ github.workspace }}/build
-        echo "::endgroup::"
-
-    - name: cmake run_gtest
-      run: |
-        echo "::group::cmake run_gtest"
-        cmake --build ${{ github.workspace }}/build --target run_gtest
-        echo "::endgroup::"
-
-    - name: cmake run_pilot_pytest
-      run: |
-        echo "::group::cmake run_pilot_pytest"
+        $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
         # A runner has no desktop to take over, so let this job map its
         # windows, the way it has always run them.
         $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-        cmake --build ${{ github.workspace }}/build --target run_pilot_pytest
+        cmake --workflow --preset ci-win-asan
         echo "::endgroup::"
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ thirdparty/install/
 thirdparty/archive/
 tmp/
 setup.mk
+CMakeUserPresets.json
 *.egg-info/
 *.pyc
 *.pyo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+enable_testing()
+
 # The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
 # Debug build must match their runtime and configuration or it corrupts the heap
 # (issue #1058). Both default on; turn one off to link debug dependencies when
@@ -51,6 +53,7 @@ endif()
 
 option(USE_CLANG_TIDY "use clang-tidy" OFF)
 option(LINT_AS_ERRORS "clang-tidy warnings as errors" OFF)
+message(STATUS "LINT_AS_ERRORS: ${LINT_AS_ERRORS}")
 
 # Sanitizers
 # - Undefined Behavior Sanitization: Preventing the unpredictable outcomes of
@@ -335,5 +338,7 @@ message(STATUS "USE_GOOGLETEST: ${USE_GOOGLETEST}")
 if(USE_GOOGLETEST)
 add_subdirectory(gtests)
 endif() # USE_GOOGLETEST
+
+add_subdirectory(tests)
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/Makefile
+++ b/Makefile
@@ -22,25 +22,37 @@ BUILD_PATH_EXT ?=
 # Additional configuration can be loaded from SETUP_FILE.
 RUNENV += PYTHONPATH=$(SOLVCON_ROOT)
 
-SKIP_PYTHON_EXECUTABLE ?= OFF
-HIDE_SYMBOL ?= ON
-DEBUG_SYMBOL ?= ON
-SOLVCON_PROFILE ?= OFF
-BUILD_METAL ?= OFF
-BUILD_QT ?= ON
-USE_CLANG_TIDY ?= OFF
+# The configure knobs are written down once, in CMakePresets.json; see
+# doc/source/devguide/cmake.md. A knob set on the command line, in the
+# environment, or in setup.mk is layered on the selected preset as a -D flag,
+# and nothing else is passed, so a make build and a preset build stay the same
+# build. Setting a knob to its preset value therefore costs nothing.
+CMAKE_KNOBS = SKIP_PYTHON_EXECUTABLE HIDE_SYMBOL DEBUG_SYMBOL SOLVCON_PROFILE \
+	BUILD_METAL BUILD_QT USE_CLANG_TIDY LINT_AS_ERRORS USE_GOOGLETEST \
+	USE_SANITIZER CMAKE_INSTALL_PREFIX CMAKE_LIBRARY_OUTPUT_DIRECTORY \
+	CMAKE_PREFIX_PATH
+CMAKE_OVERRIDES = $(strip $(foreach knob,$(CMAKE_KNOBS), \
+	$(if $(filter-out undefined default,$(origin $(knob))),\
+	-D$(knob)=$($(knob)))))
+
 CMAKE_BUILD_TYPE ?= Release
+# The build type picks the preset, so it needs no -D of its own. Override
+# CMAKE_PRESET to build another one, for instance a preset of your own from
+# CMakeUserPresets.json.
+ifeq ($(CMAKE_BUILD_TYPE), Debug)
+	CMAKE_PRESET ?= dev-dbg
+else
+	CMAKE_PRESET ?= dev-rel
+endif
 # Number of online processors. Drives both build parallelism (MAKE_PARALLEL
 # below) and the lint targets. getconf works on both Linux and macOS; fall
 # back to 1 if unavailable. Override to cap parallelism, e.g. NPROC=2.
 NPROC ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 MAKE_PARALLEL ?= -j $(NPROC)
 SOLVCON_ROOT ?= $(shell pwd)
-CMAKE_INSTALL_PREFIX ?= $(SOLVCON_ROOT)/build/fakeinstall
-CMAKE_LIBRARY_OUTPUT_DIRECTORY ?= $(SOLVCON_ROOT)/solvcon
-# Use CMAKE_PREFIX_PATH to make it easier to build with Qt, e.g.,
-# CMAKE_PREFIX_PATH=/path/to/qt/6.2.3/macos
-CMAKE_PREFIX_PATH ?=
+# Set CMAKE_PREFIX_PATH to make it easier to build with Qt, e.g.,
+# CMAKE_PREFIX_PATH=/path/to/qt/6.2.3/macos. It is one of the knobs above, so
+# it reaches CMake only when it is set.
 CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
@@ -69,8 +81,6 @@ WHICH_PYTHON := $(shell which python3)
 REALPATH_PYTHON := $(realpath $(WHICH_PYTHON))
 export DIRNAME_PYTHON := $(dir $(REALPATH_PYTHON))
 
-pyextsuffix := $(shell if [ -x "$(DIRNAME_PYTHON)/python3-config" ]; then \
-	$(DIRNAME_PYTHON)/python3-config --extension-suffix; fi)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
 ifeq ($(CMAKE_BUILD_TYPE), Debug)
@@ -98,30 +108,16 @@ cmake: $(BUILD_PATH)/Makefile
 .PHONY: xcode
 xcode: $(BUILD_PATH)_xcode/Makefile
 
-CMAKE_CMD = cmake $(SOLVCON_ROOT) \
-	-DCMAKE_PREFIX_PATH=$(CMAKE_PREFIX_PATH) \
-	-DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX) \
-	-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(CMAKE_LIBRARY_OUTPUT_DIRECTORY) \
-	-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
-	-DSKIP_PYTHON_EXECUTABLE=$(SKIP_PYTHON_EXECUTABLE) \
-	-DHIDE_SYMBOL=$(HIDE_SYMBOL) \
-	-DDEBUG_SYMBOL=$(DEBUG_SYMBOL) \
-	-DBUILD_METAL=$(BUILD_METAL) \
-	-DBUILD_QT=$(BUILD_QT) \
-	-DUSE_CLANG_TIDY=$(USE_CLANG_TIDY) \
-	-DLINT_AS_ERRORS=ON \
-	-DSOLVCON_PROFILE=$(SOLVCON_PROFILE) \
-	$(CMAKE_ARGS)
+# The preset carries the configure; -B and -G layer on top of it. The build
+# tree keeps its ABI tag, which a preset cannot compute, and the generator
+# stays the one the clean target and the workflows expect from a make build.
+CMAKE_CMD = cmake --preset $(CMAKE_PRESET) $(CMAKE_OVERRIDES) $(CMAKE_ARGS)
 
-$(BUILD_PATH)/Makefile: CMakeLists.txt Makefile
-	mkdir -p $(BUILD_PATH) ; \
-	cd $(BUILD_PATH) ; \
-	env $(RUNENV) $(CMAKE_CMD)
+$(BUILD_PATH)/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH) -G "Unix Makefiles"
 
-$(BUILD_PATH)_xcode/Makefile: CMakeLists.txt Makefile
-	mkdir -p $(BUILD_PATH)_xcode ; \
-	cd $(BUILD_PATH)_xcode ; \
-	env $(RUNENV) $(CMAKE_CMD) -G Xcode
+$(BUILD_PATH)_xcode/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH)_xcode -G Xcode
 
 .PHONY: buildext
 buildext: cmake
@@ -314,12 +310,12 @@ format: pyformat
 
 .PHONY: clean
 clean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	cmake --build $(BUILD_PATH) --target remove_solvcon_py
 	make -C $(BUILD_PATH) clean
 
 .PHONY: cmakeclean
 cmakeclean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	@if [ -f $(BUILD_PATH)/CMakeCache.txt ]; then \
+		cmake --build $(BUILD_PATH) --target remove_solvcon_py; \
+	fi
 	rm -rf $(BUILD_PATH)

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,11 @@
 # setup.py shell out to "make", and its module-copy target runs
 # "python3-config"; neither exists on Windows.  This drives CMake directly
 # through the win-rel / win-dbg presets in CMakePresets.json, adding only the
-# scdv-specific cache variables, and places the module by hand.
+# scdv-specific cache variables, and places the module by hand.  Those three
+# path variables belong in CMakeUserPresets.json; pass -Preset <name> to build
+# such a preset and the script leaves them to it.  Start that file from
+# contrib/cmake/CMakeUserPresets.win-example.json: the other template inherits
+# presets that are disabled on Windows.
 #
 # It finds a CMake >= 4.0.1 (solvcon's minimum; the VS 2022 Build Tools bundle
 # only 3.31.6, so it falls back to VS 2026's 4.x) and compiles with the same
@@ -22,6 +26,10 @@
 #       active scdv (or -ScdvBase), then place the module.
 #   .\build.ps1 -ScdvBase <dir>       activate the scdv at <dir> first
 #   .\build.ps1 -BuildType Debug      use the win-dbg preset
+#   .\build.ps1 -Preset local         use a preset from CMakeUserPresets.json,
+#                                     which is expected to supply the
+#                                     dependency-prefix paths itself (start
+#                                     from CMakeUserPresets.win-example.json)
 #   .\build.ps1 -NoQt                 build only _solvcon (BUILD_QT=OFF)
 #   .\build.ps1 -Test                 then run "pytest tests\" headless
 #   .\build.ps1 -Pilot                then launch the pilot GUI
@@ -43,6 +51,7 @@ param(
     [string]$ScdvBase,
     [string]$Repo,
     [ValidateSet('Release', 'Debug')][string]$BuildType = 'Release',
+    [string]$Preset,
     [switch]$NoQt,
     [switch]$Gtest,
     [switch]$Test,
@@ -63,7 +72,7 @@ function Assert-LastExit {
 if ($Help) {
     Get-Content -LiteralPath $PSCommandPath | Select-Object -Skip 1 |
         ForEach-Object { if ($_ -notmatch '^\s*$') { $_ -replace '^#\s?', '' } } |
-        Select-Object -First 40
+        Select-Object -First 42
     exit 0
 }
 
@@ -94,8 +103,56 @@ if (-not $Repo) { $Repo = $PSScriptRoot }
 if (-not (Test-Path -LiteralPath (Join-Path $Repo 'CMakePresets.json'))) {
     throw "no CMakePresets.json under -Repo '$Repo'; point it at a solvcon checkout"
 }
-$preset = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
-$bld = Join-Path $Repo "build\$preset"
+# A named preset is taken verbatim, so a preset from CMakeUserPresets.json can
+# be built; -BuildType then selects nothing, since the named preset states its
+# own build type.  PowerShell variable names are case-insensitive, so the
+# resolved name cannot be spelled $preset next to the -Preset parameter.
+if ($Preset) {
+    if ($PSBoundParameters.ContainsKey('BuildType')) {
+        throw '-Preset and -BuildType are exclusive: the named preset states its own build type'
+    }
+    $presetName = $Preset
+} else {
+    $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
+}
+
+function Get-ConfigurePresetBinaryDir {
+    # The binary directory a configure preset states, resolved through
+    # inherits.  Reading it beats recomputing "build\<preset>": the presets
+    # are free to name their build trees, and a user preset that inherits one
+    # of them gets its own.
+    param([string]$Root, [string]$Name)
+    $presets = @{}
+    foreach ($file in @('CMakePresets.json', 'CMakeUserPresets.json')) {
+        $path = Join-Path $Root $file
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        $doc = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        if (-not $doc.PSObject.Properties['configurePresets']) { continue }
+        foreach ($entry in $doc.configurePresets) { $presets[$entry.name] = $entry }
+    }
+    # Depth-first through inherits, nearest definition wins, as CMake resolves
+    # it.
+    function Find-BinaryDir {
+        param([string]$Name)
+        $entry = $presets[$Name]
+        if (-not $entry) { return $null }
+        if ($entry.PSObject.Properties['binaryDir']) { return $entry.binaryDir }
+        if ($entry.PSObject.Properties['inherits']) {
+            foreach ($parent in @($entry.inherits)) {
+                $found = Find-BinaryDir $parent
+                if ($found) { return $found }
+            }
+        }
+        return $null
+    }
+    $raw = Find-BinaryDir $Name
+    if (-not $raw) { throw "preset '$Name' states no binaryDir" }
+    $raw = $raw.Replace('${sourceDir}', $Root).Replace('${presetName}', $Name)
+    if ($raw -match '\$\{') { throw "unsupported macro in binaryDir '$raw'" }
+    return $raw.Replace('/', '\')
+}
+
+$bld = Get-ConfigurePresetBinaryDir $Repo $presetName
 $solvconDir = Join-Path $Repo 'solvcon'
 
 # --- MSVC environment -------------------------------------------------------
@@ -186,42 +243,59 @@ if (-not (Test-Path -LiteralPath $py)) {
 
 # --- Configure and build via the preset -------------------------------------
 
-$pybind = & $py -m pybind11 --cmakedir
-Assert-LastExit 'pybind11 --cmakedir'
 # The preset holds the static knobs (generator, build type, BUILD_QT,
 # USE_GOOGLETEST, BLA_VENDOR, output dirs); pass the scdv-specific cache
 # variables on top.  -NoQt overrides the preset's BUILD_QT=ON.
-$extra = @(
-    "-DPYTHON_EXECUTABLE=$py",
-    "-Dpybind11_path=$pybind",
-    "-DCMAKE_PREFIX_PATH=$usr"
-)
+$extra = @()
+if ($Preset) {
+    # A named preset comes from CMakeUserPresets.json, whose whole purpose is
+    # to carry the paths of one machine's dependency prefix, so leave them to
+    # it rather than overriding them from the command line.
+    Write-Host "preset $presetName supplies the dependency-prefix paths"
+} else {
+    $pybind = & $py -m pybind11 --cmakedir
+    Assert-LastExit 'pybind11 --cmakedir'
+    $extra += @(
+        "-DPYTHON_EXECUTABLE=$py",
+        "-Dpybind11_path=$pybind",
+        "-DCMAKE_PREFIX_PATH=$usr"
+    )
+}
 if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
-# -Gtest turns on the gtest binary (USE_GOOGLETEST is OFF in the preset), and
-# -Sanitize (which implies -Gtest) builds it under AddressSanitizer. The gtest
-# binary links the ASan runtime directly so ASan initializes at process start,
-# unlike loading an instrumented .pyd into a stock python.exe.
-if ($Gtest) { $extra += '-DUSE_GOOGLETEST=ON' }
+# -Gtest adds the gtest binary to the target list below; the preset already
+# states USE_GOOGLETEST, so nothing has to be turned on here. -Sanitize (which
+# implies -Gtest) builds that binary under AddressSanitizer. It links the ASan
+# runtime directly so ASan initializes at process start, unlike loading an
+# instrumented .pyd into a stock python.exe.
 if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON' }
 
 Push-Location $Repo
 try {
-    Write-Host "configuring solvcon (preset $preset, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
-    & $cmake --preset $preset @extra
+    Write-Host "configuring solvcon (preset $presetName, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
+    & $cmake --preset $presetName @extra
     Assert-LastExit 'cmake configure'
 
-    $targets = @('_solvcon')
-    if (-not $NoQt) { $targets += 'pilot' }
-    if ($Gtest) { $targets += 'test_nopython' }
-    Write-Host "building targets: $($targets -join ', ')"
-    & $cmake --build --preset $preset --target @targets
-    Assert-LastExit 'cmake build'
+    # The build presets carry the target lists: <preset> builds the module and
+    # the pilot, <preset>-module the module alone, <preset>-gtest the C++ test
+    # binary.
+    $buildPresets = @()
+    if ($NoQt) {
+        $buildPresets += "$presetName-module"
+    } else {
+        $buildPresets += $presetName
+    }
+    if ($Gtest) { $buildPresets += "$presetName-gtest" }
+    foreach ($buildPreset in $buildPresets) {
+        Write-Host "building preset: $buildPreset"
+        & $cmake --build --preset $buildPreset
+        Assert-LastExit "cmake build --preset $buildPreset"
+    }
 } finally {
     Pop-Location
 }
 
 # _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the preset's binary dir, build\$preset).
+# a RUNTIME artifact (-> the binary directory the preset states, read above).
 # Copy the module to the repo root as the top-level _solvcon: solvcon.core
 # imports it there first, and the tests' qualified type names assume that name.
 $pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |

--- a/contrib/cmake/CMakeUserPresets.example.json
+++ b/contrib/cmake/CMakeUserPresets.example.json
@@ -1,0 +1,41 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "dev-rel",
+      "displayName": "Local dependency prefix",
+      "description": "A checked-in preset plus the paths of a local dependency prefix.",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "/path/to/prefix/bin/python3"
+        },
+        "pybind11_path": "/path/to/prefix/lib/python3.14/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "/path/to/prefix"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "local",
+      "inherits": "dev-rel",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix"
+    },
+    {
+      "name": "local-module",
+      "inherits": "dev-rel-module",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, module only"
+    },
+    {
+      "name": "local-gtest",
+      "inherits": "dev-rel-gtest",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, C++ test binary"
+    }
+  ]
+}

--- a/contrib/cmake/CMakeUserPresets.win-example.json
+++ b/contrib/cmake/CMakeUserPresets.win-example.json
@@ -1,0 +1,41 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "displayName": "Local dependency prefix",
+      "description": "A checked-in preset plus the paths of a local dependency prefix.",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "C:/path/to/prefix/python3.exe"
+        },
+        "pybind11_path": "C:/path/to/prefix/Lib/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "C:/path/to/prefix"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix"
+    },
+    {
+      "name": "local-module",
+      "inherits": "win-rel-module",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, module only"
+    },
+    {
+      "name": "local-gtest",
+      "inherits": "win-rel-gtest",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, C++ test binary"
+    }
+  ]
+}

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -52,11 +52,18 @@ cmake_print_variables(PYTHON_VENV_BIN)
 execute_process(
     COMMAND ${PYTHON_VENV_BIN}/python3-config --extension-suffix
     OUTPUT_VARIABLE PYEXTSUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 add_custom_target(_solvcon_py
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_solvcon> ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
     DEPENDS _solvcon)
+
+add_custom_target(remove_solvcon_py
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        ${SOLVCON_PY_DIR}/_solvcon${PYEXTSUFFIX}
+        ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
+    COMMENT "removing the built _solvcon extension")
 
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${SOLVCON_INCLUDE_DIR}/solvcon DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -212,6 +212,10 @@ if (NOT APPLE)
         "Use pre-built Intel oneAPI MKL for BLAS/LAPACK instead of OpenBLAS"
         "$ENV{SOLVCON_USE_MKL}")
 
+    # The find_package(LAPACK) below reads it, and MKL skips that branch, so
+    # report it here as well.
+    message(STATUS "BLA_VENDOR: ${BLA_VENDOR}")
+
     # Intel oneAPI MKL is an optimized, pre-built vendor BLAS/LAPACK for x86.
     # Its single dynamic runtime (mkl_rt, LP64) exports both the reference CBLAS
     # entry points and the Fortran LAPACK symbols declared in lapack_compat.hpp,

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -15,8 +15,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
-
 if (APPLE)
     find_library(APPLE_FWK_ACCELERATE Accelerate REQUIRED)
 endif () # APPLE
@@ -62,7 +60,7 @@ target_link_libraries(
 )
 
 include(GoogleTest)
-gtest_discover_tests(test_nopython)
+gtest_discover_tests(test_nopython PROPERTIES LABELS "cpp")
 
 add_custom_target(run_gtest
     COMMAND $<TARGET_FILE:test_nopython>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+# Register the Python suites with CTest so that ctest is the one test entry
+# point on every platform, alongside the C++ cases that gtest_discover_tests
+# registers. Each suite carries its own environment through a test property,
+# which is what a per-suite value needs: a configure preset's environment map
+# would have to give both suites the same answer.
+
+# SKIP_PYTHON_EXECUTABLE leaves PYTHON_EXECUTABLE unset, and the suite has no
+# interpreter to run under without it.
+if(PYTHON_EXECUTABLE)
+    add_test(
+        NAME pytest
+        COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set_tests_properties(pytest PROPERTIES
+        LABELS "python"
+        ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+    )
+else()
+    message(STATUS "PYTHON_EXECUTABLE is unset; not registering the pytest suite")
+endif()
+
+if(BUILD_QT)
+    # The pilot runs the same suite inside its own embedded interpreter. On
+    # Linux it needs the shiboken6 shared library on the loader path, which
+    # the workflow used to export by hand.
+    add_test(
+        NAME pilot_pytest
+        COMMAND $<TARGET_FILE:pilot> --mode=pytest
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set(SOLVCON_PILOT_TEST_ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}")
+    if(NOT "${SHIBOKEN6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+        list(APPEND SOLVCON_PILOT_TEST_ENVIRONMENT
+            "LD_LIBRARY_PATH=${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
+    endif()
+    set_tests_properties(pilot_pytest PROPERTIES
+        LABELS "pilot"
+        ENVIRONMENT "${SOLVCON_PILOT_TEST_ENVIRONMENT}"
+    )
+endif()
+
+# SOLVCON_TEST_SHOW_WINDOWS is deliberately absent from both properties.
+# tests/conftest.py keeps the GUI windows off the screen unless it is set, and
+# a test property would override whatever the caller chose. Leaving it to the
+# environment keeps the developer default off the screen and lets a runner,
+# which has no desktop to take over, export it for the run.
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Steps 2, 3 of issue #1215.

After the PR, the `Makefile` configures through `cmake --preset`, `build.ps1` learns to build a preset the developer wrote, `ctest` becomes the one test entry point on every platform, and the two Windows CI jobs each name a single workflow preset instead of spelling out their own `cmake -GNinja -D...` block. The build a make user gets and the build a preset user gets are now the same build, because there is one place where it is described.

### Step 2: Build and test through the presets

The `Makefile` configures with `cmake --preset` and adds only what a preset cannot carry: `-B` for the ABI-tagged build directory, `-G` for the generator a make build has always used, and a `-D` flag for each knob that is actually set on the command line, in the environment, or in `setup.mk`. `CMAKE_KNOBS` lists those knobs and `CMAKE_OVERRIDES` turns the ones with a non-default `origin` into flags. `CMAKE_BUILD_TYPE` picks `dev-rel` or `dev-dbg`, and `CMAKE_PRESET` overrides that choice, for instance to build a preset of your own. Every target name and every `make VAR=value` override keeps working. The lint targets are deliberately not rewired, so they still run in a checkout that has never been configured.

`ctest` becomes the one test entry point. `gtest_discover_tests` already registered the C++ cases and nothing used them; the new `tests/CMakeLists.txt` joins both Python suites through `add_test()`, as `pytest` and `pilot_pytest`, each carrying its own environment in a test property and labeled `python` or `pilot`. The C++ cases pick up the `cpp` label. `enable_testing()` moves to the top level so it no longer depends on `USE_GOOGLETEST`. `SOLVCON_TEST_SHOW_WINDOWS` stays an environment variable, because a test property overrides rather than defaults, and a developer and a runner want opposite answers.

The extension suffix is already computed in `cpp/binary/pymod_solvcon/CMakeLists.txt`, so a `remove_solvcon_py` target there replaces the `Makefile`'s second shell-out to `python3-config` in `clean` and `cmakeclean`.

The three cache variables that name one machine's directories, `PYTHON_EXECUTABLE`, `pybind11_path`, and `CMAKE_PREFIX_PATH`, belong in `CMakeUserPresets.json`, which CMake reads automatically and both IDEs pick up. It is gitignored and a template ships under `contrib/cmake`, one per host family, each named so that an editor recognizes it as JSON and applies the `$schema` it declares. A build preset inherits its configure preset's `condition`, so a single template whose build presets inherit `dev-rel*` is refused on Windows as a disabled build preset; the two templates keep every `inherits` line a matched set. This is what makes an IDE build work at all: an IDE runs `cmake --preset` with nothing added, and configure used to fail at `find_package(pybind11)`.

`build.ps1` gains `-Preset` to build such a preset, in which case it leaves the dependency-prefix paths to the preset. It reads `binaryDir` out of the preset files (`Get-ConfigurePresetBinaryDir`, resolving `inherits`) instead of recomputing `build\<preset>`, and picks among the `<preset>`, `<preset>-module`, and `<preset>-gtest` build presets instead of assembling a target list in PowerShell.

`LINT_AS_ERRORS` and `BLA_VENDOR` are reported with `message()` where they are decided. Only the clang-tidy branches read the first and only the OpenBLAS branch reads the second, so a preset that sets either for the other case drew an unused cache variable warning on every configure.

### Step 3: Drive the Windows CI jobs from workflow presets

`devbuild.yml` spelled out its own `cmake -GNinja -D...` block twice, once for the Windows build job and once for the Windows sanitizer job, and neither drove the `Makefile` or the presets. Nothing kept those blocks in agreement with the preset file.

Each job now names one workflow preset, `ci-win-rel`, `ci-win-dbg`, or `ci-win-asan`, which chains configure, build, and the CTest run. The values a runner owns stay out of the checked-in file: the pybind11 package directory and the MKL include and library paths reach the `ci-` presets through `$env{}`, which the jobs export. The portable-package step rebuilds the pilot with `cmake --build --preset ci-win-rel --target pilot` and reads `pilot.exe` from the runtime output directory the preset names.

The test stage filters on the `cpp` and `pilot` labels, the coverage these jobs have always had; the plain Python suite runs on Linux and macOS. Where the jobs used to build the `run_gtest` and `run_pilot_pytest` targets they now run `ctest`, so the C++ cases report individually.