### PR TITLE
Add the plot color vocabulary and the xy plot series

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -40,6 +40,9 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/R2DWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/DrawTool.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/RWorldRenderer2d.hpp
+    # plot/
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/plot_style.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotSeries.hpp
     # app/
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RMenuModel.hpp
@@ -88,6 +91,10 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/R2DWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/DrawTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/RWorldRenderer2d.cpp
+    # plot/
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/plot_style.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotSeries.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/wrap_plot.cpp
     # app/
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RMenuModel.cpp

--- a/cpp/solvcon/pilot/plot/RPlotSeries.cpp
+++ b/cpp/solvcon/pilot/plot/RPlotSeries.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/plot/RPlotSeries.hpp>
+
+#include <cmath>
+#include <format>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace
+{
+
+void validate_operand(SimpleArray<double> const & arr, char const * name)
+{
+    if (arr.ndim() != 1)
+    {
+        throw std::invalid_argument(
+            std::format("RPlotSeries::set_data: {} must be 1-dimensional, but ndim is {}", name, arr.ndim()));
+    }
+    if (arr.nbody() > 1 && arr.stride(0) != 1)
+    {
+        throw std::invalid_argument(
+            std::format(
+                "RPlotSeries::set_data: {} must be contiguous with unit stride, but stride is {}",
+                name,
+                arr.stride(0)));
+    }
+    // The collector clones the whole buffer, so the ghost part would become
+    // samples that the nbody-based length check never saw.
+    if (arr.nghost() != 0)
+    {
+        throw std::invalid_argument(
+            std::format("RPlotSeries::set_data: {} must be ghost-free, but nghost is {}", name, arr.nghost()));
+    }
+}
+
+} /* end namespace */
+
+void RPlotSeries::set_data(SimpleArray<double> const & x, SimpleArray<double> const & y)
+{
+    validate_operand(x, "x");
+    validate_operand(y, "y");
+    if (x.nbody() != y.nbody())
+    {
+        throw std::invalid_argument(
+            std::format(
+                "RPlotSeries::set_data: x and y must have the same length, but they are {} and {}",
+                x.nbody(),
+                y.nbody()));
+    }
+
+    m_x = SimpleCollector<double>(x);
+    m_y = SimpleCollector<double>(y);
+    m_limits_stale = true;
+}
+
+void RPlotSeries::clear_data()
+{
+    m_x = SimpleCollector<double>();
+    m_y = SimpleCollector<double>();
+    m_limits_stale = true;
+}
+
+double RPlotSeries::x_at(std::size_t it) const
+{
+    if (it >= size())
+    {
+        throw std::out_of_range(
+            std::format("RPlotSeries::x_at: index {} is out of bounds with size {}", it, size()));
+    }
+    return x()[it];
+}
+
+double RPlotSeries::y_at(std::size_t it) const
+{
+    if (it >= size())
+    {
+        throw std::out_of_range(
+            std::format("RPlotSeries::y_at: index {} is out of bounds with size {}", it, size()));
+    }
+    return y()[it];
+}
+
+std::optional<std::array<double, 4>> RPlotSeries::data_limits() const
+{
+    if (!m_limits_stale)
+    {
+        return m_limits;
+    }
+
+    std::optional<std::array<double, 4>> limits;
+    std::span<double const> const xs = x();
+    std::span<double const> const ys = y();
+    for (std::size_t it = 0; it < xs.size(); ++it)
+    {
+        double const xv = xs[it];
+        double const yv = ys[it];
+        // Skip the whole sample, not just the offending coordinate: a point
+        // with a NaN y is not at a known x either.
+        if (!std::isfinite(xv) || !std::isfinite(yv))
+        {
+            continue;
+        }
+        if (!limits.has_value())
+        {
+            limits = std::array<double, 4>{xv, xv, yv, yv};
+            continue;
+        }
+        std::array<double, 4> & lim = *limits;
+        if (xv < lim[0])
+        {
+            lim[0] = xv;
+        }
+        if (xv > lim[1])
+        {
+            lim[1] = xv;
+        }
+        if (yv < lim[2])
+        {
+            lim[2] = yv;
+        }
+        if (yv > lim[3])
+        {
+            lim[3] = yv;
+        }
+    }
+
+    m_limits = limits;
+    m_limits_stale = false;
+    return m_limits;
+}
+
+void RPlotSeries::set_line_width(double width)
+{
+    if (!std::isfinite(width) || !(width > 0.0))
+    {
+        throw std::invalid_argument(
+            std::format("RPlotSeries::set_line_width: width must be finite and positive, but it is {}", width));
+    }
+    m_line_width = width;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/RPlotSeries.hpp
+++ b/cpp/solvcon/pilot/plot/RPlotSeries.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * One xy data series of the native plot: the samples, the stroke style, and the
+ * raw data limits. Qt-free, so it compiles into the no-GUI test target.
+ *
+ * @ingroup group_domain
+ */
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+
+#include <solvcon/buffer/SimpleArray.hpp>
+#include <solvcon/buffer/SimpleCollector.hpp>
+
+#include <solvcon/pilot/plot/plot_style.hpp>
+
+namespace solvcon
+{
+
+class RPlotSeries
+{
+public:
+
+    RPlotSeries() = default;
+    RPlotSeries(RPlotSeries const &) = default;
+    RPlotSeries(RPlotSeries &&) = default;
+    RPlotSeries & operator=(RPlotSeries const &) = default;
+    RPlotSeries & operator=(RPlotSeries &&) = default;
+    ~RPlotSeries() = default;
+
+    void set_data(SimpleArray<double> const & x, SimpleArray<double> const & y);
+
+    void clear_data();
+
+    std::size_t size() const { return m_x.size(); }
+
+    std::span<double const> x() const { return std::span<double const>(m_x.data(), size()); }
+    std::span<double const> y() const { return std::span<double const>(m_y.data(), size()); }
+
+    double x_at(std::size_t it) const;
+
+    double y_at(std::size_t it) const;
+
+    std::optional<std::array<double, 4>> data_limits() const;
+
+    std::string const & label() const { return m_label; }
+    void set_label(std::string label) { m_label = std::move(label); }
+
+    PlotColor color() const { return m_color; }
+
+    void set_color(PlotColor color)
+    {
+        m_color = color;
+        m_color_is_set = true;
+    }
+
+    bool color_is_set() const { return m_color_is_set; }
+
+    double line_width() const { return m_line_width; }
+
+    void set_line_width(double width);
+
+private:
+
+    SimpleCollector<double> m_x;
+    SimpleCollector<double> m_y;
+    std::string m_label;
+    PlotColor m_color;
+    bool m_color_is_set = false;
+    double m_line_width = PLOT_DEFAULT_LINE_WIDTH;
+
+    mutable bool m_limits_stale = true;
+    mutable std::optional<std::array<double, 4>> m_limits;
+}; /* end class RPlotSeries */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/plot_style.cpp
+++ b/cpp/solvcon/pilot/plot/plot_style.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/plot/plot_style.hpp>
+
+#include <array>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// The matplotlib "tab10" cycle, reused verbatim so a pilot plot reads like the
+// matplotlib one (https://matplotlib.org/stable/users/explain/colors/colors.html).
+constexpr std::array<PlotColor, 10> PLOT_COLOR_TABLE = {
+    PlotColor(31, 119, 180), // C0 #1f77b4
+    PlotColor(255, 127, 14), // C1 #ff7f0e
+    PlotColor(44, 160, 44), // C2 #2ca02c
+    PlotColor(214, 39, 40), // C3 #d62728
+    PlotColor(148, 103, 189), // C4 #9467bd
+    PlotColor(140, 86, 75), // C5 #8c564b
+    PlotColor(227, 119, 194), // C6 #e377c2
+    PlotColor(127, 127, 127), // C7 #7f7f7f
+    PlotColor(188, 189, 34), // C8 #bcbd22
+    PlotColor(23, 190, 207), // C9 #17becf
+};
+
+} /* end namespace */
+
+std::span<PlotColor const> plot_color_cycle()
+{
+    return std::span<PlotColor const>(PLOT_COLOR_TABLE.data(), PLOT_COLOR_TABLE.size());
+}
+
+PlotColor plot_cycle_color(std::size_t index)
+{
+    return PLOT_COLOR_TABLE[index % PLOT_COLOR_TABLE.size()];
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/plot_style.hpp
+++ b/cpp/solvcon/pilot/plot/plot_style.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt-free plot styling vocabulary: the color a curve is stroked with, the
+ * default stroke width, and the matplotlib C0-C9 categorical cycle to draw
+ * from when no explicit color is given.
+ *
+ * Nothing here may mention Qt. Converting a PlotColor to a QColor belongs in
+ * the Qt front end, at that boundary and nowhere else.
+ *
+ * @ingroup group_domain
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace solvcon
+{
+
+/// One sRGB color with alpha, a byte per channel.
+struct PlotColor
+{
+    std::uint8_t r = 0;
+    std::uint8_t g = 0;
+    std::uint8_t b = 0;
+    std::uint8_t a = 255;
+
+    constexpr PlotColor() = default;
+
+    constexpr PlotColor(std::uint8_t red, std::uint8_t green, std::uint8_t blue, std::uint8_t alpha = 255)
+        : r(red)
+        , g(green)
+        , b(blue)
+        , a(alpha)
+    {
+    }
+
+    constexpr bool operator==(PlotColor const &) const = default;
+}; /* end struct PlotColor */
+
+/// Default stroke width in screen pixels; matplotlib's lines.linewidth.
+inline constexpr double PLOT_DEFAULT_LINE_WIDTH = 1.5;
+
+/**
+ * The matplotlib C0-C9 categorical cycle, in order. Exactly ten entries over
+ * storage of static lifetime, so the span outlives any caller.
+ */
+std::span<PlotColor const> plot_color_cycle();
+
+/// The cycle entry for @p index, wrapping with index % plot_color_cycle().size().
+PlotColor plot_cycle_color(std::size_t index);
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/wrap_plot.cpp
+++ b/cpp/solvcon/pilot/plot/wrap_plot.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <pybind11/stl.h> // Must be the first include.
+
+#include <solvcon/pilot/wrap_pilot.hpp> // Must be the first include but give way to above.
+#include <solvcon/python/common.hpp>
+
+#include <pybind11/operators.h>
+
+#include <solvcon/buffer/pymod/SimpleArrayCaster.hpp>
+
+#include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/RPlotSeries.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+namespace
+{
+
+/// A 4-tuple, not the list that an auto-cast std::array<double, 4> would give.
+pybind11::object limits_to_python(std::optional<std::array<double, 4>> const & limits)
+{
+    if (!limits.has_value())
+    {
+        return pybind11::none();
+    }
+    std::array<double, 4> const & lim = *limits;
+    return pybind11::make_tuple(lim[0], lim[1], lim[2], lim[3]);
+}
+
+/**
+ * Reject a negative index with IndexError. A std::size_t parameter would raise
+ * TypeError instead, and the unsigned wrap-around would turn -1 into a huge
+ * in-range-looking index.
+ */
+std::size_t checked_index(std::int64_t index, std::size_t count, char const * what, char const * noun)
+{
+    if (index < 0 || static_cast<std::size_t>(index) >= count)
+    {
+        throw std::out_of_range(std::format("{}: index {} is out of bounds with {} {}", what, index, noun, count));
+    }
+    return static_cast<std::size_t>(index);
+}
+
+} /* end namespace */
+
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapPlotColor
+    : public WrapBase<WrapPlotColor, PlotColor>
+{
+
+    friend root_base_type;
+
+    WrapPlotColor(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(py::init<>())
+            .def(
+                py::init<std::uint8_t, std::uint8_t, std::uint8_t, std::uint8_t>(),
+                py::arg("r"),
+                py::arg("g"),
+                py::arg("b"),
+                py::arg("a") = 255)
+            //
+            ;
+
+        // Read-only, not writable: every function yielding a PlotColor yields
+        // a copy, so `plot_cycle_color(0).a = 128` would recolor nothing.
+        (*this)
+            .def_readonly("r", &wrapped_type::r)
+            .def_readonly("g", &wrapped_type::g)
+            .def_readonly("b", &wrapped_type::b)
+            .def_readonly("a", &wrapped_type::a)
+            .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+            .def(py::self != py::self) // NOLINT(misc-redundant-expression)
+            .def(
+                "__hash__",
+                [](wrapped_type const & self)
+                {
+                    return static_cast<py::ssize_t>(
+                        (static_cast<std::uint32_t>(self.a) << 24U) | (static_cast<std::uint32_t>(self.b) << 16U) |
+                        (static_cast<std::uint32_t>(self.g) << 8U) | static_cast<std::uint32_t>(self.r));
+                })
+            .def(
+                "__repr__",
+                [](wrapped_type const & self)
+                {
+                    return std::format(
+                        "PlotColor(r={}, g={}, b={}, a={})",
+                        static_cast<int>(self.r),
+                        static_cast<int>(self.g),
+                        static_cast<int>(self.b),
+                        static_cast<int>(self.a));
+                })
+            //
+            ;
+    }
+
+}; /* end class WrapPlotColor */
+
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotSeries
+    : public WrapBase<WrapRPlotSeries, RPlotSeries, std::shared_ptr<RPlotSeries>>
+{
+
+    friend root_base_type;
+
+    WrapRPlotSeries(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(py::init<>())
+            //
+            ;
+
+        (*this)
+            .def("set_data", &wrapped_type::set_data, py::arg("x"), py::arg("y"))
+            .def("clear_data", &wrapped_type::clear_data)
+            .def_property_readonly("size", &wrapped_type::size)
+            .def("__len__", &wrapped_type::size)
+            .def(
+                "x_at",
+                [](wrapped_type const & self, std::int64_t index)
+                { return self.x_at(checked_index(index, self.size(), "RPlotSeries::x_at", "size")); },
+                py::arg("index"))
+            .def(
+                "y_at",
+                [](wrapped_type const & self, std::int64_t index)
+                { return self.y_at(checked_index(index, self.size(), "RPlotSeries::y_at", "size")); },
+                py::arg("index"))
+            .def(
+                "data_limits",
+                [](wrapped_type const & self)
+                { return limits_to_python(self.data_limits()); })
+            .def_property("label", &wrapped_type::label, &wrapped_type::set_label)
+            // A copy, not a reference into the series: `series.color.a = 128`
+            // must fail rather than write to a temporary.
+            .def_property("color", &wrapped_type::color, &wrapped_type::set_color, py::return_value_policy::copy)
+            .def_property_readonly("color_is_set", &wrapped_type::color_is_set)
+            .def_property("line_width", &wrapped_type::line_width, &wrapped_type::set_line_width)
+            //
+            ;
+    }
+
+}; /* end class WrapRPlotSeries */
+
+void wrap_plot(pybind11::module & mod)
+{
+    namespace py = pybind11;
+
+    WrapPlotColor::commit(
+        mod,
+        "PlotColor",
+        "One sRGB color with alpha, a byte per channel. An immutable value: "
+        "the channels are read-only, so rebuild the color to change one.");
+    WrapRPlotSeries::commit(
+        mod,
+        "RPlotSeries",
+        "One xy data series: a copy of a contiguous SimpleArrayFloat64 pair "
+        "plus the style used to stroke it. Samples are read through "
+        "size / x_at / y_at.");
+
+    mod.def(
+        "plot_color_cycle",
+        []()
+        {
+            std::span<PlotColor const> const cycle = plot_color_cycle();
+            return std::vector<PlotColor>(cycle.begin(), cycle.end());
+        });
+    mod.def("plot_cycle_color", &plot_cycle_color, py::arg("index"));
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/wrap_plot.cpp
+++ b/cpp/solvcon/pilot/plot/wrap_plot.cpp
@@ -139,12 +139,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotSeries
             .def_property_readonly("size", &wrapped_type::size)
             .def("__len__", &wrapped_type::size)
             .def(
-                "x_at",
+                "x",
                 [](wrapped_type const & self, std::int64_t index)
                 { return self.x_at(checked_index(index, self.size(), "RPlotSeries::x_at", "size")); },
                 py::arg("index"))
             .def(
-                "y_at",
+                "y",
                 [](wrapped_type const & self, std::int64_t index)
                 { return self.y_at(checked_index(index, self.size(), "RPlotSeries::y_at", "size")); },
                 py::arg("index"))
@@ -178,7 +178,7 @@ void wrap_plot(pybind11::module & mod)
         "RPlotSeries",
         "One xy data series: a copy of a contiguous SimpleArrayFloat64 pair "
         "plus the style used to stroke it. Samples are read through "
-        "size / x_at / y_at.");
+        "size / x / y.");
 
     mod.def(
         "plot_color_cycle",

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1287,6 +1287,8 @@ void wrap_pilot(pybind11::module & mod)
     WrapRManager::commit(mod, "RManager", "RManager");
     WrapRManagerProxy::commit(mod, "RManagerProxy", "RManagerProxy");
 
+    wrap_plot(mod);
+
     // The C++ tool registry is the single source of truth for drawing tools.
     mod.def("draw_tool_names", &draw_tool_names);
     mod.def("default_draw_tool_name", &default_draw_tool_name);

--- a/cpp/solvcon/pilot/wrap_pilot.hpp
+++ b/cpp/solvcon/pilot/wrap_pilot.hpp
@@ -15,6 +15,7 @@ namespace python
 
 void initialize_pilot(pybind11::module & mod);
 void wrap_pilot(pybind11::module & mod);
+void wrap_plot(pybind11::module & mod);
 
 } /* end namespace python */
 

--- a/solvcon/pilot/__init__.py
+++ b/solvcon/pilot/__init__.py
@@ -19,6 +19,10 @@ from ._pilot_core import (  # noqa: F401
     RPythonConsoleDockWidget,
     RPythonTerminalDockWidget,
     RManager,
+    PlotColor,
+    RPlotSeries,
+    plot_color_cycle,
+    plot_cycle_color,
 )
 if enable:
     from .base._gui import (  # noqa: F401

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -53,6 +53,18 @@ list_of_drawtool = [
     'default_draw_tool_name',
 ]
 
+# plot_style.hpp/.cpp
+list_of_plot_style = [
+    'PlotColor',
+    'plot_color_cycle',
+    'plot_cycle_color',
+]
+
+# RPlotSeries.hpp/.cpp
+list_of_rplotseries = [
+    'RPlotSeries',
+]
+
 
 _from_impl = (  # noqa: F822
     list_of_rdomainwidget +
@@ -60,7 +72,9 @@ _from_impl = (  # noqa: F822
     list_of_rmanager +
     list_of_rpythonconsole +
     list_of_rpythonterminal +
-    list_of_drawtool
+    list_of_drawtool +
+    list_of_plot_style +
+    list_of_rplotseries
 )
 
 __all__ = _from_impl + [  # noqa: F822
@@ -83,6 +97,8 @@ _load(list_of_rmanager)
 _load(list_of_rpythonconsole)
 _load(list_of_rpythonterminal)
 _load(list_of_drawtool)
+_load(list_of_plot_style)
+_load(list_of_rplotseries)
 
 del _load
 

--- a/tests/test_pilot_plot.py
+++ b/tests/test_pilot_plot.py
@@ -62,8 +62,8 @@ class PilotPlotTC(unittest.TestCase):
         self.assertEqual(4, ser.size)
         self.assertEqual(4, len(ser))
         for index in range(4):
-            self.assertEqual(float(index), ser.x_at(index))
-            self.assertEqual(10.0 + index, ser.y_at(index))
+            self.assertEqual(float(index), ser.x(index))
+            self.assertEqual(10.0 + index, ser.y(index))
 
     def test_set_data_copies_the_operand_buffer(self):
         samples = np.arange(4, dtype='float64')
@@ -72,7 +72,7 @@ class PilotPlotTC(unittest.TestCase):
                      solvcon.SimpleArrayFloat64(array=samples))
         limits = ser.data_limits()
         samples[0] = -100.0
-        self.assertEqual(0.0, ser.x_at(0))
+        self.assertEqual(0.0, ser.x(0))
         self.assertEqual(limits, ser.data_limits())
 
     def test_clear_data_empties_and_invalidates(self):
@@ -84,7 +84,7 @@ class PilotPlotTC(unittest.TestCase):
 
     def test_index_out_of_range_raises_index_error(self):
         ser = _series([0.0, 1.0, 2.0], [3.0, 4.0, 5.0])
-        for name in ('x_at', 'y_at'):
+        for name in ('x', 'y'):
             for index in (3, -1):
                 with self.subTest(accessor=name, index=index):
                     message = ('index %d is out of bounds with size 3'
@@ -132,7 +132,7 @@ class PilotPlotTC(unittest.TestCase):
         ser = pilot.RPlotSeries()
         ser.set_data(one, one)
         self.assertEqual(1, ser.size)
-        self.assertEqual(0.0, ser.x_at(0))
+        self.assertEqual(0.0, ser.x(0))
 
     def test_rejected_set_data_leaves_the_series_untouched(self):
         ser = _series([0.0, 1.0, 2.0], [3.0, 4.0, 5.0])

--- a/tests/test_pilot_plot.py
+++ b/tests/test_pilot_plot.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the native xy-plot core: PlotColor, the matplotlib C0-C9 cycle,
+and RPlotSeries.
+
+The core is pure C++ with no Qt widget, so everything here is exercised
+through the pybind11 surface registered into ``solvcon.pilot``.
+"""
+
+import re
+import unittest
+
+import numpy as np
+
+import solvcon
+
+try:
+    from solvcon import pilot
+except ImportError:
+    pilot = None
+
+
+def _array(values):
+    """Wrap a copy of a sequence of numbers as a float64 SimpleArray."""
+    return solvcon.SimpleArrayFloat64(array=np.array(values, dtype='float64'))
+
+
+def _series(x_values, y_values):
+    """Build an RPlotSeries holding the given samples."""
+    ser = pilot.RPlotSeries()
+    ser.set_data(_array(x_values), _array(y_values))
+    return ser
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PilotPlotTC(unittest.TestCase):
+    """The native plot vocabulary: the color cycle and the xy series."""
+
+    def test_cycle_is_matplotlib_c0_to_c9(self):
+        cycle = pilot.plot_color_cycle()
+        self.assertEqual(10, len(cycle))
+        self.assertEqual((31, 119, 180, 255),
+                         (cycle[0].r, cycle[0].g, cycle[0].b, cycle[0].a))
+        self.assertEqual(cycle[0], pilot.plot_cycle_color(10))
+        self.assertEqual(cycle[3], pilot.plot_cycle_color(23))
+
+    def test_color_is_an_immutable_value(self):
+        color = pilot.PlotColor(1, 2, 3)
+        with self.assertRaises(AttributeError):
+            color.a = 9
+        self.assertEqual(pilot.PlotColor(1, 2, 3, 255), color)
+        self.assertNotEqual(pilot.PlotColor(1, 2, 3, 128), color)
+        self.assertFalse(color == None)  # noqa: E711
+        self.assertTrue(color != None)  # noqa: E711
+        self.assertNotIn(color, [1, 'a'])
+        self.assertEqual('custom', {color: 'custom'}[pilot.PlotColor(1, 2, 3)])
+
+    def test_set_data_stores_the_samples(self):
+        ser = _series([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
+        self.assertEqual(4, ser.size)
+        self.assertEqual(4, len(ser))
+        for index in range(4):
+            self.assertEqual(float(index), ser.x_at(index))
+            self.assertEqual(10.0 + index, ser.y_at(index))
+
+    def test_set_data_copies_the_operand_buffer(self):
+        samples = np.arange(4, dtype='float64')
+        ser = pilot.RPlotSeries()
+        ser.set_data(solvcon.SimpleArrayFloat64(array=samples),
+                     solvcon.SimpleArrayFloat64(array=samples))
+        limits = ser.data_limits()
+        samples[0] = -100.0
+        self.assertEqual(0.0, ser.x_at(0))
+        self.assertEqual(limits, ser.data_limits())
+
+    def test_clear_data_empties_and_invalidates(self):
+        ser = _series([0.0, 1.0], [2.0, 3.0])
+        self.assertIsNotNone(ser.data_limits())
+        ser.clear_data()
+        self.assertEqual(0, ser.size)
+        self.assertIsNone(ser.data_limits())
+
+    def test_index_out_of_range_raises_index_error(self):
+        ser = _series([0.0, 1.0, 2.0], [3.0, 4.0, 5.0])
+        for name in ('x_at', 'y_at'):
+            for index in (3, -1):
+                with self.subTest(accessor=name, index=index):
+                    message = ('index %d is out of bounds with size 3'
+                               % index)
+                    with self.assertRaisesRegex(IndexError,
+                                                re.escape(message)):
+                        getattr(ser, name)(index)
+
+    def test_set_data_rejects_what_it_cannot_draw(self):
+        ser = pilot.RPlotSeries()
+        long_x = _array(np.arange(10, dtype='float64'))
+        short_y = _array(np.arange(9, dtype='float64'))
+        square = _array(np.zeros((2, 3), dtype='float64'))
+        # Wrap the strided view itself: SimpleArrayFloat64 keeps the NumPy
+        # stride, which is the input that must not reach the accessors.
+        strided = solvcon.SimpleArrayFloat64(
+            array=np.arange(10, dtype='float64')[::2])
+        # A collector clones the whole buffer, so the ghost part would become
+        # samples that the nbody-based length check never saw.
+        ghosted = _array(np.arange(10, dtype='float64'))
+        ghosted.nghost = 3
+        cases = [
+            ('length', long_x, short_y,
+             'x and y must have the same length, but they are 10 and 9'),
+            ('ndim', square, square, 'must be 1-dimensional, but ndim is 2'),
+            ('stride', strided, strided,
+             'must be contiguous with unit stride, but stride is 2'),
+            ('ghost', ghosted, ghosted,
+             'must be ghost-free, but nghost is 3'),
+        ]
+        for reason, x_arr, y_arr, message in cases:
+            with self.subTest(reason=reason):
+                with self.assertRaisesRegex(ValueError, re.escape(message)):
+                    ser.set_data(x_arr, y_arr)
+
+    def test_stride_is_checked_only_where_a_step_exists(self):
+        for values in ([], np.zeros(0, dtype='float64'),
+                       np.arange(10, dtype='float64')[5:5]):
+            ser = _series(values, values)
+            self.assertEqual(0, ser.size)
+            self.assertIsNone(ser.data_limits())
+
+        one = solvcon.SimpleArrayFloat64(
+            array=np.arange(4, dtype='float64')[::2][:1])
+        ser = pilot.RPlotSeries()
+        ser.set_data(one, one)
+        self.assertEqual(1, ser.size)
+        self.assertEqual(0.0, ser.x_at(0))
+
+    def test_rejected_set_data_leaves_the_series_untouched(self):
+        ser = _series([0.0, 1.0, 2.0], [3.0, 4.0, 5.0])
+        size = ser.size
+        limits = ser.data_limits()
+        with self.assertRaises(ValueError):
+            ser.set_data(_array(np.arange(10, dtype='float64')),
+                         _array(np.arange(9, dtype='float64')))
+        self.assertEqual(size, ser.size)
+        self.assertEqual(limits, ser.data_limits())
+
+    def test_data_limits_are_the_raw_extent(self):
+        ser = _series([3.0, -1.0, 2.0], [7.0, 9.0, -4.0])
+        self.assertEqual((-1.0, 3.0, -4.0, 9.0), ser.data_limits())
+        self.assertEqual((5.0, 5.0, 7.0, 7.0),
+                         _series([5.0], [7.0]).data_limits())
+
+    def test_non_finite_sample_is_dropped_whole(self):
+        for bad in (float('nan'), float('inf'), float('-inf')):
+            with self.subTest(bad=bad):
+                ser = _series([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, bad])
+                self.assertEqual((0.0, 2.0, 10.0, 12.0), ser.data_limits())
+                ser = _series([bad, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
+                self.assertEqual((1.0, 3.0, 11.0, 13.0), ser.data_limits())
+                self.assertIsNone(_series([bad] * 4, [bad] * 4).data_limits())
+
+    def test_limits_cache_is_stable_and_invalidates(self):
+        ser = _series([0.0, 1.0], [2.0, 3.0])
+        first = ser.data_limits()
+        self.assertEqual((0.0, 1.0, 2.0, 3.0), first)
+        self.assertEqual(first, ser.data_limits())
+        ser.set_data(_array([0.0, 4.0]), _array([2.0, 8.0]))
+        self.assertEqual((0.0, 4.0, 2.0, 8.0), ser.data_limits())
+
+    def test_style_changes_do_not_disturb_the_limits(self):
+        ser = _series([0.0, 1.0], [2.0, 3.0])
+        limits = ser.data_limits()
+        self.assertFalse(ser.color_is_set)
+        self.assertEqual('', ser.label)
+        ser.label = 'pressure'
+        ser.color = pilot.PlotColor(1, 2, 3, 4)
+        ser.line_width = 2.5
+        self.assertEqual('pressure', ser.label)
+        self.assertEqual(pilot.PlotColor(1, 2, 3, 4), ser.color)
+        self.assertEqual(2.5, ser.line_width)
+        self.assertTrue(ser.color_is_set)
+        self.assertEqual(limits, ser.data_limits())
+
+    def test_bad_line_width_is_rejected(self):
+        ser = pilot.RPlotSeries()
+        for width in (0.0, -1.0, float('nan')):
+            with self.assertRaises(ValueError):
+                ser.line_width = width
+        self.assertEqual(1.5, ser.line_width)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
The pilot has no native xy plot: a plot of solver output is assembled in Python, so the samples cross the binding once per point.

This adds the two Qt-free pieces the rest of the plot core builds on. `PlotColor` is one sRGB color with alpha, together with the matplotlib C0-C9 cycle; reusing matplotlib's ten colors in its order means a pilot plot carries the same color meaning as the matplotlib plot the reader would otherwise have made. `RPlotSeries` holds one xy series as a contiguous `SimpleCollector<double>` pair with its label, color, and stroke width, plus lazily cached data limits that skip any sample whose x or y is not finite.

`set_data` copies its operands, the way matplotlib copies the arrays handed to plot, so a later write through the NumPy array cannot leave the samples and the cached extent disagreeing. A SimpleCollector wraps a whole buffer and carries no shape, stride, or ghost, so set_data rejects an operand that is not one-dimensional, ghost-free, or unit strided, and validates both before assigning either.

Neither plot header includes Qt; converting a PlotColor to a QColor stays in the Qt front end. Behavior is covered by `tests/test_pilot_plot.py`. The `std::span` accessors stay unbound because a Python view would dangle at the next set_data.

Related to #1049 step 1.

<!--
solvcon pull request guidelines.

- Subject: concise and informative.
- Description: clear prose.  Write single-line paragraphs separated by blank
  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
  columns renders as ragged mid-sentence breaks.
- Draft until ready: open the PR as a draft while work is in progress.  When
  the PR is ready for review, post a global PR comment that explicitly asks for
  review.  Pushing the "ready for review" button alone is not a review request,
  because the push cannot be quoted in follow-ups.
- Inline annotations: as the author, add inline annotations on the diff to
  guide the reviewer, unless the diff is one-liner-ish.
- Issue reference: end the description with "Related to #xxx" or "For issue
  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
  let PR or commit text drive issue management.
- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
  you need to know what you wrote.

Delete this comment block before submitting.
-->

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
