### PR TITLE
Split the mixed shortcut and inspector tests into tests/gui

### DIFF
--- a/tests/gui/test_painter_layers.py
+++ b/tests/gui/test_painter_layers.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the Layers page of the Painter inspector.
+"""
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.base import _gui
+    from PySide6 import QtCore, QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+def _click(widget, x, y):
+    """Post a synthetic left-button press and release to ``widget``."""
+    pos = QtCore.QPointF(x, y)
+    glob = QtCore.QPointF(widget.mapToGlobal(pos.toPoint()))
+    for etype, button, buttons in (
+            (QtCore.QEvent.Type.MouseButtonPress,
+             QtCore.Qt.LeftButton, QtCore.Qt.LeftButton),
+            (QtCore.QEvent.Type.MouseButtonRelease,
+             QtCore.Qt.LeftButton, QtCore.Qt.NoButton)):
+        QtWidgets.QApplication.sendEvent(
+            widget,
+            QtGui.QMouseEvent(etype, pos, glob, button, buttons,
+                              QtCore.Qt.NoModifier))
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class PainterLayersCanvasTC(unittest.TestCase):
+    """The page against a real canvas, bound by the Painter dock."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.painter = _gui.controller.painter
+        self.painter._ensure_dock()
+        # The manager is shared with every other pilot suite, and a canvas one
+        # of them left open would answer for this one's once it closes.
+        for subwin in self.mgr.mdiArea.subWindowList():
+            subwin.close()
+        QtWidgets.QApplication.processEvents()
+        self.widget = self.mgr.add2DWidget()
+        self.widget.setDrawTool("select")
+        self.world = solvcon.WorldFp64()
+        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(self.world)
+        view = solvcon.ViewTransform2dFp64()
+        view.pan(100.0, 100.0)
+        view.zoom = 20.0
+        # Set the view before showing so the resize auto-centering, which a
+        # well-formed transform disables, leaves the mapping deterministic.
+        self.widget.setViewTransform(view)
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        # The manager and its Painter dock outlive this class, so a canvas
+        # left open would answer for the tests that follow.
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+
+    def test_the_list_follows_the_active_canvas(self):
+        page = self.painter.panel.layers
+        # Activation is delivered through a zero timer, so let it run.
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual([row.name for row in page.shown_rows],
+                         [f"Rectangle {self.sid}"])
+
+    def test_the_highlight_follows_a_pick_on_the_canvas(self):
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        _click(self.sub.widget(), 100, 100)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        page.refresh()
+        selected = [row.name for row in page.shown_rows if row.selected()]
+        self.assertEqual(selected, [f"Rectangle {self.sid}"])
+
+    def test_pressing_a_row_selects_the_shape_on_the_canvas(self):
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        _click(page.shown_rows[0], 10, 10)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        self.assertEqual([row.name for row in page.shown_rows
+                          if row.selected()], [f"Rectangle {self.sid}"])
+
+    def test_a_pick_arms_the_select_tool_first(self):
+        # The canvas draws no selection while a shape tool is armed, and
+        # switching tools drops the selection, so a pick that only wrote the
+        # id would leave nothing marked.
+        page = self.painter.panel.layers
+        self.widget.setDrawTool("circle")
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        _click(page.shown_rows[0], 10, 10)
+        self.assertEqual(self.widget.drawTool, "select")
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        # The rail and the Canvas menu share the action the pick triggered.
+        self.assertTrue(self.painter.panel.tool_buttons["select"].isChecked())
+
+    def test_a_pick_on_a_row_the_world_has_dropped_selects_nothing(self):
+        # The list polls, so a row can outlive its shape by one tick; the pick
+        # drops a dead id and heals the list without waiting for the next poll.
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        row = page.shown_rows[0]
+        self.world.remove_shape(self.sid)
+        _click(row, 10, 10)
+        self.assertEqual(self.widget.selectedShape, -1)
+        self.assertEqual(page.shown_rows, [])
+
+    def test_a_pick_on_a_stale_row_from_another_world_selects_nothing(self):
+        # Ids start over per world. A list that still names the previous
+        # canvas can match a live id on the one in front; the pick drops
+        # rather than selecting a shape the row never stood for.
+        page = self.painter.panel.layers
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        row = page.shown_rows[0]
+        other = self.mgr.add2DWidget()
+        other_world = solvcon.WorldFp64()
+        other_sid = other_world.add_circle(0, 0, 1)
+        self.assertEqual(other_sid, self.sid)
+        other.updateWorld(other_world)
+        other.setDrawTool("select")
+        other_sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.mgr.mdiArea.setActiveSubWindow(other_sub)
+        # Leave the activation refresh on the timer; the list still names
+        # the first canvas while the active one is already the second.
+        _click(row, 10, 10)
+        self.assertEqual(other.selectedShape, -1)
+        self.assertEqual(self.widget.selectedShape, -1)
+        other_sub.close()
+        QtWidgets.QApplication.processEvents()
+
+    def test_closing_the_canvas_leaves_the_list_standing(self):
+        # The sub-window deletes the canvas on close, and a page that held it
+        # would read freed memory on its next poll.
+        page = self.painter.panel.layers
+        self.sub.close()
+        QtWidgets.QApplication.processEvents()
+        page.refresh()
+        self.assertEqual(page.shown_rows, [])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_shortcut.py
+++ b/tests/gui/test_shortcut.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.base import _gui
+    from solvcon.pilot.base import _gui_common
+    from PySide6 import QtCore, QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+# QtTest is its own PySide6 extension, and the macOS CI job rewrites the Qt
+# rpath of QtCore, QtGui, and QtWidgets only, so importing it there fails.
+# Keeping it out of the block above stops that from unbinding pilot for the
+# whole module, which would fail every test in the file rather than skipping
+# the two that need live key delivery.
+try:
+    from PySide6.QtTest import QTest
+except ImportError:
+    QTest = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+_PANEL_CHORDS = (
+    ("panel.agent_console", ["Ctrl+Shift+A"]),
+    ("panel.inspector", ["Ctrl+Shift+I"]),
+    ("panel.painter", ["Ctrl+Shift+P"]),
+)
+
+_DRAW_TOOL_KEYS = (
+    ("select", "V"),
+    ("line", "L"),
+    ("triangle", "T"),
+    ("rectangle", "R"),
+    ("ellipse", "E"),
+    ("circle", "C"),
+)
+
+
+def _can_take_keyboard(widget):
+    """Whether the platform will hand ``widget`` the keyboard.
+
+    A run whose terminal stays frontmost never gets an active window, and
+    activateWindow cannot argue with that. Probe it so a test needing real key
+    delivery skips instead of failing for a reason unrelated to the code.
+    """
+    widget.window().activateWindow()
+    widget.window().raise_()
+    widget.setFocus()
+    QtWidgets.QApplication.processEvents()
+    return widget.hasFocus() and widget.isActiveWindow()
+
+
+def _live_sequences(action):
+    return [s.toString(QtGui.QKeySequence.PortableText)
+            for s in action.shortcuts()]
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class ShortcutTC(unittest.TestCase):
+    """Live QAction bindings for the commands routed through the roof."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+
+    def _assert_action_matches_resolved(self, object_name, qt_context):
+        action = self.model.action(object_name)
+        self.assertIsNotNone(action)
+        resolved = self.mgr.resolve_shortcut(object_name)
+        self.assertTrue(resolved["known"])
+        self.assertTrue(resolved["bound"])
+        self.assertEqual(_live_sequences(action), resolved["sequences"])
+        self.assertEqual(action.shortcutContext(), qt_context)
+
+    def test_undo_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "edit.undo", QtCore.Qt.WindowShortcut)
+
+    def test_redo_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "edit.redo", QtCore.Qt.WindowShortcut)
+
+    def test_camera_reset_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "camera.reset", QtCore.Qt.WidgetShortcut)
+
+    def test_console_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "window.console", QtCore.Qt.WindowShortcut)
+
+    def test_panel_actions_carry_the_resolved_bindings(self):
+        for oid, _ in _PANEL_CHORDS:
+            with self.subTest(oid=oid):
+                self._assert_action_matches_resolved(
+                    oid, QtCore.Qt.WindowShortcut)
+
+    def test_new_2d_canvas_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "canvas.blank_2d", QtCore.Qt.WindowShortcut)
+
+    def test_draw_tool_actions_carry_the_resolved_bindings(self):
+        for tool, _key in _DRAW_TOOL_KEYS:
+            with self.subTest(tool=tool):
+                self._assert_action_matches_resolved(
+                    "draw.tool." + tool, QtCore.Qt.WidgetShortcut)
+
+    def test_exit_action_carries_quit_and_platform_role(self):
+        self._assert_action_matches_resolved(
+            "file.exit", QtCore.Qt.ApplicationShortcut)
+        action = self.model.action("file.exit")
+        if self.mgr.shortcut_platform == "mac":
+            self.assertEqual(action.menuRole(), QtGui.QAction.QuitRole)
+        else:
+            self.assertEqual(action.menuRole(), QtGui.QAction.NoRole)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class ApplyShortcutHelperTC(unittest.TestCase):
+    """apply_shortcut installs a binding by objectName without hand wiring."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def test_applies_a_known_command_to_a_fresh_action(self):
+        act = QtGui.QAction("Console", self.mgr.mainWindow)
+        act.setObjectName("window.console")
+        _gui_common.apply_shortcut(act, mgr=self.mgr)
+        resolved = self.mgr.resolve_shortcut("window.console")
+        self.assertEqual(_live_sequences(act), resolved["sequences"])
+        self.assertEqual(act.shortcutContext(), QtCore.Qt.WindowShortcut)
+
+    def test_unknown_id_is_a_noop(self):
+        act = QtGui.QAction("Scratch", self.mgr.mainWindow)
+        act.setObjectName("no.such.command")
+        act.setShortcut("Ctrl+X")
+        act.setShortcutContext(QtCore.Qt.ApplicationShortcut)
+        act.setMenuRole(QtGui.QAction.AboutRole)
+        _gui_common.apply_shortcut(act, mgr=self.mgr)
+        self.assertEqual(act.shortcut().toString(
+            QtGui.QKeySequence.PortableText), "Ctrl+X")
+        self.assertEqual(act.shortcutContext(),
+                         QtCore.Qt.ApplicationShortcut)
+        self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None,
+                 "live key delivery needs a real window surface and QtTest")
+class DrawToolShortcutTC(unittest.TestCase):
+    """The draw-tool letters reach a focused canvas and nothing else."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.mgr.add2DWidget()
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        self.target = self.sub.widget()
+        self.mgr.setDrawTool("select")
+        QtWidgets.QApplication.processEvents()
+
+    def _type(self, widget, key):
+        if not _can_take_keyboard(widget):
+            self.skipTest("the platform did not grant the keyboard")
+        QTest.keyClick(widget, key)
+        QtWidgets.QApplication.processEvents()
+
+    def test_canvas_carries_every_draw_tool_action(self):
+        names = {a.objectName() for a in self.target.actions()}
+        for tool, _key in _DRAW_TOOL_KEYS:
+            self.assertIn("draw.tool." + tool, names)
+
+    def test_letter_on_a_focused_canvas_picks_its_tool(self):
+        for tool, key in _DRAW_TOOL_KEYS:
+            with self.subTest(tool=tool):
+                # Start from a tool the letter is not for, so a key that never
+                # arrived cannot pass by leaving the choice as it was.
+                self.mgr.setDrawTool(
+                    "select" if "circle" == tool else "circle")
+                self._type(self.target, getattr(QtCore.Qt, "Key_" + key))
+                self.assertEqual(self.mgr.drawTool, tool)
+
+    def test_letter_typed_in_a_text_field_stays_in_the_field(self):
+        edit = QtWidgets.QLineEdit(self.mgr.mainWindow)
+        edit.show()
+        try:
+            self.mgr.setDrawTool("line")
+            self._type(edit, QtCore.Qt.Key_R)
+            self.assertEqual(self.mgr.drawTool, "line")
+            self.assertEqual(edit.text(), "r")
+        finally:
+            edit.setParent(None)
+            edit.deleteLater()
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_solution_info.py
+++ b/tests/gui/test_solution_info.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.base import _gui
+    from solvcon.pilot._euler import _solution_info
+    from PySide6.QtWidgets import QApplication
+except ImportError:
+    pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class SolutionInfoTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def _feature(self):
+        feature = _solution_info.SolutionInfo(mgr=self.mgr)
+        feature.populate_menu()
+        feature._action.setChecked(True)  # builds the dock and panel
+        return feature
+
+    def test_panel_starts_paused_without_session(self):
+        feature = self._feature()
+        # Before Start there is no run, and the status tree says so.
+        self.assertIsNone(feature._session)
+        root = feature._panel._tree.topLevelItem(0)
+        self.assertIn("not started", root.text(0))
+
+    def test_start_builds_session_and_viewer(self):
+        feature = self._feature()
+        feature._panel._mach.setValue(2.5)
+        feature._on_start()
+        # Stop the timer so the heavy march does not run during the test.
+        feature._session['timer'].stop()
+        self.assertIsNotNone(feature._session)
+        self.assertEqual(feature._session['step'], 0)
+        self.assertIsNotNone(self.mgr.currentR3DWidget())
+        sections = [feature._panel._tree.topLevelItem(i).text(0)
+                    for i in range(feature._panel._tree.topLevelItemCount())]
+        self.assertTrue(any(s.startswith("step: 0") for s in sections))
+
+    def test_start_sets_viewer_mesh_for_inspector(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        # The inspector reads the active viewer's mesh; the solver viewer must
+        # carry the run's mesh so the mesh panel is not empty during a run.
+        self.assertIsNotNone(self.mgr.currentR3DWidget().mesh)
+        QApplication.processEvents()
+
+    def test_start_notifies_viewer_updated(self):
+        feature = self._feature()
+        calls = []
+        feature.viewer_updated = lambda: calls.append(1)
+        # Opening the viewer first and then starting reuses it, which raises no
+        # sub-window activation, so start must notify the inspector itself.
+        feature._panel._viewer_btn.setChecked(True)
+        feature._on_start()
+        feature._session['timer'].stop()
+        self.assertEqual(len(calls), 1)
+        QApplication.processEvents()
+
+    def test_step_advances_one_frame(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        feature._panel.set_paused(True)
+        feature._panel._steps.setValue(3)
+        feature._on_step()
+        self.assertEqual(feature._session['step'], 3)
+
+    def test_pause_toggle_controls_timer(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._panel._pause.setChecked(True)
+        self.assertFalse(feature._session['timer'].isActive())
+        feature._panel._pause.setChecked(False)
+        self.assertTrue(feature._session['timer'].isActive())
+        feature._session['timer'].stop()
+
+    def test_field_change_redraws_without_marching(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        feature._panel._pause.setChecked(True)
+        step = feature._session['step']
+        feature._panel._field.setCurrentText('pressure')
+        # Picking a field recolors the current frame; it must not march.
+        self.assertEqual(feature._session['step'], step)
+        root = feature._panel._tree.topLevelItem(1)
+        self.assertIn("pressure", root.text(0))
+
+    def test_viewer_button_opens_and_closes_subwindow(self):
+        feature = self._feature()
+        feature._panel._viewer_btn.setChecked(True)
+        self.assertIsNotNone(feature._viewer)
+        self.assertIsNotNone(self.mgr.currentR3DWidget())
+        feature._panel._viewer_btn.setChecked(False)
+        self.assertIsNone(feature._viewer)
+        QApplication.processEvents()
+
+    def test_closing_viewer_stops_run_without_drawing(self):
+        feature = self._feature()
+        feature._on_start()
+        # Closing the domain sub-window while marching must stop the timer,
+        # drop the viewer, and leave later frames as no-ops rather than
+        # drawing into the freed widget.
+        feature._close_viewer()
+        self.assertIsNone(feature._viewer)
+        self.assertFalse(feature._session['timer'].isActive())
+        self.assertFalse(feature._panel._viewer_btn.isChecked())
+        step = feature._session['step']
+        feature._advance()
+        feature._draw_frame()
+        self.assertEqual(feature._session['step'], step)
+        QApplication.processEvents()
+
+    def test_start_reopens_a_closed_viewer(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._close_viewer()
+        feature._on_start()
+        feature._session['timer'].stop()
+        self.assertIsNotNone(feature._viewer)
+        self.assertTrue(feature._panel._viewer_btn.isChecked())
+        QApplication.processEvents()
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class SolutionInspectorTC(unittest.TestCase):
+    """The wired controller refreshes the inspector when a run sets the
+    mesh."""
+
+    def test_open_viewer_then_start_populates_inspector(self):
+        ctl = _gui.controller
+        ctl.build()
+        ctl.tree_panel._action.setChecked(True)
+        sol = ctl.solution_info
+        sol._action.setChecked(True)
+        # Open the viewer first, then start: the reused viewer raises no
+        # activation, so only the wired refresh keeps the inspector from
+        # standing on "No mesh loaded".
+        sol._panel._viewer_btn.setChecked(True)
+        QApplication.processEvents()
+        sol._on_start()
+        sol._session['timer'].stop()
+        QApplication.processEvents()
+        root = ctl.tree_panel._mesh_tree._tree.topLevelItem(0)
+        self.assertEqual(root.text(0), "StaticMesh (2D)")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -6,24 +6,17 @@ Tests for the Layers page of the Painter inspector.
 """
 
 import math
-import os
 import unittest
 
 import solvcon
 
 try:
     from solvcon import pilot
-    from solvcon.pilot.base import _gui
     from solvcon.pilot import painter as _painter
     from solvcon.pilot.painter import _layers
     from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pilot = None
-
-# The offscreen platform cannot back a live window; neither can the headless
-# Windows CI runner, whose WARP software rasterizer faults on one.
-NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
-                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
 def _click(widget, x, y):
@@ -219,129 +212,6 @@ class PainterLayersPageTC(unittest.TestCase):
         self.page.setPalette(palette)
         self.assertNotEqual(self.page.styleSheet(), before)
         self.assertNotEqual(self.page.shown_rows[0].icon.toImage(), icon)
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class PainterLayersCanvasTC(unittest.TestCase):
-    """The page against a real canvas, bound by the Painter dock."""
-
-    def setUp(self):
-        self.mgr = _gui.controller.build()
-        self.painter = _gui.controller.painter
-        self.painter._ensure_dock()
-        # The manager is shared with every other pilot suite, and a canvas one
-        # of them left open would answer for this one's once it closes.
-        for subwin in self.mgr.mdiArea.subWindowList():
-            subwin.close()
-        QtWidgets.QApplication.processEvents()
-        self.widget = self.mgr.add2DWidget()
-        self.widget.setDrawTool("select")
-        self.world = solvcon.WorldFp64()
-        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
-        self.widget.updateWorld(self.world)
-        view = solvcon.ViewTransform2dFp64()
-        view.pan(100.0, 100.0)
-        view.zoom = 20.0
-        # Set the view before showing so the resize auto-centering, which a
-        # well-formed transform disables, leaves the mapping deterministic.
-        self.widget.setViewTransform(view)
-        self.mgr.show()
-        self.sub = self.mgr.mdiArea.subWindowList()[-1]
-        self.sub.show()
-        self.mgr.mdiArea.setActiveSubWindow(self.sub)
-        QtWidgets.QApplication.processEvents()
-
-    def tearDown(self):
-        # The manager and its Painter dock outlive this class, so a canvas
-        # left open would answer for the tests that follow.
-        self.sub.close()
-        QtWidgets.QApplication.processEvents()
-
-    def test_the_list_follows_the_active_canvas(self):
-        page = self.painter.panel.layers
-        # Activation is delivered through a zero timer, so let it run.
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        self.assertEqual([row.name for row in page.shown_rows],
-                         [f"Rectangle {self.sid}"])
-
-    def test_the_highlight_follows_a_pick_on_the_canvas(self):
-        page = self.painter.panel.layers
-        QtWidgets.QApplication.processEvents()
-        _click(self.sub.widget(), 100, 100)
-        self.assertEqual(self.widget.selectedShape, self.sid)
-        page.refresh()
-        selected = [row.name for row in page.shown_rows if row.selected()]
-        self.assertEqual(selected, [f"Rectangle {self.sid}"])
-
-    def test_pressing_a_row_selects_the_shape_on_the_canvas(self):
-        page = self.painter.panel.layers
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        _click(page.shown_rows[0], 10, 10)
-        self.assertEqual(self.widget.selectedShape, self.sid)
-        self.assertEqual([row.name for row in page.shown_rows
-                          if row.selected()], [f"Rectangle {self.sid}"])
-
-    def test_a_pick_arms_the_select_tool_first(self):
-        # The canvas draws no selection while a shape tool is armed, and
-        # switching tools drops the selection, so a pick that only wrote the
-        # id would leave nothing marked.
-        page = self.painter.panel.layers
-        self.widget.setDrawTool("circle")
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        _click(page.shown_rows[0], 10, 10)
-        self.assertEqual(self.widget.drawTool, "select")
-        self.assertEqual(self.widget.selectedShape, self.sid)
-        # The rail and the Canvas menu share the action the pick triggered.
-        self.assertTrue(self.painter.panel.tool_buttons["select"].isChecked())
-
-    def test_a_pick_on_a_row_the_world_has_dropped_selects_nothing(self):
-        # The list polls, so a row can outlive its shape by one tick; the pick
-        # drops a dead id and heals the list without waiting for the next poll.
-        page = self.painter.panel.layers
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        row = page.shown_rows[0]
-        self.world.remove_shape(self.sid)
-        _click(row, 10, 10)
-        self.assertEqual(self.widget.selectedShape, -1)
-        self.assertEqual(page.shown_rows, [])
-
-    def test_a_pick_on_a_stale_row_from_another_world_selects_nothing(self):
-        # Ids start over per world. A list that still names the previous
-        # canvas can match a live id on the one in front; the pick drops
-        # rather than selecting a shape the row never stood for.
-        page = self.painter.panel.layers
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        row = page.shown_rows[0]
-        other = self.mgr.add2DWidget()
-        other_world = solvcon.WorldFp64()
-        other_sid = other_world.add_circle(0, 0, 1)
-        self.assertEqual(other_sid, self.sid)
-        other.updateWorld(other_world)
-        other.setDrawTool("select")
-        other_sub = self.mgr.mdiArea.subWindowList()[-1]
-        self.mgr.mdiArea.setActiveSubWindow(other_sub)
-        # Leave the activation refresh on the timer; the list still names
-        # the first canvas while the active one is already the second.
-        _click(row, 10, 10)
-        self.assertEqual(other.selectedShape, -1)
-        self.assertEqual(self.widget.selectedShape, -1)
-        other_sub.close()
-        QtWidgets.QApplication.processEvents()
-
-    def test_closing_the_canvas_leaves_the_list_standing(self):
-        # The sub-window deletes the canvas on close, and a page that held it
-        # would read freed memory on its next poll.
-        page = self.painter.panel.layers
-        self.sub.close()
-        QtWidgets.QApplication.processEvents()
-        page.refresh()
-        self.assertEqual(page.shown_rows, [])
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -2,34 +2,16 @@
 # BSD 3-Clause License, see COPYING
 
 
-import os
 import unittest
 
 import solvcon
 
 try:
     from solvcon import pilot
-    from solvcon.pilot.base import _gui
-    from solvcon.pilot.base import _gui_common
-    from PySide6 import QtCore, QtGui, QtWidgets
+    from PySide6 import QtGui
 except ImportError:
     pilot = None
     QtGui = None
-
-# QtTest is its own PySide6 extension, and the macOS CI job rewrites the Qt
-# rpath of QtCore, QtGui, and QtWidgets only, so importing it there fails.
-# Keeping it out of the block above stops that from unbinding pilot for the
-# whole module, which would fail every test in the file rather than skipping
-# the two that need live key delivery.
-try:
-    from PySide6.QtTest import QTest
-except ImportError:
-    QTest = None
-
-# The offscreen platform cannot back a live window; neither can the headless
-# Windows CI runner, whose WARP software rasterizer faults on one.
-NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
-                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 # KeyMod::Primary and Key::Z ordinals from keymap.hpp, passed to
 # shortcut_conflicts_rebinding; a static_assert in wrap_pilot.cpp pins them.
@@ -58,25 +40,6 @@ if QtGui is not None:
         "file.exit": QtGui.QKeySequence.StandardKey.Quit,
         "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
     }
-
-
-def _can_take_keyboard(widget):
-    """Whether the platform will hand ``widget`` the keyboard.
-
-    A run whose terminal stays frontmost never gets an active window, and
-    activateWindow cannot argue with that. Probe it so a test needing real key
-    delivery skips instead of failing for a reason unrelated to the code.
-    """
-    widget.window().activateWindow()
-    widget.window().raise_()
-    widget.setFocus()
-    QtWidgets.QApplication.processEvents()
-    return widget.hasFocus() and widget.isActiveWindow()
-
-
-def _live_sequences(action):
-    return [s.toString(QtGui.QKeySequence.PortableText)
-            for s in action.shortcuts()]
 
 
 def _portable_standard_sequences(standard_key):
@@ -218,146 +181,6 @@ class ShortcutResolutionTC(unittest.TestCase):
             "window.console", _KEYMOD_PRIMARY, _KEY_Z)
         pairs = {frozenset(pair) for pair in conflicts}
         self.assertIn(frozenset({"edit.undo", "window.console"}), pairs)
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class ShortcutTC(unittest.TestCase):
-    """Live QAction bindings for the commands routed through the roof."""
-
-    def setUp(self):
-        self.mgr = _gui.controller.build()
-        self.model = self.mgr.menu_model
-
-    def _assert_action_matches_resolved(self, object_name, qt_context):
-        action = self.model.action(object_name)
-        self.assertIsNotNone(action)
-        resolved = self.mgr.resolve_shortcut(object_name)
-        self.assertTrue(resolved["known"])
-        self.assertTrue(resolved["bound"])
-        self.assertEqual(_live_sequences(action), resolved["sequences"])
-        self.assertEqual(action.shortcutContext(), qt_context)
-
-    def test_undo_action_carries_the_resolved_binding(self):
-        self._assert_action_matches_resolved(
-            "edit.undo", QtCore.Qt.WindowShortcut)
-
-    def test_redo_action_carries_the_resolved_binding(self):
-        self._assert_action_matches_resolved(
-            "edit.redo", QtCore.Qt.WindowShortcut)
-
-    def test_camera_reset_action_carries_the_resolved_binding(self):
-        self._assert_action_matches_resolved(
-            "camera.reset", QtCore.Qt.WidgetShortcut)
-
-    def test_console_action_carries_the_resolved_binding(self):
-        self._assert_action_matches_resolved(
-            "window.console", QtCore.Qt.WindowShortcut)
-
-    def test_panel_actions_carry_the_resolved_bindings(self):
-        for oid, _ in _PANEL_CHORDS:
-            with self.subTest(oid=oid):
-                self._assert_action_matches_resolved(
-                    oid, QtCore.Qt.WindowShortcut)
-
-    def test_new_2d_canvas_action_carries_the_resolved_binding(self):
-        self._assert_action_matches_resolved(
-            "canvas.blank_2d", QtCore.Qt.WindowShortcut)
-
-    def test_draw_tool_actions_carry_the_resolved_bindings(self):
-        for tool, _key in _DRAW_TOOL_KEYS:
-            with self.subTest(tool=tool):
-                self._assert_action_matches_resolved(
-                    "draw.tool." + tool, QtCore.Qt.WidgetShortcut)
-
-    def test_exit_action_carries_quit_and_platform_role(self):
-        self._assert_action_matches_resolved(
-            "file.exit", QtCore.Qt.ApplicationShortcut)
-        action = self.model.action("file.exit")
-        if self.mgr.shortcut_platform == "mac":
-            self.assertEqual(action.menuRole(), QtGui.QAction.QuitRole)
-        else:
-            self.assertEqual(action.menuRole(), QtGui.QAction.NoRole)
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class ApplyShortcutHelperTC(unittest.TestCase):
-    """apply_shortcut installs a binding by objectName without hand wiring."""
-
-    def setUp(self):
-        self.mgr = pilot.RManager.instance.setUp()
-
-    def test_applies_a_known_command_to_a_fresh_action(self):
-        act = QtGui.QAction("Console", self.mgr.mainWindow)
-        act.setObjectName("window.console")
-        _gui_common.apply_shortcut(act, mgr=self.mgr)
-        resolved = self.mgr.resolve_shortcut("window.console")
-        self.assertEqual(_live_sequences(act), resolved["sequences"])
-        self.assertEqual(act.shortcutContext(), QtCore.Qt.WindowShortcut)
-
-    def test_unknown_id_is_a_noop(self):
-        act = QtGui.QAction("Scratch", self.mgr.mainWindow)
-        act.setObjectName("no.such.command")
-        act.setShortcut("Ctrl+X")
-        act.setShortcutContext(QtCore.Qt.ApplicationShortcut)
-        act.setMenuRole(QtGui.QAction.AboutRole)
-        _gui_common.apply_shortcut(act, mgr=self.mgr)
-        self.assertEqual(act.shortcut().toString(
-            QtGui.QKeySequence.PortableText), "Ctrl+X")
-        self.assertEqual(act.shortcutContext(),
-                         QtCore.Qt.ApplicationShortcut)
-        self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None,
-                 "live key delivery needs a real window surface and QtTest")
-class DrawToolShortcutTC(unittest.TestCase):
-    """The draw-tool letters reach a focused canvas and nothing else."""
-
-    def setUp(self):
-        self.mgr = _gui.controller.build()
-        self.mgr.add2DWidget()
-        self.mgr.show()
-        self.sub = self.mgr.mdiArea.subWindowList()[-1]
-        self.sub.show()
-        self.mgr.mdiArea.setActiveSubWindow(self.sub)
-        self.target = self.sub.widget()
-        self.mgr.setDrawTool("select")
-        QtWidgets.QApplication.processEvents()
-
-    def _type(self, widget, key):
-        if not _can_take_keyboard(widget):
-            self.skipTest("the platform did not grant the keyboard")
-        QTest.keyClick(widget, key)
-        QtWidgets.QApplication.processEvents()
-
-    def test_canvas_carries_every_draw_tool_action(self):
-        names = {a.objectName() for a in self.target.actions()}
-        for tool, _key in _DRAW_TOOL_KEYS:
-            self.assertIn("draw.tool." + tool, names)
-
-    def test_letter_on_a_focused_canvas_picks_its_tool(self):
-        for tool, key in _DRAW_TOOL_KEYS:
-            with self.subTest(tool=tool):
-                # Start from a tool the letter is not for, so a key that never
-                # arrived cannot pass by leaving the choice as it was.
-                self.mgr.setDrawTool(
-                    "select" if "circle" == tool else "circle")
-                self._type(self.target, getattr(QtCore.Qt, "Key_" + key))
-                self.assertEqual(self.mgr.drawTool, tool)
-
-    def test_letter_typed_in_a_text_field_stays_in_the_field(self):
-        edit = QtWidgets.QLineEdit(self.mgr.mainWindow)
-        edit.show()
-        try:
-            self.mgr.setDrawTool("line")
-            self._type(edit, QtCore.Qt.Key_R)
-            self.assertEqual(self.mgr.drawTool, "line")
-            self.assertEqual(edit.text(), "r")
-        finally:
-            edit.setParent(None)
-            edit.deleteLater()
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_solution_info.py
+++ b/tests/test_pilot_solution_info.py
@@ -2,7 +2,6 @@
 # BSD 3-Clause License, see COPYING
 
 
-import os
 import math
 import unittest
 
@@ -13,16 +12,9 @@ from solvcon.multidim.euler import oblique
 
 try:
     from solvcon import pilot
-    from solvcon.pilot.base import _gui
     from solvcon.pilot._euler import _solution_info
-    from PySide6.QtWidgets import QApplication
 except ImportError:
     pilot = None
-
-# The offscreen platform cannot back a live window; neither can the headless
-# Windows CI runner, whose WARP software rasterizer faults on one.
-NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
-                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
@@ -68,149 +60,6 @@ class ComputeFieldTC(unittest.TestCase):
         self.assertEqual(density.shape[0], svr.ncell)
         np.testing.assert_array_equal(
             density, svr.so0n.ndarray[svr.ngstcell:, 0])
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class SolutionInfoTC(unittest.TestCase):
-    def setUp(self):
-        self.mgr = pilot.RManager.instance.setUp()
-
-    def _feature(self):
-        feature = _solution_info.SolutionInfo(mgr=self.mgr)
-        feature.populate_menu()
-        feature._action.setChecked(True)  # builds the dock and panel
-        return feature
-
-    def test_panel_starts_paused_without_session(self):
-        feature = self._feature()
-        # Before Start there is no run, and the status tree says so.
-        self.assertIsNone(feature._session)
-        root = feature._panel._tree.topLevelItem(0)
-        self.assertIn("not started", root.text(0))
-
-    def test_start_builds_session_and_viewer(self):
-        feature = self._feature()
-        feature._panel._mach.setValue(2.5)
-        feature._on_start()
-        # Stop the timer so the heavy march does not run during the test.
-        feature._session['timer'].stop()
-        self.assertIsNotNone(feature._session)
-        self.assertEqual(feature._session['step'], 0)
-        self.assertIsNotNone(self.mgr.currentR3DWidget())
-        sections = [feature._panel._tree.topLevelItem(i).text(0)
-                    for i in range(feature._panel._tree.topLevelItemCount())]
-        self.assertTrue(any(s.startswith("step: 0") for s in sections))
-
-    def test_start_sets_viewer_mesh_for_inspector(self):
-        feature = self._feature()
-        feature._on_start()
-        feature._session['timer'].stop()
-        # The inspector reads the active viewer's mesh; the solver viewer must
-        # carry the run's mesh so the mesh panel is not empty during a run.
-        self.assertIsNotNone(self.mgr.currentR3DWidget().mesh)
-        QApplication.processEvents()
-
-    def test_start_notifies_viewer_updated(self):
-        feature = self._feature()
-        calls = []
-        feature.viewer_updated = lambda: calls.append(1)
-        # Opening the viewer first and then starting reuses it, which raises no
-        # sub-window activation, so start must notify the inspector itself.
-        feature._panel._viewer_btn.setChecked(True)
-        feature._on_start()
-        feature._session['timer'].stop()
-        self.assertEqual(len(calls), 1)
-        QApplication.processEvents()
-
-    def test_step_advances_one_frame(self):
-        feature = self._feature()
-        feature._on_start()
-        feature._session['timer'].stop()
-        feature._panel.set_paused(True)
-        feature._panel._steps.setValue(3)
-        feature._on_step()
-        self.assertEqual(feature._session['step'], 3)
-
-    def test_pause_toggle_controls_timer(self):
-        feature = self._feature()
-        feature._on_start()
-        feature._panel._pause.setChecked(True)
-        self.assertFalse(feature._session['timer'].isActive())
-        feature._panel._pause.setChecked(False)
-        self.assertTrue(feature._session['timer'].isActive())
-        feature._session['timer'].stop()
-
-    def test_field_change_redraws_without_marching(self):
-        feature = self._feature()
-        feature._on_start()
-        feature._session['timer'].stop()
-        feature._panel._pause.setChecked(True)
-        step = feature._session['step']
-        feature._panel._field.setCurrentText('pressure')
-        # Picking a field recolors the current frame; it must not march.
-        self.assertEqual(feature._session['step'], step)
-        root = feature._panel._tree.topLevelItem(1)
-        self.assertIn("pressure", root.text(0))
-
-    def test_viewer_button_opens_and_closes_subwindow(self):
-        feature = self._feature()
-        feature._panel._viewer_btn.setChecked(True)
-        self.assertIsNotNone(feature._viewer)
-        self.assertIsNotNone(self.mgr.currentR3DWidget())
-        feature._panel._viewer_btn.setChecked(False)
-        self.assertIsNone(feature._viewer)
-        QApplication.processEvents()
-
-    def test_closing_viewer_stops_run_without_drawing(self):
-        feature = self._feature()
-        feature._on_start()
-        # Closing the domain sub-window while marching must stop the timer,
-        # drop the viewer, and leave later frames as no-ops rather than
-        # drawing into the freed widget.
-        feature._close_viewer()
-        self.assertIsNone(feature._viewer)
-        self.assertFalse(feature._session['timer'].isActive())
-        self.assertFalse(feature._panel._viewer_btn.isChecked())
-        step = feature._session['step']
-        feature._advance()
-        feature._draw_frame()
-        self.assertEqual(feature._session['step'], step)
-        QApplication.processEvents()
-
-    def test_start_reopens_a_closed_viewer(self):
-        feature = self._feature()
-        feature._on_start()
-        feature._close_viewer()
-        feature._on_start()
-        feature._session['timer'].stop()
-        self.assertIsNotNone(feature._viewer)
-        self.assertTrue(feature._panel._viewer_btn.isChecked())
-        QApplication.processEvents()
-
-
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class SolutionInspectorTC(unittest.TestCase):
-    """The wired controller refreshes the inspector when a run sets the
-    mesh."""
-
-    def test_open_viewer_then_start_populates_inspector(self):
-        ctl = _gui.controller
-        ctl.build()
-        ctl.tree_panel._action.setChecked(True)
-        sol = ctl.solution_info
-        sol._action.setChecked(True)
-        # Open the viewer first, then start: the reused viewer raises no
-        # activation, so only the wired refresh keeps the inspector from
-        # standing on "No mesh loaded".
-        sol._panel._viewer_btn.setChecked(True)
-        QApplication.processEvents()
-        sol._on_start()
-        sol._session['timer'].stop()
-        QApplication.processEvents()
-        root = ctl.tree_panel._mesh_tree._tree.topLevelItem(0)
-        self.assertEqual(root.text(0), "StaticMesh (2D)")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Stacked on master now that #1236 has merged. **Review only commit `f40b0e23`.**

Related to #1222. Stacked on #1236. Continues splitting the files that mix window-driving and headless classes.

Code motion only. Every moved and every remaining class body is byte-identical to its original, checked mechanically.

| source | stays | moves to `tests/gui/` |
|---|---|---|
| `test_pilot_painter_layers.py` | `_StubCanvas`, `PainterLayersPageTC` | `test_painter_layers.py`: `PainterLayersCanvasTC` |
| `test_pilot_shortcut.py` | `ShortcutResolutionTC` | `test_shortcut.py`: `ShortcutTC`, `ApplyShortcutHelperTC`, `DrawToolShortcutTC` |
| `test_pilot_solution_info.py` | `ComputeFieldTC` | `test_solution_info.py`: `SolutionInfoTC`, `SolutionInspectorTC` |

`_click`, `_PANEL_CHORDS`, and `_DRAW_TOOL_KEYS` are read from both sides and are duplicated rather than imported across the directory boundary.

`DrawToolShortcutTC` is guarded by `NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None`, and `QTest` comes from a separate import guard that deliberately sits outside the main one, with a comment explaining that macOS CI rewrites the Qt rpath for QtCore, QtGui, and QtWidgets only. That block moves verbatim with the class, comment included, and leaves the source since nothing there references `QTest` any more.

The single added line in a source file is `from PySide6 import QtGui`, narrowed from an import that also brought in `QtCore` and `QtWidgets`, which no longer have users there.
