### PR TITLE
Manage the pilot sub-windows from the `Window` menu

### DIFF
--- a/solvcon/pilot/panel/_window_manager.py
+++ b/solvcon/pilot/panel/_window_manager.py
@@ -5,11 +5,11 @@
 """
 Window manager feature for pilot.
 
-List every open MDI sub-window under the "Window" menu and bring one to
-the foreground when its entry is chosen.
+Arrange the open MDI sub-windows from the "Window" menu, list them
+there, and bring one to the foreground when its entry is chosen.
 """
 
-from PySide6 import QtGui
+from PySide6 import QtGui, QtWidgets
 
 from ..base import _gui_common
 
@@ -19,39 +19,149 @@ __all__ = [
 
 
 class WindowManager(_gui_common.PilotFeature):
-    """List open MDI sub-windows under the "Window" menu.
+    """Arrange and list open MDI sub-windows under the "Window" menu.
 
-    One checkable action per open sub-window, labelled by its title.
-    Triggering an action activates that sub-window; the active one is
-    checked. The list is rebuilt each time the menu is about to show.
+    The menu carries three sections: the arrangement actions, the tabbed
+    view toggle, and one checkable action per open sub-window labelled by
+    its title. Triggering a sub-window entry activates it, and the active
+    one is checked. Every section is refreshed when the menu is about to
+    show.
     """
 
     #: objectName tagging every dynamic per-sub-window action.
     ITEM_ID = "window.subwindow"
+    #: objectName of the tile layout action.
+    TILE_ID = "window.layout.tile"
+    #: objectName of the cascade layout action.
+    CASCADE_ID = "window.layout.cascade"
+    #: objectName of the single-row tiling action.
+    HORIZONTAL_ID = "window.layout.horizontal"
+    #: objectName of the single-column tiling action.
+    VERTICAL_ID = "window.layout.vertical"
+    #: objectName of the tabbed view mode toggle.
+    TABBED_ID = "window.layout.tabbed"
 
     def __init__(self, *args, **kw):
         super(WindowManager, self).__init__(*args, **kw)
         self._menu = None
         self._items = []
+        self._layout_actions = []
 
     def populate_menu(self):
-        """Anchor the dynamic list on the "Window" menu.
+        """Build the static sections and anchor the dynamic list.
 
-        The menu holds nothing static (panel toggles live under
-        View/Panels), so the list is seeded right away: a native menu
-        bar hides an empty menu, and a hidden menu can never fire
+        Entries are placed by weight, leaving room for a later feature to
+        slot one in. The dynamic list is seeded right away: a native menu
+        bar hides an empty menu, and a hidden menu never fires
         aboutToShow to fill itself.
         """
         self._menu = self._mgr.menu_model.menu("Window")
+
+        self._layout_actions = [
+            self.add_action(
+                "Window", "Tile",
+                "Tile the open sub-windows to fill the area",
+                self._tile, id=self.TILE_ID, weight=10),
+            self.add_action(
+                "Window", "Tile Horizontally",
+                "Arrange the open sub-windows in a single row",
+                self._tile_horizontal, id=self.HORIZONTAL_ID, weight=11),
+            self.add_action(
+                "Window", "Tile Vertically",
+                "Arrange the open sub-windows in a single column",
+                self._tile_vertical, id=self.VERTICAL_ID, weight=12),
+            self.add_action(
+                "Window", "Cascade",
+                "Stack the open sub-windows with an offset",
+                self._cascade, id=self.CASCADE_ID, weight=13),
+        ]
+        self._mgr.menu_model.place_separator("Window", weight=20)
+
+        act = self.add_action(
+            "Window", "Tabbed View",
+            "Show the sub-windows as pages of a tab bar",
+            None, id=self.TABBED_ID, weight=30, checkable=True)
+        act.toggled.connect(self._set_tabbed)
+
+        self._mgr.menu_model.place_separator("Window", weight=40)
+
         self._menu.aboutToShow.connect(self._rebuild)
         self._rebuild()
 
-    def _rebuild(self):
-        """Refresh the sub-window list to match the MDI area.
+    def _tile(self):
+        self._mgr.mdiArea.tileSubWindows()
 
-        Drop the actions from the previous show, then append one checkable
+    def _cascade(self):
+        self._mgr.mdiArea.cascadeSubWindows()
+
+    def _set_tabbed(self, on):
+        """Switch the MDI area between sub-window and tabbed view.
+
+        Closable and movable tabs keep the window controls that the
+        sub-window frames provided.
+        """
+        mdi = self._mgr.mdiArea
+        if on:
+            mdi.setViewMode(QtWidgets.QMdiArea.ViewMode.TabbedView)
+            mdi.setTabsClosable(True)
+            mdi.setTabsMovable(True)
+        else:
+            mdi.setViewMode(QtWidgets.QMdiArea.ViewMode.SubWindowView)
+        self._update_layout_actions()
+
+    def _tile_horizontal(self):
+        self._arrange(horizontal=True)
+
+    def _tile_vertical(self):
+        self._arrange(horizontal=False)
+
+    def _update_layout_actions(self):
+        """Enable the arrangement actions only when they can act.
+
+        They need a sub-window to arrange and the sub-window view to
+        arrange it in; geometry means nothing while the area shows tabs.
+        """
+        mdi = self._mgr.mdiArea
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+        tabbed = mdi.viewMode() == QtWidgets.QMdiArea.ViewMode.TabbedView
+        for act in self._layout_actions:
+            act.setEnabled(bool(subwins) and not tabbed)
+
+    def _arrange(self, horizontal):
+        """Line the visible sub-windows up along one direction.
+
+        Each takes an equal share of the viewport: a row over the full
+        height when ``horizontal``, a column over the full width
+        otherwise. ``QMdiArea`` offers no directional counterpart to
+        ``tileSubWindows``, so the geometry is dealt out by hand. A
+        minimized or maximized sub-window is restored first, or its new
+        geometry would not take effect.
+        """
+        mdi = self._mgr.mdiArea
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+        if not subwins:
+            return
+
+        area = mdi.contentsRect()
+        width, height = area.width(), area.height()
+        if horizontal:
+            width //= len(subwins)
+        else:
+            height //= len(subwins)
+
+        for index, subwin in enumerate(subwins):
+            if subwin.isMinimized() or subwin.isMaximized():
+                subwin.showNormal()
+            x = area.x() + index * width if horizontal else area.x()
+            y = area.y() if horizontal else area.y() + index * height
+            subwin.setGeometry(x, y, width, height)
+
+    def _rebuild(self):
+        """Refresh the menu to match the MDI area.
+
+        Drop the entries from the previous show, then append one checkable
         action per visible sub-window in area order, checking the active
-        one. A disabled placeholder is shown when none are open.
+        one. A disabled placeholder stands in when none are open.
         """
         for act in self._items:
             self._menu.removeAction(act)
@@ -61,6 +171,8 @@ class WindowManager(_gui_common.PilotFeature):
         mdi = self._mgr.mdiArea
         active = mdi.activeSubWindow()
         subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+
+        self._update_layout_actions()
 
         if not subwins:
             self._append_placeholder()

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -133,6 +133,172 @@ class WindowMenuTC(unittest.TestCase):
         self.assertTrue(items[-1].text().endswith("Euler solver"))
 
 
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class WindowLayoutTC(unittest.TestCase):
+    """Drive the layout actions in the "Window" menu."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.area = self.mgr.mdiArea
+        self.mgr.show()
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def _show(self):
+        """Fire the real freshness hook that refreshes the menu."""
+        self.model.menu("Window").aboutToShow.emit()
+
+    def _layout_ids(self):
+        """Every arrangement action the menu is expected to carry.
+
+        Not a class attribute: ``WindowManager`` is unbound when the GUI
+        imports fail, and a class-body reference would then break
+        collection of this skipped module.
+        """
+        return (WindowManager.TILE_ID, WindowManager.CASCADE_ID,
+                WindowManager.HORIZONTAL_ID, WindowManager.VERTICAL_ID)
+
+    def test_layout_actions_precede_the_list(self):
+        # The arrangement actions sit above the first separator, ahead of
+        # the tabbed view toggle and the dynamic list.
+        acts = self.model.menu("Window").actions()
+        names = [a.objectName() for a in acts]
+        sep = [i for i, a in enumerate(acts) if a.isSeparator()]
+        self.assertEqual(len(sep), 2)
+        for aid in self._layout_ids():
+            self.assertLess(names.index(aid), sep[0])
+
+    def test_layout_actions_follow_open_windows(self):
+        self._show()
+        for aid in self._layout_ids():
+            self.assertFalse(self.model.action(aid).isEnabled())
+        self.mgr.add2DWidget()
+        self._show()
+        for aid in self._layout_ids():
+            self.assertTrue(self.model.action(aid).isEnabled())
+
+    def _two_stacked_windows(self):
+        """Open two sub-windows piled up, with the menu shown.
+
+        The MDI area spreads new sub-windows out on its own, so piling
+        them onto one rectangle leaves the arrangement as the only way
+        the geometries can separate. Showing the menu is what enables the
+        arrangement actions, exactly as a user reaches them; triggering a
+        disabled action would silently do nothing.
+        """
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        for subwin in self.area.subWindowList():
+            subwin.setGeometry(0, 0, 200, 150)
+        self._show()
+
+    def test_tile_separates_the_windows(self):
+        self._two_stacked_windows()
+        self.model.action(WindowManager.TILE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+
+    def test_cascade_offsets_the_windows(self):
+        self._two_stacked_windows()
+        self.model.action(WindowManager.CASCADE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertNotEqual(one.topLeft(), two.topLeft())
+
+    def test_horizontal_tiling_forms_a_single_row(self):
+        self._two_stacked_windows()
+        self.model.action(WindowManager.HORIZONTAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+        self.assertEqual(one.y(), two.y())
+        self.assertEqual(one.height(), two.height())
+        self.assertNotEqual(one.x(), two.x())
+
+    def test_vertical_tiling_forms_a_single_column(self):
+        self._two_stacked_windows()
+        self.model.action(WindowManager.VERTICAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+        self.assertEqual(one.x(), two.x())
+        self.assertEqual(one.width(), two.width())
+        self.assertNotEqual(one.y(), two.y())
+
+    def test_directional_tiling_restores_a_minimized_window(self):
+        self._two_stacked_windows()
+        minimized = self.area.subWindowList()[0]
+        minimized.showMinimized()
+        self.model.action(WindowManager.HORIZONTAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        self.assertFalse(minimized.isMinimized())
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class TabbedViewTC(unittest.TestCase):
+    """Drive the "Tabbed View" toggle in the "Window" menu."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.area = self.mgr.mdiArea
+        self.mgr.show()
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+        # The MDI area outlives each case; put the view mode back so a
+        # leftover tab bar cannot leak into the next case.
+        self.addCleanup(self.model.action(WindowManager.TABBED_ID)
+                        .setChecked, False)
+
+    def tearDown(self):
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def _show(self):
+        """Fire the real freshness hook that refreshes the menu."""
+        self.model.menu("Window").aboutToShow.emit()
+
+    def test_toggle_switches_the_view_mode(self):
+        act = self.model.action(WindowManager.TABBED_ID)
+        Mode = QtWidgets.QMdiArea.ViewMode
+        self.assertEqual(self.area.viewMode(), Mode.SubWindowView)
+        act.setChecked(True)
+        self.assertEqual(self.area.viewMode(), Mode.TabbedView)
+        act.setChecked(False)
+        self.assertEqual(self.area.viewMode(), Mode.SubWindowView)
+
+    def test_tabs_are_closable_and_movable(self):
+        # Without these, a window opened in the tabbed view could never
+        # be closed or reordered from the tab bar.
+        self.model.action(WindowManager.TABBED_ID).setChecked(True)
+        self.assertTrue(self.area.tabsClosable())
+        self.assertTrue(self.area.tabsMovable())
+
+    def test_tabbed_view_disables_the_layout_actions(self):
+        self.mgr.add2DWidget()
+        act = self.model.action(WindowManager.TABBED_ID)
+        self._show()
+        self.assertTrue(self.model.action(WindowManager.TILE_ID)
+                        .isEnabled())
+        act.setChecked(True)
+        self.assertFalse(self.model.action(WindowManager.TILE_ID)
+                         .isEnabled())
+        self.assertTrue(act.isEnabled())
+        act.setChecked(False)
+        self.assertTrue(self.model.action(WindowManager.TILE_ID)
+                        .isEnabled())
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
The `Window` menu listed the open MDI sub-windows and activated one on selection, but offered no way to arrange them. Several open viewers overlapped each other, and dragging every frame by hand was the only remedy.

The menu now opens with an arrangement section: `Tile` and `Cascade` drive the `QMdiArea` layouts, while `Tile Horizontally` and `Tile Vertically` line the sub-windows up in a single row or column. Qt offers no directional counterpart to `tileSubWindows`, so those two deal equal shares of the viewport out by hand and restore a minimized or maximized frame first. A `Tabbed View` toggle switches the area to closable, movable tabs, which suits hopping between full-size viewers; the arrangement actions are disabled there because geometry means nothing once the area shows tabs.

For issue #357.

The snapshot is for the tabbed view:

<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/0734fbf4-b872-429b-b9c3-580050143ba4" />
