### PR TITLE
Give the world a change stamp for its readers to poll

### DIFF
--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -326,6 +326,7 @@ public:
     void add_point(point_type const & vertex)
     {
         m_points->append(vertex);
+        mark_changed();
     }
     void add_point(value_type x, value_type y, value_type z)
     {
@@ -344,6 +345,7 @@ public:
     {
         m_segments->append(segment);
         m_bare_segment_indices.push_back(m_segments->size() - 1);
+        mark_changed();
     }
     void add_segment(point_type const & p0, point_type const & p1)
     {
@@ -361,10 +363,12 @@ public:
     void add_bezier(bezier_type const & bezier)
     {
         m_curves->append(bezier);
+        mark_changed();
     }
     void add_bezier(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
     {
         m_curves->append(p0, p1, p2, p3);
+        mark_changed();
     }
     size_t nbezier() const { return m_curves->size(); }
     bezier_type bezier(size_t i) const { return m_curves->get(i); }
@@ -502,6 +506,8 @@ public:
 
     size_t nshape() const { return m_nshape; }
 
+    uint64_t version() const { return m_version; }
+
     /**
      * True if `shape_id` refers to a live (non-DEAD) shape. Unlike the
      * accessors above this never throws, so callers can probe a stale id.
@@ -582,6 +588,9 @@ public:
     std::string describe_state(DescribeLevel level = DescribeLevel::BASIC) const;
 
 private:
+
+    /// Stamp the world as changed; see version().
+    void mark_changed() { ++m_version; }
 
     /// 2D endpoints of segment i, as [x0, y0, x1, y1].
     std::vector<double> segment_coords(size_t i) const
@@ -700,6 +709,7 @@ private:
     std::vector<ShapeRecord> m_shape_registry;
 
     size_t m_nshape = 0; ///< Count of live (non-DEAD) shapes.
+    uint64_t m_version = 0; ///< Moves on every change; see version().
     std::unique_ptr<rtree_type> m_rtree; ///< Spatial index for shapes for viewport query.
 
     /// The kind of an undoable shape change.
@@ -778,6 +788,7 @@ int32_t World<T>::register_shape(ShapeType type,
     // Record the creation so undo removes the shape and redo brings it back
     // with the same type.
     record_op({.op = ShapeOp::CREATE, .shape_id = shape_id, .type = type});
+    mark_changed();
 
     return shape_id;
 }
@@ -960,6 +971,7 @@ void World<T>::apply_translate(int32_t shape_id, value_type dx, value_type dy)
     }
     // Reinsert with updated bounding box.
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+    mark_changed();
 }
 
 template <typename T>
@@ -1025,6 +1037,7 @@ void World<T>::apply_rotate(int32_t shape_id, value_type angle, value_type cx, v
     }
     // Reinsert with updated bounding box.
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+    mark_changed();
 }
 
 template <typename T>
@@ -1128,6 +1141,7 @@ void World<T>::kill_shape(int32_t shape_id)
     m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
     rec.type = ShapeType::DEAD;
     --m_nshape;
+    mark_changed();
 }
 
 template <typename T>
@@ -1139,6 +1153,7 @@ void World<T>::revive_shape(int32_t shape_id, ShapeType type)
     rec.type = type;
     ++m_nshape;
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+    mark_changed();
 }
 
 template <typename T>
@@ -1370,6 +1385,7 @@ void World<T>::clear()
     m_redo_stack.clear();
     m_in_operation = false;
     m_has_open = false;
+    mark_changed();
 }
 
 template <typename T>

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -73,6 +73,12 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
 
     (*this)
         .def_property_readonly("nshape", &wrapped_type::nshape)
+        .def_property_readonly(
+            "version",
+            &wrapped_type::version,
+            "A stamp that changes whenever what the world draws does. The "
+            "number means nothing on its own; a different one is a different "
+            "world.")
         .def("undo", &wrapped_type::undo)
         .def("redo", &wrapped_type::redo)
         .def_property_readonly("can_undo", &wrapped_type::can_undo)

--- a/solvcon/pilot/painter/_layers.py
+++ b/solvcon/pilot/painter/_layers.py
@@ -179,7 +179,7 @@ class LayersPage(PaletteStyled):
         super().__init__(parent)
         self._source = None
         self._fingerprint = None
-        self._world_id = None
+        self._drawn_world = None
         self._pixmaps = {}
         self.rows = []
         self._build()
@@ -215,7 +215,7 @@ class LayersPage(PaletteStyled):
 
     def draws_world(self, world):
         """Whether the rows were last drawn for ``world``."""
-        return world is not None and id(world) == self._world_id
+        return world is not None and world is self._drawn_world
 
     def set_canvas_source(self, source):
         """Bind the page to ``source``, a callable handing back the canvas.
@@ -230,10 +230,10 @@ class LayersPage(PaletteStyled):
         # Rendered rather than refreshed: two blank canvases show the same
         # nothing, so a refresh would take the page for unchanged and leave
         # the previous canvas's objects on screen.
-        fingerprint, content = self._snapshot()
+        fingerprint = self._state_key()
         self._fingerprint = fingerprint
-        self._world_id = None if fingerprint is None else fingerprint[0]
-        self._render(content)
+        self._drawn_world = None if fingerprint is None else fingerprint[0]
+        self._render(self._content())
 
     def showEvent(self, event):
         """Poll the bound canvas only while the page is on screen."""
@@ -248,12 +248,12 @@ class LayersPage(PaletteStyled):
 
     def refresh(self):
         """Redraw the list when the canvas it is bound to has changed."""
-        fingerprint, content = self._snapshot()
+        fingerprint = self._state_key()
         if fingerprint == self._fingerprint:
             return
         self._fingerprint = fingerprint
-        self._world_id = None if fingerprint is None else fingerprint[0]
-        self._render(content)
+        self._drawn_world = None if fingerprint is None else fingerprint[0]
+        self._render(self._content())
 
     def _build(self):
         self._filters = _Filters(self)
@@ -307,26 +307,25 @@ class LayersPage(PaletteStyled):
         selected = widget.selectedShape
         return world, selected if world.shape_is_live(selected) else -1
 
-    def _snapshot(self):
-        """Fingerprint and row content for the bound canvas, one world read.
-
-        The fingerprint is what the poll compares: the world identity, the
-        selection, and the world's own state string. Segment coordinates ride
-        in that string, so a rotate changes it and the list rebuilds; an
-        unchanged tick skips the per-shape oriented boxes the rows show.
+    def _state_key(self):
+        """What the list shows, as a value the poll can compare: the world it
+        draws, the selection it marks, and the world's change stamp.
         """
         world, selected = self._selection()
+        return None if world is None else (world, selected, world.version)
+
+    def _content(self):
+        """What the rows show, read from the world the page is bound to."""
+        world, selected = self._selection()
         if world is None:
-            return None, ()
-        state = world.describe_state()
+            return ()
         # Newest first: the world draws in registry order, so the last shape
         # added is on top of the canvas and the one the list names first.
-        shapes = json.loads(state)["shapes"][::-1]
-        content = tuple(
+        shapes = json.loads(world.describe_state())["shapes"][::-1]
+        return tuple(
             (shape["id"], shape["type"], self._name_of(shape),
              self._metric_of(world, shape), shape["id"] == selected)
             for shape in shapes)
-        return (id(world), selected, state), content
 
     def _render(self, content):
         for index, entry in enumerate(content):

--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -677,10 +677,10 @@ class EntityTreeWidget(TreePanelBase):
 
     def _describe(self, world, level):
         """Return the cached ``describe_state`` JSON for ``level``."""
-        fingerprint = world.describe_state(level="basic")
+        fingerprint = (world, world.version)
         if fingerprint != self._fingerprint:
             self._fingerprint = fingerprint
-            self._cache = {"basic": fingerprint}
+            self._cache = {}
         if level not in self._cache:
             self._cache[level] = world.describe_state(level=level)
         return self._cache[level]

--- a/tests/gui/test_tree_panel.py
+++ b/tests/gui/test_tree_panel.py
@@ -102,6 +102,9 @@ class _CountingWorld:
         self._real = real
         self.calls = {"basic": 0, "diagnostics": 0}
 
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
     def describe_state(self, level="basic"):
         self.calls[level] += 1
         return self._real.describe_state(level=level)
@@ -149,7 +152,10 @@ class EntityTreeWidgetTC(unittest.TestCase):
         tree.set_world(world)
         tree.set_world(world)  # unchanged poll reuses the cache
         self.assertEqual(world.calls["diagnostics"], 1)
-        real.add_line(5, 5, 6, 6)  # a real edit flips the fingerprint
+        # An untouched world is not serialized at all: the change stamp is
+        # what the poll compares, so no level is swept to notice a quiet tick.
+        self.assertEqual(world.calls["basic"], 0)
+        real.add_line(5, 5, 6, 6)  # a real edit moves the stamp
         tree.set_world(world)
         self.assertEqual(world.calls["diagnostics"], 2)
 

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -34,6 +34,21 @@ def _click(widget, x, y):
                               QtCore.Qt.NoModifier))
 
 
+class _RecordingWorld:
+    """Wraps a world, noting every time it is asked to serialize itself."""
+
+    def __init__(self, real, reads):
+        self._real = real
+        self._reads = reads
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def describe_state(self, *args, **kw):
+        self._reads.append(kw.get("level", "basic"))
+        return self._real.describe_state(*args, **kw)
+
+
 class _StubCanvas:
     """Stand-in for the 2D canvas, so a test can set the selection directly.
 
@@ -137,6 +152,23 @@ class PainterLayersPageTC(unittest.TestCase):
         self.page.refresh()
         self.assertEqual([row.metric for row in self.page.shown_rows],
                          ["r 3", "2 x 4"])
+
+    def test_a_quiet_tick_does_not_serialize_the_world(self):
+        # The list rebuilds from the world's serialized state, and the poll
+        # compares the change stamp instead of it, so a tick over an untouched
+        # world reads the stamp and stops there.
+        reads = []
+        real = self.world
+        self.canvas.world = _RecordingWorld(real, reads)
+        # Handing over another world is itself a change; let the list take it.
+        self.page.refresh()
+        reads.clear()
+        self.page.refresh()
+        self.assertEqual(reads, [])
+        real.add_circle(0, 0, 1)
+        self.page.refresh()
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(len(self.page.shown_rows), 3)
 
     def test_rows_track_adding_removing_and_undo(self):
         third = self.world.add_circle(0, 0, 1)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -360,6 +360,90 @@ class WorldPrimitivesTC(unittest.TestCase):
             self.w.add_polygon([[0, 0], [1, 1]])
 
 
+class WorldVersionTC(unittest.TestCase):
+    """The stamp that tells a reader the world has changed."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def _changed_by(self, act):
+        """Return whether ``act`` moved the stamp."""
+        before = self.w.version
+        act()
+        return self.w.version != before
+
+    def test_every_way_of_adding_geometry_moves_it(self):
+        # A reader compares the stamp instead of the geometry, so anything the
+        # canvas would draw differently has to move it.
+        for name, act in (
+                ("point", lambda: self.w.add_point(0, 0, 0)),
+                ("segment", lambda: self.w.add_segment(
+                    solvcon.Point3dFp64(0, 0, 0),
+                    solvcon.Point3dFp64(1, 1, 0))),
+                ("bezier", lambda: self.w.add_bezier(
+                    solvcon.Point3dFp64(0, 0, 0),
+                    solvcon.Point3dFp64(1, 0, 0),
+                    solvcon.Point3dFp64(1, 1, 0),
+                    solvcon.Point3dFp64(0, 1, 0))),
+                ("line", lambda: self.w.add_line(0, 0, 1, 1)),
+                ("triangle", lambda: self.w.add_triangle(0, 0, 1, 0, 0, 1)),
+                ("rectangle", lambda: self.w.add_rectangle(0, 0, 1, 1)),
+                ("ellipse", lambda: self.w.add_ellipse(0, 0, 2, 1)),
+                ("circle", lambda: self.w.add_circle(0, 0, 1)),
+                ("polyline", lambda: self.w.add_polyline([[0, 0], [1, 1]])),
+                ("polygon", lambda: self.w.add_polygon(
+                    [[0, 0], [1, 0], [1, 1]]))):
+            with self.subTest(name=name):
+                self.assertTrue(self._changed_by(act))
+
+    def test_moving_and_removing_a_shape_moves_it(self):
+        sid = self.w.add_rectangle(0, 0, 2, 1)
+        self.assertTrue(self._changed_by(
+            lambda: self.w.translate_shape(sid, 1, 1)))
+        self.assertTrue(self._changed_by(
+            lambda: self.w.rotate_shape(sid, 0.5 * math.pi, 0, 0)))
+        self.assertTrue(self._changed_by(lambda: self.w.remove_shape(sid)))
+
+    def test_undo_and_redo_move_it(self):
+        # They change what is drawn as much as the edit they replay, and a
+        # reader that missed them would show a world that no longer exists.
+        sid = self.w.add_circle(0, 0, 1)
+        self.w.translate_shape(sid, 3, 0)
+        self.assertTrue(self._changed_by(self.w.undo))
+        self.assertTrue(self._changed_by(self.w.redo))
+        self.assertTrue(self._changed_by(self.w.clear))
+
+    def test_reading_the_world_leaves_it_alone(self):
+        # Only edits move the stamp; a query that moved it would have every
+        # reader redrawing on its own reads.
+        sid = self.w.add_circle(0, 0, 1)
+        before = self.w.version
+        self.w.describe_state()
+        self.w.shape_bbox(sid)
+        self.w.shape_obb(sid)
+        self.w.pick_shape(0, 0, 0.1)
+        self.w.shape_is_live(sid)
+        self.assertEqual(self.w.version, before)
+
+    def test_reaching_past_the_world_into_its_pads_is_not_seen(self):
+        # The stamp covers what goes through the world. A caller that writes
+        # into the pads it hands out moves geometry behind its back, which is
+        # what the accessors' own documentation warns of.
+        self.w.add_segment(solvcon.Point3dFp64(0, 0, 0),
+                           solvcon.Point3dFp64(1, 1, 0))
+        before = self.w.version
+        self.w.segments.set_at(0, 5.0, 5.0, 6.0, 6.0)
+        self.assertEqual(self.w.version, before)
+
+    def test_an_edit_that_changes_nothing_leaves_it_alone(self):
+        # A drag's first event often lands on the press point, and the world
+        # takes that as no move at all.
+        sid = self.w.add_rectangle(0, 0, 2, 1)
+        before = self.w.version
+        self.w.translate_shape(sid, 0, 0)
+        self.assertEqual(self.w.version, before)
+
+
 class WorldUndoRedoTC(unittest.TestCase):
     """Undo and redo of shape creation."""
 


### PR DESCRIPTION
The panels that show what a world holds had no cheap way to notice an edit: the Painter's Layers page serialized the whole world every 250 ms and the entity tree every 500 ms, both only to learn whether anything had happened. `World` now carries a stamp that moves whenever its geometry does, and both panels poll that instead, serializing only when there is something new to show.

Every mutation funnels through a handful of internal primitives, so the stamp is bumped in those rather than in each public entry point, and undo and redo move it as the edits they replay do. What it does not cover is written down where it is declared: a caller that reaches past the world into the pads `points()`, `segments()`, and `curves()` hand out moves geometry the stamp does not see, and the undo history is not geometry, so `can_undo()` can turn true without it moving. A test pins the first of those so the limit stays honest.

The entity tree's cache is keyed on the stamp together with the world it came from, and the Layers page's poll key likewise. Both hold the world as the object rather than as its `id`, since stamps count per world and an id a dead world freed can be handed out to the next.

Related to #1241.
