### PR TITLE
Save the compiler cache only outside pull requests

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -73,6 +73,7 @@ jobs:
           key: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           restore-keys: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           create-symlink: true
+          save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
           # key. A master push or nightly run saves this cache; pull requests
           # restore it (a PR on a non-default base branch cannot, so it runs
@@ -157,6 +158,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         create-symlink: true
+        save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
         # key. A master push or nightly run saves this cache; pull requests
         # restore it (a PR on a non-default base branch cannot, so it runs
@@ -342,6 +344,7 @@ jobs:
           variant: sccache
           key: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
           restore-keys: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
           # key. A master push or nightly run saves this cache; pull requests
           # restore it (a PR on a non-default base branch cannot, so it runs
@@ -533,6 +536,7 @@ jobs:
         key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         create-symlink: true
+        save: ${{ github.event_name != 'pull_request' }}
         max-size: 1500M
 
     - name: make gtest USE_SANITIZER=ON

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,6 +100,7 @@ jobs:
         key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         create-symlink: true
+        save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
         # key. A master push or nightly run saves this cache; pull requests
         # restore it (a PR on a non-default base branch cannot, so it runs

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -86,6 +86,7 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           create-symlink: true
+          save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
           # key. A master push or nightly run saves this cache; pull requests
           # restore it (a PR on a non-default base branch cannot, so it runs


### PR DESCRIPTION
Related to #1222.

The comments on the ccache steps already state the policy: a master push or nightly run saves the cache and a pull request restores it. Nothing enforced it, because `hendrikmuhs/ccache-action` saves on every run by default.

A cache written during a pull-request run is scoped to that run's `refs/pull/N/merge` ref. No other pull request, and no master push, can ever restore it. It is write-only, it is read by nobody, and it still counts against the 10 GB repository quota. GitHub evicts by least recent use, so these archives crowd out the master-branch entries that pull requests do restore from.

The quota is full of exactly that. Measured today from `gh api repos/solvcon/solvcon/actions/cache/usage` and `actions/caches`, at 10.2 GB against the 10 GB limit:

| ref | caches | size |
|---|---|---|
| `refs/heads/master` | 16 | 2.93 GB |
| `refs/pull/1223/merge` | 19 | 3.40 GB |
| `refs/pull/1219/merge` | 16 | 1.85 GB |
| `refs/pull/1225/merge` | 6 | 1.04 GB |
| `refs/pull/1226/merge` | 4 | 0.45 GB |

About 6.7 GB, two thirds of the quota, is pull-request-scoped and unrestorable, against 2.93 GB of master entries that every pull request can use. The last two rows are #1225 and #1226, two pull requests in this same series, which have already written 1.5 GB that nothing will ever read.

The consequence is intermittent rather than constant, and it is worth being precise about that. While a master entry survives, pull requests restore it and hit rates are high: #1225 measured 97.84% on Linux and 97.41% on macOS today. When quota pressure evicts a master entry, the next pull request that needs it compiles from scratch. That is run 30532183716, a pull request touching only Python files, which logged "No cache found" on both the Linux and macOS ccache steps, finished 0 hits out of 231 cacheable compilations, and spent about 31 minutes building. Cutting the write-only two thirds of the quota is what makes that outcome stop recurring.

This passes `save: ${{ github.event_name != 'pull_request' }}` to every ccache-action step: the `standalone_buffer`, `build`, `build_windows`, and `sanitizer` jobs in devbuild, the `lint` job, and `nouse_install`. The condition is not a no-op on the last two even though their `if:` normally excludes pull requests, because `MMGH_FORCE_SANITIZER` and `MMGH_FORCE_NOUSE_INSTALL` can put them on a pull-request event.

The profiling job already passes `save: false`, which is stricter, and is left alone: it reads the key the `build` job writes, so making it conditional would let nightly runs start writing into that namespace.

The vcpkg `actions/cache` step is also left alone. Its primary key is a constant, and `actions/cache` skips its post-run save on an exact key hit, so once master has written that entry every pull request restores it and writes nothing.

Verified on a pull request against a fork: the ccache step logged `save: false`, and the workflows parse and schedule unchanged.
