### PR TITLE
Painter Canvas 2: fit, size, and center the view

### DIFF
--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -658,6 +658,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                 py::return_value_policy::copy)
             .def("setViewTransform", &wrapped_type::setViewTransform, py::arg("v"))
             .def("resetView", &wrapped_type::resetView)
+            .def_property_readonly(
+                "viewportSize",
+                [](wrapped_type & self)
+                {
+                    return py::make_tuple(self.width(), self.height());
+                },
+                "The drawing area as (width, height) in device-independent pixels.")
             .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
             .def_property_readonly("world", &wrapped_type::world)
             .def("requestRepaint", &wrapped_type::requestRepaint)

--- a/solvcon/pilot/painter/_canvas.py
+++ b/solvcon/pilot/painter/_canvas.py
@@ -5,10 +5,14 @@
 The Canvas page of the Painter inspector: how the canvas shows the world.
 """
 
+import json
+import math
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ._sections import Placeholder, Section
 from ._style import blend, mono_font, rule, shade, PaletteStyled
+from ..panel._tree_panel import EntityTreeWidget
 
 __all__ = [
     'CanvasPage',
@@ -19,9 +23,18 @@ def _format_zoom(zoom):
     """Return the zoom as the readout shows it, screen pixels per world unit
     read as a percentage."""
     percent = 100.0 * zoom
-    # Whole percents while the view is anywhere near its own scale, which is
-    # what the design shows; a far zoom out needs the digits below one.
     return f"{round(percent):g}%" if percent >= 1.0 else f"{percent:.3g}%"
+
+
+def _box_center(bounds):
+    """The middle of ``bounds`` as ``(min_x, min_y, max_x, max_y)``.
+
+    Halved before summed: two bounds far enough out add up past the double
+    range, and the middle between them would come back infinite though it lies
+    well inside.
+    """
+    min_x, min_y, max_x, max_y = bounds
+    return 0.5 * min_x + 0.5 * max_x, 0.5 * min_y + 0.5 * max_y
 
 
 class _Readout(QtWidgets.QFrame):
@@ -61,18 +74,14 @@ class CanvasPage(PaletteStyled):
     """The inspector's Canvas page: the view over the bound canvas.
 
     Like the other pages, this one reads the canvas it is bound to on a timer,
-    because the view carries no change signal. What the poll compares is the
-    zoom, which is what the View section reads; the pan is left out, since it
-    moves the view without changing that.
-
-    The buttons that act on the view, and the sections the model cannot back
-    yet, arrive with later steps of the redesign; they stand here as their
-    designed titles, greyed out.
+    because neither the world nor the view carries a change signal. What the
+    poll compares is the zoom, which the readout shows, and counts of what the
+    world holds, which say whether there is anything to fit. The pan is left
+    out: it moves the view without changing either.
     """
 
     # Poll period in milliseconds, the Design page's rate and for its reason:
-    # the reading is cheap enough to take this often, and a slower one reads as
-    # lag while the wheel moves the zoom under it.
+    # a slower one reads as lag while the wheel moves the zoom under it.
     _POLL_MS = 60
 
     #: The greyed-out sections, as ``(title, what the section waits for)``.
@@ -83,19 +92,28 @@ class CanvasPage(PaletteStyled):
         ("Units", "display units and precision"),
     )
 
+    _FIT_MARGIN = 0.9
+    # Stand-in span when content has no extent on either axis.
+    _MIN_SPAN = 1.0
+
+    _ACTION_HEIGHT = 26
+    _ACTION_GAP = 5
     _LABEL_PX = 10
     _VALUE_PX = 11
+    _ACTION_PX = 11
     _RADIUS = 5
 
     # How far each of these sits from the panel color.
     _MUTED_MIX = 0.35
     _GREYED_MIX = 0.6
     _BORDER_MIX = 0.25
+    _HOVER_MIX = 0.08
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._source = None
-        self._key = None
+        self._key = (None, None)
+        self.buttons = {}
         self.placeholders = {}
         self._build()
         self._timer = QtCore.QTimer(self)
@@ -119,6 +137,9 @@ class CanvasPage(PaletteStyled):
         read walks freed memory.
         """
         self._source = source
+        # Rendered rather than refreshed: two canvases can share a zoom and the
+        # same empty-world counts, so a refresh would take the page for
+        # unchanged.
         self._key = self._state_key()
         self._render()
 
@@ -155,44 +176,165 @@ class CanvasPage(PaletteStyled):
         layout.addStretch(1)
 
     def _build_view(self):
-        """Build the View section, for now the zoom readout alone."""
+        """Build the View section: the zoom readout over the view buttons."""
         self._view = Section("View", parent=self)
         self._readout = _Readout("Zoom", self._view)
         self._view.body.addWidget(self._readout)
+        self._view.body.addLayout(self._build_actions())
         return self._view
+
+    def _build_actions(self):
+        """Build the view buttons, in design order."""
+        layout = QtWidgets.QHBoxLayout()
+        layout.setSpacing(self._ACTION_GAP)
+        for name, handler in (("Fit", self._on_fit),
+                              ("100%", self._on_actual),
+                              ("Center", self._on_center)):
+            button = QtWidgets.QPushButton(name, self._view)
+            button.setObjectName("action")
+            button.setFixedHeight(self._ACTION_HEIGHT)
+            button.setCursor(QtCore.Qt.PointingHandCursor)
+            button.clicked.connect(handler)
+            layout.addWidget(button)
+            self.buttons[name] = button
+        return layout
 
     def _canvas(self):
         """The 2D canvas to read, or ``None`` when none is active."""
         return None if self._source is None else self._source()
 
     def _state_key(self):
-        """What the page shows, as a value the poll can compare."""
+        """What the page reads off the canvas, as a value the poll can compare:
+        the zoom it shows, and counts of what the world holds.
+
+        The counts stand in for the world itself, which would cost a full
+        serialization every tick. They do not move when a shape is dragged, and
+        they need not: all the page shows of the world is whether it holds
+        anything, and Fit measures the geometry when it is pressed.
+        """
         widget = self._canvas()
-        return None if widget is None else widget.viewTransform.zoom
+        if widget is None:
+            return (None, None)
+        world = widget.world
+        return (widget.viewTransform.zoom,
+                None if world is None else (world.nshape, world.npoint,
+                                            world.nsegment, world.nbezier))
 
     def _render(self):
-        """Show the zoom of the canvas the page is bound to."""
-        self._readout.set_value(
-            "" if self._key is None else _format_zoom(self._key))
-        self._view.setEnabled(self._key is not None)
+        """Show the bound canvas's zoom and whether its world can be fitted."""
+        zoom, counts = self._key
+        self._readout.set_value("" if zoom is None else _format_zoom(zoom))
+        self._view.setEnabled(zoom is not None)
+        self.buttons["Fit"].setEnabled(self._can_fit(counts))
+
+    def _can_fit(self, counts):
+        """Whether the world reports anything Fit could frame.
+
+        Pad leftovers from a removed shape keep ``nsegment`` / ``nbezier``
+        non-zero, so Fit may stay enabled and no-op when bounds are empty.
+        """
+        return counts is not None and any(counts)
+
+    @staticmethod
+    def _content_bounds(widget):
+        """The extent of what ``widget`` draws, or ``None`` for nothing."""
+        world = widget.world
+        if world is None:
+            return None
+        return EntityTreeWidget.world_bounds(
+            json.loads(world.describe_state()))
+
+    def _on_fit(self):
+        """Frame everything the world draws, with a margin around it."""
+        widget = self._canvas()
+        if widget is None:
+            return
+        bounds = self._content_bounds(widget)
+        if bounds is None:
+            return
+        min_x, min_y, max_x, max_y = bounds
+        width, height = widget.viewportSize
+        zoom = self._fit_zoom(width, max_x - min_x, height, max_y - min_y)
+        self._show(widget, zoom, _box_center(bounds))
+
+    @classmethod
+    def _fit_zoom(cls, size_x, span_x, size_y, span_y):
+        """The zoom that frames ``span_x`` by ``span_y`` in a canvas ``size_x``
+        by ``size_y``.
+
+        Use the tightest positive-span axis; skip a flat axis so ``_MIN_SPAN``
+        does not shrink the other, and fall back to that span when both are
+        flat.
+        """
+        room = [size / span
+                for size, span in ((size_x, span_x), (size_y, span_y))
+                if span > 0.0]
+        return cls._FIT_MARGIN * min(
+            room or [min(size_x, size_y) / cls._MIN_SPAN])
+
+    def _on_actual(self):
+        """Zoom to one pixel per world unit, about the view's own middle."""
+        widget = self._canvas()
+        if widget is None:
+            return
+        width, height = widget.viewportSize
+        # Set zoom to 1; scaling by 1/zoom need not land exactly there.
+        self._show(widget, 1.0, widget.viewTransform.world_from_screen(
+            0.5 * width, 0.5 * height))
+
+    def _on_center(self):
+        """Put the content, or the origin, in the middle of the canvas."""
+        widget = self._canvas()
+        if widget is None:
+            return
+        bounds = self._content_bounds(widget)
+        self._show(widget, widget.viewTransform.zoom,
+                   (0.0, 0.0) if bounds is None else _box_center(bounds))
+
+    def _show(self, widget, zoom, center):
+        """Zoom ``widget`` to ``zoom`` with ``center`` in the middle of it.
+
+        Apply zoom first so the pan uses the clamped transform; on a
+        non-finite pan, restore the prior view so zoom is not left alone.
+        """
+        before = widget.viewTransform
+        # A second copy of the same transform: the first is the way back.
+        view = widget.viewTransform
+        view.zoom = zoom
+        widget.setViewTransform(view)
+        view = widget.viewTransform
+        width, height = widget.viewportSize
+        center_x, center_y = center
+        view.pan_x = 0.5 * width - view.zoom * center_x
+        view.pan_y = 0.5 * height + view.zoom * center_y
+        if not (math.isfinite(view.pan_x) and math.isfinite(view.pan_y)):
+            widget.setViewTransform(before)
+            return
+        widget.setViewTransform(view)
+        widget.requestRepaint()
+        self.refresh()
 
     def _apply_style(self):
-        """Color the section heads and the readout from the palette."""
+        """Color the section heads, the readout, and the buttons from the
+        palette."""
         palette = self.palette()
         text = palette.color(QtGui.QPalette.WindowText)
         panel = palette.color(QtGui.QPalette.Window)
         muted = blend(text, panel, self._MUTED_MIX)
+        greyed = blend(text, panel, self._GREYED_MIX)
+        border = shade(self, self._BORDER_MIX)
+        base = palette.color(QtGui.QPalette.Base)
         self.setStyleSheet(f"""
             QLabel#section {{
                 color: {muted.name()};
             }}
             QLabel#section:disabled {{
-                color: {blend(text, panel, self._GREYED_MIX).name()};
+                color: {greyed.name()};
             }}
             QFrame#box {{
-                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border: 1px solid {border.name()};
                 border-radius: {self._RADIUS}px;
-                background: {palette.color(QtGui.QPalette.Base).name()};
+                background: {base.name()};
             }}
             QLabel#name {{
                 font-size: {self._LABEL_PX}px;
@@ -200,6 +342,18 @@ class CanvasPage(PaletteStyled):
             }}
             QLabel#value {{
                 font-size: {self._VALUE_PX}px;
+            }}
+            QPushButton#action {{
+                border: 1px solid {border.name()};
+                border-radius: {self._RADIUS}px;
+                font-size: {self._ACTION_PX}px;
+                background: {base.name()};
+            }}
+            QPushButton#action:hover {{
+                background: {shade(self, self._HOVER_MIX).name()};
+            }}
+            QPushButton#action:disabled {{
+                color: {greyed.name()};
             }}
             """)
 

--- a/tests/test_pilot_painter_canvas.py
+++ b/tests/test_pilot_painter_canvas.py
@@ -5,17 +5,24 @@
 Tests for the Canvas page of the Painter inspector.
 """
 
+import os
 import unittest
 
 import solvcon
 
 try:
     from solvcon import pilot
+    from solvcon.pilot.base import _gui
     from solvcon.pilot import painter as _painter
     from solvcon.pilot.painter import _canvas
-    from PySide6 import QtGui
+    from PySide6 import QtGui, QtWidgets
 except ImportError:
     pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
 def _view(pan_x=0.0, pan_y=0.0, zoom=1.0):
@@ -27,16 +34,40 @@ def _view(pan_x=0.0, pan_y=0.0, zoom=1.0):
     return view
 
 
-class _StubCanvas:
-    """Stand-in for the 2D canvas: a view over a world.
+def _assert_shows(case, canvas, *points):
+    """Fail unless every world point given lands inside ``canvas``."""
+    width, height = canvas.viewportSize
+    for point in points:
+        x, y = canvas.viewTransform.screen_from_world(*point)
+        case.assertTrue(0 < x < width, x)
+        case.assertTrue(0 < y < height, y)
 
-    The real canvas hands back a detached copy of its transform, so the stub
-    copies too; a page that wrote into the canvas's own transform would pass
-    here and fail there.
+
+def _assert_centered(case, canvas, point):
+    """Fail unless the world ``point`` lands in the middle of ``canvas``."""
+    width, height = canvas.viewportSize
+    x, y = canvas.viewTransform.screen_from_world(*point)
+    case.assertAlmostEqual(x, 0.5 * width, places=3)
+    case.assertAlmostEqual(y, 0.5 * height, places=3)
+
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas.
+
+    The real canvas hands back a detached copy of its transform and takes a
+    whole one back, so the stub copies in both directions; a page that wrote
+    into the canvas's own transform would pass here and fail there.
+
+    :class:`PainterCanvasCanvasTC` covers the live canvas path, including the
+    zoom clamp the stub leaves alone.
     """
+
+    SIZE = (400, 300)
 
     def __init__(self, world):
         self.world = world
+        self.viewportSize = self.SIZE
+        self.repaints = 0
         self._view = _view()
 
     @property
@@ -46,10 +77,13 @@ class _StubCanvas:
     def setViewTransform(self, view):
         self._view = _view(view.pan_x, view.pan_y, view.zoom)
 
+    def requestRepaint(self):
+        self.repaints += 1
+
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class PainterCanvasPageTC(unittest.TestCase):
-    """What the View section reads off the canvas it is bound to."""
+    """What the View section reads and what its buttons do to the view."""
 
     @classmethod
     def setUpClass(cls):
@@ -61,6 +95,24 @@ class PainterCanvasPageTC(unittest.TestCase):
         self.canvas = _StubCanvas(self.world)
         self.page = _canvas.CanvasPage()
         self.page.set_canvas_source(lambda: self.canvas)
+
+    def _shown_center(self):
+        """The world point the middle of the canvas shows."""
+        width, height = self.canvas.viewportSize
+        return self.canvas.viewTransform.world_from_screen(
+            0.5 * width, 0.5 * height)
+
+    def _assert_shows(self, *points):
+        _assert_shows(self, self.canvas, *points)
+
+    def _fit(self):
+        """Press Fit, after the poll has seen what the world now holds.
+
+        Qt drops a press on a disabled button, and Fit is disabled until the
+        page has read a world with something in it.
+        """
+        self.page.refresh()
+        self.page.buttons["Fit"].click()
 
     def _set_view(self, **kw):
         self.canvas.setViewTransform(_view(**kw))
@@ -88,23 +140,169 @@ class PainterCanvasPageTC(unittest.TestCase):
         self.assertEqual(self.page.zoom, "400%")
 
     def test_a_pan_leaves_the_readout_where_it_stands(self):
-        # The page shows the zoom alone, and the poll compares what it shows.
         self._set_view(zoom=2.0)
         self._set_view(pan_x=120.0, pan_y=-40.0, zoom=2.0)
         self.assertEqual(self.page.zoom, "200%")
 
     def test_binding_another_canvas_shows_that_one(self):
-        # The panel rebinds the page as the active sub-window changes, and what
-        # it reads follows the canvas handed over.
+        self.world.add_circle(0, 0, 1)
         self._set_view(zoom=3.0)
-        self.page.set_canvas_source(lambda: _StubCanvas(self.world))
+        self.assertTrue(self.page.buttons["Fit"].isEnabled())
+        self.page.set_canvas_source(lambda: _StubCanvas(solvcon.WorldFp64()))
         self.assertEqual(self.page.zoom, "100%")
+        self.assertFalse(self.page.buttons["Fit"].isEnabled())
+
+    def test_the_buttons_stand_in_design_order(self):
+        self.assertEqual(list(self.page.buttons), ["Fit", "100%", "Center"])
+
+    def test_a_hundred_percent_keeps_the_view_center(self):
+        self._set_view(pan_x=30.0, pan_y=-70.0, zoom=8.0)
+        center = self._shown_center()
+        self.page.buttons["100%"].click()
+        self.assertEqual(self.canvas.viewTransform.zoom, 1.0)
+        for got, want in zip(self._shown_center(), center):
+            self.assertAlmostEqual(got, want)
+        self.assertEqual(self.page.zoom, "100%")
+        self.assertEqual(self.canvas.repaints, 1)
+
+    def test_center_preserves_the_zoom(self):
+        self.world.add_circle(10, 20, 3)
+        self._set_view(pan_x=5.0, pan_y=5.0, zoom=3.0)
+        self.page.buttons["Center"].click()
+        self.assertEqual(self.canvas.viewTransform.zoom, 3.0)
+        for got, want in zip(self._shown_center(), (10.0, 20.0)):
+            self.assertAlmostEqual(got, want)
+        self.assertEqual(self.canvas.repaints, 1)
+
+    def test_center_on_an_empty_world_shows_the_origin(self):
+        self._set_view(pan_x=400.0, pan_y=-90.0, zoom=2.0)
+        self.page.buttons["Center"].click()
+        self.assertEqual(self.canvas.viewTransform.zoom, 2.0)
+        for got in self._shown_center():
+            self.assertAlmostEqual(got, 0.0)
+
+    def test_fit_frames_the_content_inside_the_canvas(self):
+        self.world.add_rectangle(-20, -10, 20, 10)
+        self._fit()
+        self.assertAlmostEqual(self.canvas.viewTransform.zoom,
+                               _canvas.CanvasPage._FIT_MARGIN
+                               * self.canvas.viewportSize[0] / 40)
+        self._assert_shows((-20, -10), (20, 10))
+        for got in self._shown_center():
+            self.assertAlmostEqual(got, 0.0)
+
+    def test_fit_frames_a_shape_where_the_poll_never_saw_it(self):
+        # Counts do not move on translate; Fit must re-measure.
+        sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.page.refresh()
+        before = self.page._key
+        self.world.translate_shape(sid, 500.0, 500.0)
+        self.assertEqual(self.page._key, before)
+        self.page.buttons["Fit"].click()
+        self._assert_shows((498, 499), (502, 501))
+
+    def test_fit_covers_the_geometry_no_shape_owns(self):
+        self.world.add_segment(solvcon.Point3dFp64(100, 100, 0),
+                               solvcon.Point3dFp64(140, 130, 0))
+        self.world.add_point(80, 90, 0)
+        self._fit()
+        self._assert_shows((80, 90), (140, 130))
+
+    def test_fit_fills_the_canvas_with_content_smaller_than_a_unit(self):
+        # Must not floor the span to _MIN_SPAN.
+        self.world.add_rectangle(-0.1, -0.1, 0.1, 0.1)
+        self._fit()
+        self.assertAlmostEqual(self.canvas.viewTransform.zoom,
+                               _canvas.CanvasPage._FIT_MARGIN
+                               * self.canvas.viewportSize[1] / 0.2)
+
+    def test_fit_frames_a_segment_flat_on_one_axis_by_the_other(self):
+        self.world.add_segment(solvcon.Point3dFp64(0, 5, 0),
+                               solvcon.Point3dFp64(0.1, 5, 0))
+        self._fit()
+        self.assertAlmostEqual(self.canvas.viewTransform.zoom,
+                               _canvas.CanvasPage._FIT_MARGIN
+                               * self.canvas.viewportSize[0] / 0.1)
+        self._assert_shows((0, 5), (0.1, 5))
+
+    def test_fit_centers_bounds_whose_sum_would_overflow(self):
+        self.world.add_point(9e307, 9e307, 0)
+        self.world.add_point(1e308, 1e308, 0)
+        self._fit()
+        # Written out rather than figured the way the page figures it, so the
+        # test does not agree with a page that halves the wrong way.
+        middle = 9.5e307
+        _assert_centered(self, self.canvas, (middle, middle))
+
+    def test_fit_gives_a_world_of_no_extent_a_span(self):
+        self.world.add_point(4, -6, 0)
+        self._fit()
+        zoom = self.canvas.viewTransform.zoom
+        self.assertGreater(zoom, 0.0)
+        self.assertLess(zoom, float("inf"))
+        for got, want in zip(self._shown_center(), (4.0, -6.0)):
+            self.assertAlmostEqual(got, want)
+
+    def test_fit_is_greyed_out_while_there_is_nothing_to_fit(self):
+        self.assertFalse(self.page.buttons["Fit"].isEnabled())
+        for name in ("100%", "Center"):
+            self.assertTrue(self.page.buttons[name].isEnabled())
+        self.world.add_circle(0, 0, 1)
+        self.page.refresh()
+        self.assertTrue(self.page.buttons["Fit"].isEnabled())
+
+    def test_fit_on_a_removed_shape_is_a_no_op_until_undo(self):
+        # Pad leftovers keep counts non-zero, so Fit stays enabled and no-ops
+        # until undo brings drawable geometry back.
+        sid = self.world.add_circle(0, 0, 1)
+        self.page.refresh()
+        self.world.remove_shape(sid)
+        self.page.refresh()
+        self.assertTrue(self.page.buttons["Fit"].isEnabled())
+        before = self.canvas.viewTransform
+        self.page.buttons["Fit"].click()
+        after = self.canvas.viewTransform
+        self.assertEqual((after.pan_x, after.pan_y, after.zoom),
+                         (before.pan_x, before.pan_y, before.zoom))
+        self.assertEqual(self.canvas.repaints, 0)
+        self.world.undo()
+        self._fit()
+        self._assert_shows((-1, -1), (1, 1))
+
+    def test_a_center_the_pan_cannot_reach_leaves_the_view_alone(self):
+        # Overflowing pan must not leave a half-applied zoom.
+        self.world.add_point(1e307, 1e307, 0)
+        self.page.refresh()
+        before = self.canvas.viewTransform
+        self.page.buttons["Fit"].click()
+        after = self.canvas.viewTransform
+        self.assertEqual((after.pan_x, after.pan_y, after.zoom),
+                         (before.pan_x, before.pan_y, before.zoom))
+        self.assertEqual(self.canvas.repaints, 0)
 
     def test_without_a_canvas_the_view_section_is_dead(self):
         self.canvas = None
         self.page.refresh()
         self.assertEqual(self.page.zoom, "")
-        self.assertFalse(self.page._view.isEnabled())
+        for name, button in self.page.buttons.items():
+            with self.subTest(name=name):
+                self.assertFalse(button.isEnabled())
+
+    def test_a_press_after_the_canvas_is_gone_reaches_nothing(self):
+        self.world.add_circle(0, 0, 1)
+        self._set_view(pan_x=10.0, pan_y=-20.0, zoom=2.0)
+        stub = self.canvas
+        before = stub.viewTransform
+        self.canvas = None
+        for name in self.page.buttons:
+            with self.subTest(name=name):
+                self.page.buttons[name].click()
+                self.assertEqual(
+                    (stub.viewTransform.pan_x, stub.viewTransform.pan_y,
+                     stub.viewTransform.zoom),
+                    (before.pan_x, before.pan_y, before.zoom))
+        self.page.refresh()
+        self.assertEqual(self.page.zoom, "")
 
     def test_sections_the_model_cannot_fill_are_greyed_out(self):
         self.assertEqual(list(self.page.placeholders),
@@ -126,6 +324,71 @@ class PainterCanvasPageTC(unittest.TestCase):
         palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
         self.page.setPalette(palette)
         self.assertNotEqual(self.page.styleSheet(), before)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class PainterCanvasCanvasTC(unittest.TestCase):
+    """The page against a real canvas, bound by the Painter dock."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.painter = _gui.controller.painter
+        self.painter._ensure_dock()
+        # The manager is shared with every other pilot suite, and a canvas one
+        # of them left open would answer for this one's once it closes.
+        for subwin in self.mgr.mdiArea.subWindowList():
+            subwin.close()
+        QtWidgets.QApplication.processEvents()
+        self.widget = self.mgr.add2DWidget()
+        self.world = solvcon.WorldFp64()
+        self.world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(self.world)
+        # Set the view before showing so the resize auto-centering, which a
+        # well-formed transform disables, leaves the mapping deterministic.
+        self.widget.setViewTransform(_view(100.0, 100.0, 20.0))
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+
+    def _page(self):
+        page = self.painter.panel.canvas
+        # Activation is delivered through a zero timer, so let it run.
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        return page
+
+    def test_the_readout_follows_the_active_canvas(self):
+        self.assertEqual(self._page().zoom, "2000%")
+
+    def test_the_canvas_reports_the_space_the_view_maps_into(self):
+        self.assertEqual(
+            self.widget.viewportSize,
+            (self.sub.widget().width(), self.sub.widget().height()))
+
+    def test_fit_frames_the_shape_on_the_canvas(self):
+        self._page().buttons["Fit"].click()
+        _assert_shows(self, self.widget, (-2, -1), (2, 1))
+
+    def test_fit_centers_a_world_too_wide_for_the_zoom_band(self):
+        # Pan must use the clamped zoom, not the requested one.
+        self.world.add_point(-1e12, -1e12, 0)
+        self.world.add_point(1e12, 1e12, 0)
+        self._page().buttons["Fit"].click()
+        _assert_centered(self, self.widget, (0.0, 0.0))
+
+    def test_closing_the_canvas_leaves_the_page_standing(self):
+        page = self._page()
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual(page.zoom, "")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Painter's Canvas page gains the three view buttons the design draws under the zoom readout. Fit frames everything the world draws, shapes and bare segments, curves and points alike, and greys out when there is nothing to frame. 100% zooms to exactly one pixel per world unit about the middle the view already shows, and Center pans the content, or the origin, into that middle without touching the zoom.

Centering needs the size of the space the view maps into, which the wrapper did not expose, so `R2DWidget` hands its drawing area over as `viewportSize`. The canvas clamps the zoom it is given, so the pan is figured from the transform it hands back, and a center too far out for that pan to stay finite leaves the view alone rather than half written.

Fit only needs to know whether the world holds anything, so the poll compares counts of what it holds rather than the serialized state, which costs 4.6 ms against 0.0003 ms at a thousand shapes and would have slowed the zoom readout. Counts do not move when a shape is dragged, so Fit measures the geometry when it is pressed.

At 556 changed lines this is over the 500-line guideline, about 300 of them tests.

Related to #1175.
