### PR TITLE
Require backticks around code tokens in commit logs

### DIFF
--- a/.claude/skills/commit-code/SKILL.md
+++ b/.claude/skills/commit-code/SKILL.md
@@ -49,6 +49,9 @@ These contradict common defaults, so apply them deliberately:
   with ..." trailers; this project keeps commits human-authored (see
   `create-pr`).
 - **No semantic prefixes.** Never use `feat:`, `fix:`, `docs:`, etc.
+- **Backtick every code token.** Paths, `make` and CMake targets,
+  identifiers, macros, variables, flags, commands, and literal values
+  are quoted in the subject as well as the body.
 - **No closing keywords.** Never use `close`/`fixes`/`resolves #n`. Do
   not reference an issue unless explicitly instructed; when you are, end
   the body with "Related to #xxx" or "For issue #xxx".

--- a/STYLE.md
+++ b/STYLE.md
@@ -890,6 +890,16 @@ Structure a message as a subject line, a blank line, and an optional body:
 - Separate the subject from the body with one blank line; many git tools rely
   on this split.
 - Wrap the body at 72 characters. Git does not wrap it for you.
+- Backtick-quote every token that is code rather than prose, in the subject as
+  well as the body: paths, `make` and CMake targets, identifiers, macros,
+  variables, flags, commands, and literal values. Write "Drop
+  `USE_GOOGLETEST` from the `ctest` wiring", never the same sentence
+  unquoted. A bare identifier reads as an ordinary word and hides where the
+  name starts and ends; the quoted form also renders monospaced on a forge
+  that formats Markdown. Ordinary nouns stay unquoted: the solver, the pilot,
+  and the mesh are prose. A subject has little room, so prefer wording that
+  needs no identifier, and name one only when the plain phrasing would be
+  vague.
 
 Use the body to explain what changed and why, not how -- the diff already
 shows how. Make it self-contained: a reader should judge the change without


### PR DESCRIPTION
The "Commit Log" section of `STYLE.md` prescribes the subject mood, the 72-column wrap, and the issue-reference form, but never says how to set a code token apart from prose. The convention lives only in the history: the last 80 commits carry 61 backticked spans, and subjects such as "Explain why `RField` does not reuse the `TrianglePad` container" quote the identifiers they name. A rule a writer has to reconstruct from past commits is a rule that gets dropped.

State it in `STYLE.md`, naming both what to quote and what to leave alone, since backticking an ordinary noun is its own kind of noise. The `commit-code` skill repeats it: that skill defers to `STYLE.md` for the message format and restates only the conventions that contradict default git habits, which is where a frequently missed rule belongs.