### PR TITLE
Make the pilot theme and terminal tests cheap

### DIFF
--- a/cpp/solvcon/pilot/theme/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/theme/RThemeManager.cpp
@@ -81,7 +81,7 @@ void RThemeManager::apply()
         m_window_color = native.color(QPalette::Window);
         QApplication::setPalette(native);
         // Leave the native look untouched, including any style the platform set.
-        qApp->setStyleSheet(QString());
+        setApplicationStyleSheet(QString());
     }
     else
     {
@@ -89,7 +89,7 @@ void RThemeManager::apply()
             buildPalette(themePaletteFor(m_backend->platform(), variant), variant);
         m_window_color = curated.color(QPalette::Window);
         QApplication::setPalette(curated);
-        qApp->setStyleSheet(supplementalStyleSheet(curated));
+        setApplicationStyleSheet(supplementalStyleSheet(curated));
     }
     if (m_window != nullptr)
     {
@@ -242,6 +242,19 @@ QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant var
     return pal;
 }
 
+void RThemeManager::setApplicationStyleSheet(QString const & sheet)
+{
+    // An application-wide stylesheet change unpolishes and repolishes every
+    // widget in the process, so pay for it only when the text really differs.
+    if (sheet == m_style_sheet)
+    {
+        return;
+    }
+
+    m_style_sheet = sheet;
+    qApp->setStyleSheet(sheet);
+}
+
 QString RThemeManager::supplementalStyleSheet(QPalette const & pal) const
 {
     // A QPalette cannot draw a tooltip border or a focus ring, so add just
@@ -265,11 +278,20 @@ void RThemeManager::restorePersisted()
         settings.value(QStringLiteral("theme/look")).toString().toUtf8().constData());
 }
 
-void RThemeManager::persist() const
+void RThemeManager::persist()
 {
+    // The store is only read when a session starts, so a write that repeats
+    // what was already written buys nothing and touches the disk.
+    if (m_persisted_mode == m_mode && m_persisted_look == m_look)
+    {
+        return;
+    }
+
     QSettings settings(QStringLiteral("solvcon"), QStringLiteral("pilot"));
     settings.setValue(QStringLiteral("theme/mode"), QString::fromStdString(modeId()));
     settings.setValue(QStringLiteral("theme/look"), QString::fromStdString(lookId()));
+    m_persisted_mode = m_mode;
+    m_persisted_look = m_look;
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/theme/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/theme/RThemeManager.hpp
@@ -16,6 +16,7 @@
 #include <solvcon/pilot/common/common_detail.hpp> // Must be the first include.
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <solvcon/pilot/theme/theme.hpp>
@@ -24,6 +25,7 @@
 #include <QColor>
 #include <QObject>
 #include <QPalette>
+#include <QString>
 
 class QWidget;
 
@@ -134,6 +136,13 @@ private:
     /// accent when the backend supplies one, and filling the disabled group.
     QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
 
+    /**
+     * Hand @p sheet to the application, skipping the call when it repeats the
+     * sheet already in force. The manager is the only writer of the
+     * application stylesheet, so the cached text cannot go stale.
+     */
+    void setApplicationStyleSheet(QString const & sheet);
+
     /// A thin stylesheet that adds what a QPalette cannot: a tooltip border and
     /// a focus ring on text inputs, colored from @p pal. Applied under the
     /// curated look and cleared under the system look, which stays native.
@@ -143,7 +152,7 @@ private:
     void restorePersisted();
 
     /// Write the current mode and look so the next session starts on them.
-    void persist() const;
+    void persist();
 
     ThemeMode m_mode = ThemeMode::System;
 
@@ -165,6 +174,16 @@ private:
     /// Guards the one-time style install, so repeated apply() calls do not
     /// rebuild the style object.
     bool m_style_installed = false;
+
+    /// The application stylesheet last handed out, empty under the system look.
+    QString m_style_sheet;
+
+    /**
+     * The mode and look last written to the store. Absent until the first
+     * write, so a session that never leaves the defaults still records them.
+     */
+    std::optional<ThemeMode> m_persisted_mode;
+    std::optional<ThemeLook> m_persisted_look;
 }; /* end class RThemeManager */
 
 } /* end namespace solvcon */

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -42,14 +42,19 @@ class TerminalWidgetTC(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.mgr = pilot.RManager.instance.setUp()
+        # Pin a known variant so the syntax and output colors are
+        # deterministic, and restore the shared default afterward. A theme
+        # switch repolishes every widget, so pay for it once for the class
+        # rather than twice per test.
+        cls.mgr.set_theme("light")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mgr.set_theme("system")
 
     def setUp(self):
         self.term = self.mgr.pyterm
         self.edit = self.term.textEdit
-        # Pin a known variant so the syntax and output colors are
-        # deterministic, and restore the shared default afterward.
-        self.mgr.set_theme("light")
-        self.addCleanup(self.mgr.set_theme, "system")
         # Start each test from a clean primary prompt, abandoning any block a
         # previous test left open in the shared interpreter.
         self.term.resetInput()
@@ -231,6 +236,9 @@ class TerminalWidgetTC(unittest.TestCase):
                          (expected.red(), expected.green(), expected.blue()))
 
     def test_output_colors_follow_a_dark_switch(self):
+        # The only test that leaves the class-wide pin, so it puts the light
+        # variant back for the tests that follow.
+        self.addCleanup(self.mgr.set_theme, "light")
         # Under the dark theme the captured stderr stays red-dominant but
         # takes a distinct, brighter value than the light table's, and stdout
         # takes the dark palette's text color.

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -278,14 +278,22 @@ class ThemeConsoleTC(unittest.TestCase):
         # keep the tests independent of the order they run in.
         self.mgr.set_theme("system")
 
+    def _console_dock(self):
+        for dock in self.mgr.mainWindow.findChildren(QtWidgets.QDockWidget):
+            if "Console" == dock.windowTitle():
+                return dock
+        self.fail("the console dock is not in the main window")
+
     def _console_edits(self):
         # The console's transcript and command editors are the QTextEdit
-        # instances in the pilot. Deliver the posted palette-change events and
-        # polish each so its palette resolves against the current application
-        # palette before it is read.
+        # instances under its dock. Deliver the posted palette-change events
+        # and polish each so its palette resolves against the current
+        # application palette before it is read. Polishing every text edit in
+        # the process instead would repolish widgets this test says nothing
+        # about, at the price of re-running their stylesheets.
         self.app.processEvents()
-        edits = [w for w in self.app.allWidgets()
-                 if isinstance(w, QtWidgets.QTextEdit)]
+        edits = self._console_dock().findChildren(QtWidgets.QTextEdit)
+        self.assertEqual(len(edits), 2)
         for edit in edits:
             edit.ensurePolished()
         return edits


### PR DESCRIPTION
Related to #1222.

A theme switch is expensive. `RThemeManager::setMode` writes QSettings, flips `QStyleHints::setColorScheme`, then `apply()` calls `QApplication::setPalette` plus `qApp->setStyleSheet(...)`, and an application-wide stylesheet change unpolishes and repolishes every widget in the process. The theme and terminal tests paid for that far more often than they needed to. This makes them cheap rather than skipping them, so local runs get faster too.

Three changes:

- `TerminalWidgetTC` pinned the light variant in `setUp` and restored it after every test, so each of the 21 tests paid two switches before doing any work. The pin moves to `setUpClass` and the restore to `tearDownClass`, taking 42 switches down to 2.
- `apply()` now caches the last stylesheet and calls `qApp->setStyleSheet` only when it changes, and `persist()` returns early when the mode and look already match what was written.
- `ThemeConsoleTC._console_edits` polished every QTextEdit in the process right after a full repolish. It now takes the two text edits under the console dock.

Measured on ubuntu-24.04, against a pull request that changes only workflow YAML so its test steps run the same suite on the same runners. Nothing is skipped on either side:

| step | before | after |
|---|---|---|
| `make pytest BUILD_QT=ON` | 115.04 s | 48.26 s |
| `make run_pilot_pytest` | 81.78 s | 39.50 s |

Two notes for review. The palette pass in `apply()` is deliberately left unguarded, because the canvas and console listeners hang off `themeChanged` and the palette is what the tests read. The persist cache is a `std::optional` that starts absent, so the first write always happens and a session that never leaves the defaults still records them.

Found while measuring, not caused by this change: `ThemePolishTC.test_mode_and_look_persist_across_sessions` is flaky on macOS at about the same rate on an unmodified tree. Filed as #1227.
