### PR TITLE
Painter Canvas 1: read the zoom on the inspector's Canvas page

### DIFF
--- a/solvcon/pilot/painter/_canvas.py
+++ b/solvcon/pilot/painter/_canvas.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The Canvas page of the Painter inspector: how the canvas shows the world.
+"""
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from ._sections import Placeholder, Section
+from ._style import blend, mono_font, rule, shade, PaletteStyled
+
+__all__ = [
+    'CanvasPage',
+]
+
+
+def _format_zoom(zoom):
+    """Return the zoom as the readout shows it, screen pixels per world unit
+    read as a percentage."""
+    percent = 100.0 * zoom
+    # Whole percents while the view is anywhere near its own scale, which is
+    # what the design shows; a far zoom out needs the digits below one.
+    return f"{round(percent):g}%" if percent >= 1.0 else f"{percent:.3g}%"
+
+
+class _Readout(QtWidgets.QFrame):
+    """One boxed reading: what it measures, then the number."""
+
+    _HEIGHT = 28
+    _MARGINS = (8, 0, 8, 0)
+    _GAP = 8
+
+    def __init__(self, label, parent=None):
+        super().__init__(parent)
+        self.setObjectName("box")
+        self.setFixedHeight(self._HEIGHT)
+        name = QtWidgets.QLabel(label, self)
+        name.setObjectName("name")
+        self._value = QtWidgets.QLabel(self)
+        self._value.setObjectName("value")
+        self._value.setFont(mono_font())
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        layout.addWidget(name)
+        layout.addStretch(1)
+        layout.addWidget(self._value)
+
+    @property
+    def value(self):
+        """The number the box reads, as it is written there."""
+        return self._value.text()
+
+    def set_value(self, text):
+        """Show ``text``, which is empty for a box reading nothing."""
+        self._value.setText(text)
+
+
+class CanvasPage(PaletteStyled):
+    """The inspector's Canvas page: the view over the bound canvas.
+
+    Like the other pages, this one reads the canvas it is bound to on a timer,
+    because the view carries no change signal. What the poll compares is the
+    zoom, which is what the View section reads; the pan is left out, since it
+    moves the view without changing that.
+
+    The buttons that act on the view, and the sections the model cannot back
+    yet, arrive with later steps of the redesign; they stand here as their
+    designed titles, greyed out.
+    """
+
+    # Poll period in milliseconds, the Design page's rate and for its reason:
+    # the reading is cheap enough to take this often, and a slower one reads as
+    # lag while the wheel moves the zoom under it.
+    _POLL_MS = 60
+
+    #: The greyed-out sections, as ``(title, what the section waits for)``.
+    PLACEHOLDERS = (
+        ("Grid", "grid and snap options"),
+        ("Axes & origin", "axes and origin styling"),
+        ("Background", "background presets"),
+        ("Units", "display units and precision"),
+    )
+
+    _LABEL_PX = 10
+    _VALUE_PX = 11
+    _RADIUS = 5
+
+    # How far each of these sits from the panel color.
+    _MUTED_MIX = 0.35
+    _GREYED_MIX = 0.6
+    _BORDER_MIX = 0.25
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._source = None
+        self._key = None
+        self.placeholders = {}
+        self._build()
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self._POLL_MS)
+        self._timer.timeout.connect(self.refresh)
+        self._apply_style()
+        self._render()
+
+    @property
+    def zoom(self):
+        """The zoom the readout shows, as it is written there."""
+        return self._readout.value
+
+    def set_canvas_source(self, source):
+        """Bind the page to ``source``, a callable handing back the canvas.
+
+        The callable returns the 2D canvas to read, or ``None`` when none is
+        active. The canvas is asked for on every read rather than held,
+        because it is a C++ widget owned by its sub-window: a reference kept
+        across the window's close outlives the object behind it, and the next
+        read walks freed memory.
+        """
+        self._source = source
+        self._key = self._state_key()
+        self._render()
+
+    def showEvent(self, event):
+        """Poll the bound canvas only while the page is on screen."""
+        super().showEvent(event)
+        self.refresh()
+        self._timer.start()
+
+    def hideEvent(self, event):
+        """Stop polling once the page leaves the screen."""
+        super().hideEvent(event)
+        self._timer.stop()
+
+    def refresh(self):
+        """Redraw the page when the canvas it is bound to has changed."""
+        key = self._state_key()
+        if key == self._key:
+            return
+        self._key = key
+        self._render()
+
+    def _build(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_view())
+        for title, waits_for in self.PLACEHOLDERS:
+            layout.addWidget(rule(QtWidgets.QFrame.HLine))
+            self.placeholders[title] = Placeholder(
+                title, waits_for, parent=self)
+            layout.addWidget(self.placeholders[title])
+
+        layout.addStretch(1)
+
+    def _build_view(self):
+        """Build the View section, for now the zoom readout alone."""
+        self._view = Section("View", parent=self)
+        self._readout = _Readout("Zoom", self._view)
+        self._view.body.addWidget(self._readout)
+        return self._view
+
+    def _canvas(self):
+        """The 2D canvas to read, or ``None`` when none is active."""
+        return None if self._source is None else self._source()
+
+    def _state_key(self):
+        """What the page shows, as a value the poll can compare."""
+        widget = self._canvas()
+        return None if widget is None else widget.viewTransform.zoom
+
+    def _render(self):
+        """Show the zoom of the canvas the page is bound to."""
+        self._readout.set_value(
+            "" if self._key is None else _format_zoom(self._key))
+        self._view.setEnabled(self._key is not None)
+
+    def _apply_style(self):
+        """Color the section heads and the readout from the palette."""
+        palette = self.palette()
+        text = palette.color(QtGui.QPalette.WindowText)
+        panel = palette.color(QtGui.QPalette.Window)
+        muted = blend(text, panel, self._MUTED_MIX)
+        self.setStyleSheet(f"""
+            QLabel#section {{
+                color: {muted.name()};
+            }}
+            QLabel#section:disabled {{
+                color: {blend(text, panel, self._GREYED_MIX).name()};
+            }}
+            QFrame#box {{
+                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border-radius: {self._RADIUS}px;
+                background: {palette.color(QtGui.QPalette.Base).name()};
+            }}
+            QLabel#name {{
+                font-size: {self._LABEL_PX}px;
+                color: {muted.name()};
+            }}
+            QLabel#value {{
+                font-size: {self._VALUE_PX}px;
+            }}
+            """)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_design.py
+++ b/solvcon/pilot/painter/_design.py
@@ -10,6 +10,7 @@ import math
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _icons
+from ._sections import Placeholder
 from ._style import (blend, mono_font, obb_metrics, rule, shade,
                      PaletteStyled)
 
@@ -133,34 +134,6 @@ class _Field(QtWidgets.QFrame):
             self.committed.emit(value)
 
 
-class _Placeholder(QtWidgets.QWidget):
-    """A greyed-out stand-in for a section the model cannot fill yet.
-
-    It carries the design's own title, so the page keeps its designed shape.
-    """
-
-    _ARROW = chr(0x25b8)
-    _MARGINS = (12, 11, 12, 11)
-    _FONT_PX = 10
-    _LETTER_SPACING = 110
-
-    def __init__(self, title, waits_for, folded=True, parent=None):
-        super().__init__(parent)
-        text = f"{self._ARROW}  {title.upper()}" if folded else title.upper()
-        label = QtWidgets.QLabel(text, self)
-        label.setObjectName("section")
-        font = label.font()
-        font.setPixelSize(self._FONT_PX)
-        font.setLetterSpacing(QtGui.QFont.PercentageSpacing,
-                              self._LETTER_SPACING)
-        label.setFont(font)
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(*self._MARGINS)
-        layout.addWidget(label)
-        self.setToolTip(f"{title}  (needs {waits_for})")
-        self.setEnabled(False)
-
-
 class DesignPage(PaletteStyled):
     """The inspector's Design page: the selected shape and its position.
 
@@ -271,7 +244,7 @@ class DesignPage(PaletteStyled):
         layout.addStretch(1)
 
     def _add_placeholder(self, title, waits_for, folded=True):
-        self.placeholders[title] = _Placeholder(title, waits_for, folded, self)
+        self.placeholders[title] = Placeholder(title, waits_for, folded, self)
         return self.placeholders[title]
 
     def _build_selection(self):

--- a/solvcon/pilot/painter/_gui.py
+++ b/solvcon/pilot/painter/_gui.py
@@ -8,6 +8,7 @@ Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _icons
+from ._canvas import CanvasPage
 from ._design import DesignPage
 from ._layers import LayersPage
 from ._style import blend, rule, shade, PaletteStyled
@@ -295,9 +296,7 @@ class PainterPanel(QtWidgets.QWidget):
     ``draw.tool`` action the Canvas menu also shows, plus the greyed-out Text
     and Grid slots the model cannot back yet. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
-    among them, and hands the active canvas to whichever page reads one. The
-    Canvas page arrives with a later step of the redesign, so it is still a
-    greyed-out placeholder naming what it will hold.
+    among them, and hands the active canvas to every page.
     """
 
     # The design's inspector width, in device-independent pixels. It is the
@@ -307,11 +306,6 @@ class PainterPanel(QtWidgets.QWidget):
 
     #: Inspector page names, in tab order.
     PAGES = ("Design", "Layers", "Canvas")
-
-    # What a page yet to be built says it will hold.
-    _PLACEHOLDERS = {
-        "Canvas": "View, grid, axes, background, and units",
-    }
 
     def __init__(self, tool_actions, short_labels=None, parent=None):
         """
@@ -330,6 +324,9 @@ class PainterPanel(QtWidgets.QWidget):
         self._design = DesignPage(self._stack)
         self._layers = LayersPage(self._stack)
         self._layers.picked.connect(self._on_picked)
+        self._canvas = CanvasPage(self._stack)
+        # In tab order, so the stack and the tab row cannot drift apart.
+        self._pages = (self._design, self._layers, self._canvas)
         self._tabs = _SegmentedTabs(self.PAGES)
         self._tabs.selected.connect(self.show_page)
         self._inspector = self._build_inspector()
@@ -365,10 +362,15 @@ class PainterPanel(QtWidgets.QWidget):
         """The Layers page."""
         return self._layers
 
+    @property
+    def canvas(self):
+        """The Canvas page."""
+        return self._canvas
+
     def set_canvas_source(self, source):
         """Tell the inspector how to reach the active 2D canvas."""
         self._source = source
-        for page in (self._design, self._layers):
+        for page in self._pages:
             page.set_canvas_source(source)
 
     def _on_picked(self, shape_id):
@@ -400,18 +402,14 @@ class PainterPanel(QtWidgets.QWidget):
         comes back into view, so a canvas switch does not pay for pages the
         user is not looking at.
         """
-        for page in (self._design, self._layers):
+        for page in self._pages:
             if page.isVisible():
                 page.refresh()
 
     def _build_inspector(self):
         """Build the tab row over the stack of pages."""
-        pages = {"Design": self._design, "Layers": self._layers}
-        for name in self.PAGES:
-            page = pages.get(name)
-            self._stack.addWidget(
-                self._build_page(self._PLACEHOLDERS[name])
-                if page is None else page)
+        for page in self._pages:
+            self._stack.addWidget(page)
         inspector = QtWidgets.QWidget(self)
         inspector.setMinimumWidth(self._INSPECTOR_WIDTH)
         layout = QtWidgets.QVBoxLayout(inspector)
@@ -421,18 +419,6 @@ class PainterPanel(QtWidgets.QWidget):
         layout.addWidget(rule(QtWidgets.QFrame.HLine))
         layout.addWidget(self._stack, 1)
         return inspector
-
-    def _build_page(self, placeholder):
-        """Build one inspector page, for now just its greyed-out summary."""
-        page = QtWidgets.QWidget(self._stack)
-        layout = QtWidgets.QVBoxLayout(page)
-        layout.setContentsMargins(8, 8, 8, 8)
-        label = QtWidgets.QLabel(placeholder, page)
-        label.setWordWrap(True)
-        label.setEnabled(False)
-        layout.addWidget(label)
-        layout.addStretch(1)
-        return page
 
     def current_page(self):
         """The name of the page the inspector shows."""

--- a/solvcon/pilot/painter/_sections.py
+++ b/solvcon/pilot/painter/_sections.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The titled sections the pages of the Painter inspector are built from.
+
+The design heads every section the same way, a small uppercase title with a
+fold arrow, and leaves several of them to follow-ups. Both the open section and
+the greyed-out stand-in live here, so a page that fills one and a page that
+still waits on the model draw the same head.
+"""
+
+from PySide6 import QtGui, QtWidgets
+
+__all__ = [
+    'ARROW_OPEN',
+    'ARROW_FOLDED',
+    'Section',
+    'Placeholder',
+]
+
+#: The fold arrow of an open section and of a folded one.
+ARROW_OPEN = chr(0x25be)
+ARROW_FOLDED = chr(0x25b8)
+
+_MARGINS = (12, 11, 12, 11)
+_GAP = 9
+_FONT_PX = 10
+_LETTER_SPACING = 110
+
+
+class Section(QtWidgets.QWidget):
+    """One section of a page: the design's head over the controls it holds.
+
+    A page adds its controls to :attr:`body`, the layout the head already sits
+    in, so they land under the title with the design's own spacing.
+    """
+
+    def __init__(self, title, arrow=ARROW_OPEN, parent=None):
+        """
+        :param arrow: The fold arrow to head the title with, or an empty
+            string for a section that folds nothing.
+        :type arrow: str
+        """
+        super().__init__(parent)
+        self.body = QtWidgets.QVBoxLayout(self)
+        self.body.setContentsMargins(*_MARGINS)
+        self.body.setSpacing(_GAP)
+        self.body.addWidget(self._build_title(title, arrow))
+
+    def _build_title(self, title, arrow):
+        label = QtWidgets.QLabel(
+            f"{arrow}  {title.upper()}" if arrow else title.upper(), self)
+        label.setObjectName("section")
+        font = label.font()
+        font.setPixelSize(_FONT_PX)
+        font.setLetterSpacing(QtGui.QFont.PercentageSpacing, _LETTER_SPACING)
+        label.setFont(font)
+        return label
+
+
+class Placeholder(Section):
+    """A greyed-out stand-in for a section the model cannot fill yet.
+
+    It carries the design's own title, so the page keeps its designed shape.
+    """
+
+    def __init__(self, title, waits_for, folded=True, parent=None):
+        super().__init__(title, ARROW_FOLDED if folded else "", parent)
+        self.setToolTip(f"{title}  (needs {waits_for})")
+        self.setEnabled(False)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_painter_canvas.py
+++ b/tests/test_pilot_painter_canvas.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the Canvas page of the Painter inspector.
+"""
+
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import painter as _painter
+    from solvcon.pilot.painter import _canvas
+    from PySide6 import QtGui
+except ImportError:
+    pilot = None
+
+
+def _view(pan_x=0.0, pan_y=0.0, zoom=1.0):
+    """A view transform panned and zoomed as given."""
+    view = solvcon.ViewTransform2dFp64()
+    view.pan_x = pan_x
+    view.pan_y = pan_y
+    view.zoom = zoom
+    return view
+
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas: a view over a world.
+
+    The real canvas hands back a detached copy of its transform, so the stub
+    copies too; a page that wrote into the canvas's own transform would pass
+    here and fail there.
+    """
+
+    def __init__(self, world):
+        self.world = world
+        self._view = _view()
+
+    @property
+    def viewTransform(self):
+        return _view(self._view.pan_x, self._view.pan_y, self._view.zoom)
+
+    def setViewTransform(self, view):
+        self._view = _view(view.pan_x, view.pan_y, view.zoom)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PainterCanvasPageTC(unittest.TestCase):
+    """What the View section reads off the canvas it is bound to."""
+
+    @classmethod
+    def setUpClass(cls):
+        # No window needed, only a live QGuiApplication to hold a widget.
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        self.canvas = _StubCanvas(self.world)
+        self.page = _canvas.CanvasPage()
+        self.page.set_canvas_source(lambda: self.canvas)
+
+    def _set_view(self, **kw):
+        self.canvas.setViewTransform(_view(**kw))
+        self.page.refresh()
+
+    def test_the_readout_reads_the_zoom_as_a_percentage(self):
+        self.assertEqual(self.page.zoom, "100%")
+        self._set_view(zoom=0.6833)
+        self.assertEqual(self.page.zoom, "68%")
+        self._set_view(zoom=2.5)
+        self.assertEqual(self.page.zoom, "250%")
+
+    def test_a_far_zoom_out_keeps_the_digits_below_one(self):
+        self._set_view(zoom=0.0025)
+        self.assertEqual(self.page.zoom, "0.25%")
+
+    def test_a_zoom_the_world_cannot_see_still_refreshes(self):
+        # Zooming moves no geometry, so a poll watching the world alone would
+        # leave the readout behind.
+        self.world.add_circle(0, 0, 1)
+        self.page.refresh()
+        before = self.page.zoom
+        self._set_view(zoom=4.0)
+        self.assertNotEqual(self.page.zoom, before)
+        self.assertEqual(self.page.zoom, "400%")
+
+    def test_a_pan_leaves_the_readout_where_it_stands(self):
+        # The page shows the zoom alone, and the poll compares what it shows.
+        self._set_view(zoom=2.0)
+        self._set_view(pan_x=120.0, pan_y=-40.0, zoom=2.0)
+        self.assertEqual(self.page.zoom, "200%")
+
+    def test_binding_another_canvas_shows_that_one(self):
+        # The panel rebinds the page as the active sub-window changes, and what
+        # it reads follows the canvas handed over.
+        self._set_view(zoom=3.0)
+        self.page.set_canvas_source(lambda: _StubCanvas(self.world))
+        self.assertEqual(self.page.zoom, "100%")
+
+    def test_without_a_canvas_the_view_section_is_dead(self):
+        self.canvas = None
+        self.page.refresh()
+        self.assertEqual(self.page.zoom, "")
+        self.assertFalse(self.page._view.isEnabled())
+
+    def test_sections_the_model_cannot_fill_are_greyed_out(self):
+        self.assertEqual(list(self.page.placeholders),
+                         ["Grid", "Axes & origin", "Background", "Units"])
+        for title, section in self.page.placeholders.items():
+            with self.subTest(title=title):
+                self.assertFalse(section.isEnabled())
+                self.assertIn("needs", section.toolTip())
+
+    def test_the_page_fits_the_designed_inspector(self):
+        self.assertLessEqual(self.page.sizeHint().width(),
+                             _painter.PainterPanel._INSPECTOR_WIDTH)
+
+    def test_the_page_restyles_with_the_palette(self):
+        # A color captured once would survive a theme switch as is.
+        before = self.page.styleSheet()
+        palette = QtGui.QPalette(self.page.palette())
+        palette.setColor(QtGui.QPalette.Window, QtGui.QColor("black"))
+        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
+        self.page.setPalette(palette)
+        self.assertNotEqual(self.page.styleSheet(), before)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Painter inspector's third tab has been a greyed-out placeholder since the frame landed. It now shows the page the redesign draws: a View section reading the zoom of the canvas the panel is bound to, over the Grid, axes and origin, background, and units sections, which keep their designed titles and stay greyed out until the model can back them. The page reads the canvas on a timer, as the Design and Layers pages do, because the view carries no change signal, and the poll compares the zoom alone, which is all the page shows.

The small uppercase head the design gives every section moves out of the Design page into a module the pages share, so the placeholders there and the sections here cannot drift apart.

The buttons that act on the view follow in the next change.

Related to #1175.
