### PR TITLE
Enforce which lane a test file belongs to

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,6 +131,12 @@ jobs:
         make checktws
         echo "::endgroup::"
 
+    - name: make checktests (check test lane layout)
+      run: |
+        echo "::group::make checktests"
+        make checktests
+        echo "::endgroup::"
+
     - name: make flake8
       run: |
         echo "::group::make flake8"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
   does not take over the desktop (`tests/conftest.py`). Export
   `SOLVCON_TEST_SHOW_WINDOWS=ON` to watch the windows instead, which hands
   them the desktop and the keyboard for the length of the run.
+- Tests that need a real top-level window live under `tests/gui/`;
+  everything else lives in `tests/`. CI selects between them by path, so a
+  new window test filed outside `tests/gui/` runs where no window can back
+  it. `make pytest` runs both, `make pytest-fast` skips `tests/gui/`, and
+  `make pytest-gui` runs only it. `tests/gui/README.md` states the rule and
+  `make checktests` enforces it.
 - `make gtest` -- build and run the full C++ test suite.
 - `./build/rel<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test` -- run a
   single gtest after `make gtest` has built the binary
@@ -118,7 +124,7 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
 - `make pyprof` -- run profiling benchmarks; results land in
   `profiling/results/`.
 
-**Lint** (`make lint` runs all five)
+**Lint** (`make lint` runs all six)
 
 - `make cformat` -- check C++ formatting (read-only; use
   `make FORCE_CLANG_FORMAT=inplace cformat` to fix).
@@ -126,6 +132,7 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
 - `make flake8` -- Python style and 79-char line limit.
 - `make checkascii` -- reject non-ASCII bytes in source.
 - `make checktws` -- reject trailing whitespace.
+- `make checktests` -- reject a test filed in the wrong lane (see below).
 
 **Format**
 

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,13 @@ checkascii:
 checktws:
 	$(WHICH_PYTHON) contrib/lint/check_ascii.py --check-tws
 
+# Keep the window tests under tests/gui and everything else out of it, so the
+# two CI lanes keep selecting what they mean to. tests/gui/README.md states
+# the rule.
+.PHONY: checktests
+checktests:
+	$(WHICH_PYTHON) contrib/lint/check_test_layout.py
+
 # Run the lint targets concurrently, scaled to the processor count, and keep
 # going on failure so every check reports before make exits non-zero.
 .PHONY: lint
@@ -308,7 +315,7 @@ lint:
 	@$(MAKE) --no-print-directory -j $(NPROC) -k lint_targets
 
 .PHONY: lint_targets
-lint_targets: cformat cinclude flake8 checkascii checktws
+lint_targets: cformat cinclude flake8 checkascii checktws checktests
 
 .PHONY: pyformat
 pyformat:

--- a/contrib/lint/check_test_layout.py
+++ b/contrib/lint/check_test_layout.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Test lane checker for solvcon.
+
+A test that needs a real top-level window surface belongs under tests/gui,
+and everything else belongs outside it. See tests/gui/README.md for the rule
+and the reasoning.
+
+Both directions are checked. The second one, a tests/gui file that has
+stopped being a window test, is the one that rots without help, because a
+file keeps its place long after its contents have moved on.
+"""
+
+import ast
+import pathlib
+import sys
+
+GUARD = 'NO_LIVE_WINDOW'
+TESTS_DIR = pathlib.Path('tests')
+GUI_DIR = TESTS_DIR / 'gui'
+
+
+def needs_live_window(path):
+    text = path.read_text(encoding='utf-8')
+    # The token appears in prose too, so confirm it is really referenced
+    # before believing it. Parsing every file instead would cost more than
+    # the rest of this script put together.
+    if GUARD not in text:
+        return False
+    tree = ast.parse(text, filename=str(path))
+    return any(isinstance(node, ast.Name) and GUARD == node.id
+               for node in ast.walk(tree))
+
+
+def main():
+    if not TESTS_DIR.is_dir():
+        print(f'FAILED: {TESTS_DIR} not found, run from the repository root',
+              file=sys.stderr)
+        return 1
+
+    gui, plain = [], []
+    for path in sorted(TESTS_DIR.rglob('test_*.py')):
+        (gui if GUI_DIR in path.parents else plain).append(path)
+
+    print(f'Checking {len(gui) + len(plain)} test files for lane placement')
+
+    failed = [f'{p}: window test outside {GUI_DIR}'
+              for p in plain if needs_live_window(p)]
+    failed += [f'{p}: no window test left'
+               for p in gui if not needs_live_window(p)]
+
+    if failed:
+        print(f'\nFAILED: {len(failed)} test files are in the wrong lane, '
+              f'see {GUI_DIR}/README.md:')
+        for line in failed:
+            print(f'  - {line}')
+        print(f'\nChecked {len(gui) + len(plain)} files total.')
+        return 1
+
+    print(f'SUCCESS: All {len(gui) + len(plain)} test files are in the '
+          f'right lane.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Related to #1222. Last of the series; #1235 through #1238 have merged, so this is a single commit on master. The earlier ones moved the window tests into `tests/gui/`; this one makes the layout hold on its own, answering the second half of the review comment on #1222 about keeping the split legible.

Nothing so far states which lane a new test belongs to. CI picks the lane by path, so a window test left outside `tests/gui/` runs where no window can back it, and a file that drifts into `tests/gui/` quietly stops running on a pull request. Neither failure is loud.

`make checktests` reports either direction. The lane is read from `NO_LIVE_WINDOW`, the guard those tests already carry, so no new marker or convention is introduced. It is wired into `lint_targets` and into its own step in `lint.yml`, because the lint workflow calls each target on its own rather than calling `make lint`, so the Makefile alone would not have run it on CI.

Verified against the real tree and against a deliberately misplaced file in each direction, including a nested subdirectory and a file that names the guard only in prose:

```
Checking 81 test files for lane placement
SUCCESS: All 81 test files are in the right lane.

  - tests/test_stray_check.py: window test outside tests/gui
  - tests/gui/test_lapsed_check.py: no window test left
  - tests/nested/test_nested_check.py: window test outside tests/gui
```

Two notes on what this deliberately does not do.

There is no hook and no pytest-collection check. An earlier draft had one, and it was wrong twice over: a pull request runs `pytest-fast`, which is `--ignore=tests/gui`, so the collection check could never observe the "lapsed" direction on the lane that matters, and `pytest.UsageError` aborts the whole session, so one misfiled file nobody touched would block an unrelated local test run. `make lint` and the CI lint job cover both directions completely.

The guard is still defined once per file, seventeen times over. Hoisting it into a shared `tests/gui/lane.py` and checking for the import would turn lane membership from an inferred symptom into a declared one, and it is the better shape. It is deliberately not in this change, because it is a mechanical edit across seventeen files whose natural trigger is the first real edit to the guard expression itself, such as a new headless CI platform. Doing it now would bury the enforcement in a rename.
