### PR TITLE
Move the pilot's Qt style sheets out of widget code

### DIFF
--- a/solvcon/pilot/_style.py
+++ b/solvcon/pilot/_style.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+What the pilot's Python widgets build their style sheets out of.
+
+The C++ theme manager owns the curated palette and the application-wide sheet
+it derives from it; a Python widget that wants more than the palette gives
+mixes its own shades here instead of naming a color. Every shade is a step
+between two palette colors, so a widget styled from :class:`Shades` follows a
+light/dark switch without a hex value anywhere in its code.
+"""
+
+import functools
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+__all__ = [
+    'Shades',
+    'RuleCatalog',
+    'PaletteStyle',
+    'PaletteStyled',
+]
+
+
+# Qt 6.6 added this event, and the theme backends still guard for older Qt.
+# Naming it in a class body would fail the import of the whole pilot there.
+_DPR_CHANGE_EVENT = getattr(QtCore.QEvent, 'DevicePixelRatioChange', None)
+
+# How far the shades every page shares sit from the color they mix against.
+_MUTED_MIX = 0.35
+_GREYED_MIX = 0.6
+_BORDER_MIX = 0.25
+
+
+class Shades:
+    """The colors a widget styles itself in, read off its own palette.
+
+    A mix off them is asked for by how far it moves rather than by name, so
+    a rule states the step it wants and gets it in whatever theme is current.
+    """
+
+    @staticmethod
+    def blend(color, other, ratio):
+        """Mix ``ratio`` of ``other`` into ``color``."""
+        keep = 1.0 - ratio
+        return QtGui.QColor(
+            round(color.red() * keep + other.red() * ratio),
+            round(color.green() * keep + other.green() * ratio),
+            round(color.blue() * keep + other.blue() * ratio))
+
+    def __init__(self, widget):
+        palette = widget.palette()
+        self.text = palette.color(QtGui.QPalette.WindowText)
+        self.panel = palette.color(QtGui.QPalette.Window)
+        self.base = palette.color(QtGui.QPalette.Base)
+        self.accent = palette.color(QtGui.QPalette.Highlight)
+        self.on_accent = palette.color(QtGui.QPalette.HighlightedText)
+        self.on_base = palette.color(QtGui.QPalette.Text)
+
+    # Mixed on demand: a paint that wants one of the three should not pay
+    # for the other two.
+    @functools.cached_property
+    def muted(self):
+        """The shade a secondary label reads in."""
+        return self.dimmed(_MUTED_MIX)
+
+    @functools.cached_property
+    def greyed(self):
+        """The shade a control the model cannot back yet reads in."""
+        return self.dimmed(_GREYED_MIX)
+
+    @functools.cached_property
+    def border(self):
+        """The hairline a box is drawn with."""
+        return self.raised(_BORDER_MIX)
+
+    def dimmed(self, ratio):
+        """The text color moved ``ratio`` back toward the panel."""
+        return self.blend(self.text, self.panel, ratio)
+
+    def raised(self, ratio):
+        """The panel color moved ``ratio`` toward the text, which steps a
+        surface darker under a light palette and lighter under a dark one."""
+        return self.blend(self.panel, self.text, ratio)
+
+    def tinted(self, ratio):
+        """The panel color moved ``ratio`` toward the accent."""
+        return self.blend(self.panel, self.accent, ratio)
+
+
+class RuleCatalog:
+    """A catalog of style rules, one method per role it styles.
+
+    A neighbourhood subclasses this and adds a static method per role, named
+    for the thing it styles and returning the rules that color it. A widget
+    asks :meth:`sheet` for the roles it draws, so a role defined once covers
+    every page that draws it.
+    """
+
+    @classmethod
+    def sheet(cls, widget, *roles):
+        """The style sheet ``widget`` carries for the ``roles`` it draws."""
+        shades = Shades(widget)
+        return "".join(getattr(cls, role)(shades) for role in roles)
+
+
+class PaletteStyle:
+    """A mixin that keeps a widget's style sheet current with the palette.
+
+    A class mixes this in ahead of the Qt widget it derives from, builds its
+    style sheet in :meth:`_apply_style`, and calls it once its children exist;
+    the mixin re-applies it whenever the application palette changes.
+    """
+
+    # Both palette events matter. The theme manager pairs a new application
+    # palette with a fresh global style sheet, whose re-polish arrives here as
+    # PaletteChange; under the system look it sets the palette alone, and
+    # ApplicationPaletteChange is what carries that.
+    #
+    # The icons rasterize for the screen they are on, so a move between screens
+    # of different scale has to re-render them just as a theme switch does.
+    # Where Qt cannot report that move, the icons keep the scale they were
+    # rendered at until the next palette change.
+    _RESTYLE_EVENTS = (
+        (QtCore.QEvent.PaletteChange, QtCore.QEvent.ApplicationPaletteChange)
+        + ((_DPR_CHANGE_EVENT,) if _DPR_CHANGE_EVENT is not None else ()))
+
+    def event(self, event):
+        if event.type() in self._RESTYLE_EVENTS:
+            self._apply_style()
+            self.update()
+        return super().event(event)
+
+    def _apply_style(self):
+        raise NotImplementedError
+
+
+class PaletteStyled(PaletteStyle, QtWidgets.QWidget):
+    """A plain widget whose child controls are styled from the palette."""
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_canvas.py
+++ b/solvcon/pilot/painter/_canvas.py
@@ -8,10 +8,11 @@ The Canvas page of the Painter inspector: how the canvas shows the world.
 import json
 import math
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
+from .._style import PaletteStyled
 from ._sections import Placeholder, Section
-from ._style import blend, mono_font, rule, shade, PaletteStyled
+from ._style import Parts, Rules
 from ..panel._tree_panel import EntityTreeWidget
 
 __all__ = [
@@ -49,10 +50,10 @@ class _Readout(QtWidgets.QFrame):
         self.setObjectName("box")
         self.setFixedHeight(self._HEIGHT)
         name = QtWidgets.QLabel(label, self)
-        name.setObjectName("name")
+        name.setObjectName("label")
         self._value = QtWidgets.QLabel(self)
         self._value.setObjectName("value")
-        self._value.setFont(mono_font())
+        self._value.setFont(Parts.mono_font())
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(*self._MARGINS)
         layout.setSpacing(self._GAP)
@@ -98,16 +99,6 @@ class CanvasPage(PaletteStyled):
 
     _ACTION_HEIGHT = 26
     _ACTION_GAP = 5
-    _LABEL_PX = 10
-    _VALUE_PX = 11
-    _ACTION_PX = 11
-    _RADIUS = 5
-
-    # How far each of these sits from the panel color.
-    _MUTED_MIX = 0.35
-    _GREYED_MIX = 0.6
-    _BORDER_MIX = 0.25
-    _HOVER_MIX = 0.08
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -168,7 +159,7 @@ class CanvasPage(PaletteStyled):
         layout.setSpacing(0)
         layout.addWidget(self._build_view())
         for title, waits_for in self.PLACEHOLDERS:
-            layout.addWidget(rule(QtWidgets.QFrame.HLine))
+            layout.addWidget(Parts.rule(QtWidgets.QFrame.HLine))
             self.placeholders[title] = Placeholder(
                 title, waits_for, parent=self)
             layout.addWidget(self.placeholders[title])
@@ -317,44 +308,7 @@ class CanvasPage(PaletteStyled):
     def _apply_style(self):
         """Color the section heads, the readout, and the buttons from the
         palette."""
-        palette = self.palette()
-        text = palette.color(QtGui.QPalette.WindowText)
-        panel = palette.color(QtGui.QPalette.Window)
-        muted = blend(text, panel, self._MUTED_MIX)
-        greyed = blend(text, panel, self._GREYED_MIX)
-        border = shade(self, self._BORDER_MIX)
-        base = palette.color(QtGui.QPalette.Base)
-        self.setStyleSheet(f"""
-            QLabel#section {{
-                color: {muted.name()};
-            }}
-            QLabel#section:disabled {{
-                color: {greyed.name()};
-            }}
-            QFrame#box {{
-                border: 1px solid {border.name()};
-                border-radius: {self._RADIUS}px;
-                background: {base.name()};
-            }}
-            QLabel#name {{
-                font-size: {self._LABEL_PX}px;
-                color: {muted.name()};
-            }}
-            QLabel#value {{
-                font-size: {self._VALUE_PX}px;
-            }}
-            QPushButton#action {{
-                border: 1px solid {border.name()};
-                border-radius: {self._RADIUS}px;
-                font-size: {self._ACTION_PX}px;
-                background: {base.name()};
-            }}
-            QPushButton#action:hover {{
-                background: {shade(self, self._HOVER_MIX).name()};
-            }}
-            QPushButton#action:disabled {{
-                color: {greyed.name()};
-            }}
-            """)
+        self.setStyleSheet(
+            Rules.sheet(self, "section", "box", "readout", "action"))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_design.py
+++ b/solvcon/pilot/painter/_design.py
@@ -7,12 +7,12 @@ The Design page of the Painter inspector: what is selected and where it sits.
 
 import math
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
+from .._style import PaletteStyled, Shades
 from . import _icons
 from ._sections import Placeholder
-from ._style import (blend, mono_font, obb_metrics, rule, shade,
-                     PaletteStyled)
+from ._style import Parts, Rules
 
 __all__ = [
     'DesignPage',
@@ -61,7 +61,7 @@ class _Field(QtWidgets.QFrame):
         label.setObjectName("axis")
         label.setFixedWidth(self._LETTER_WIDTH)
         self._edit = QtWidgets.QLineEdit(self)
-        self._edit.setFont(mono_font())
+        self._edit.setFont(Parts.mono_font())
         self._edit.setReadOnly(not editable)
         # An editor asks for room for a line of text, and four of them would
         # open the dock wider than the inspector the design draws. The grid
@@ -169,16 +169,6 @@ class DesignPage(PaletteStyled):
     _GAP = 10
     _HEADER_GAP = 8
     _GRID_GAP = 6
-    _NAME_PX = 12
-    _SMALL_PX = 10
-    _VALUE_PX = 11
-    _RADIUS = 5
-
-    # How far each of these sits from the panel color.
-    _MUTED_MIX = 0.35
-    _GREYED_MIX = 0.6
-    _BADGE_MIX = 0.15
-    _BORDER_MIX = 0.25
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -235,10 +225,10 @@ class DesignPage(PaletteStyled):
         layout.setSpacing(0)
         layout.addWidget(self._build_selection())
         for title, waits_for in self.PLACEHOLDERS:
-            layout.addWidget(rule(QtWidgets.QFrame.HLine))
+            layout.addWidget(Parts.rule(QtWidgets.QFrame.HLine))
             layout.addWidget(self._add_placeholder(title, waits_for))
 
-        layout.addWidget(rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(Parts.rule(QtWidgets.QFrame.HLine))
         layout.addWidget(
             self._add_placeholder("Layers", "shape names", folded=False))
         layout.addStretch(1)
@@ -263,7 +253,7 @@ class DesignPage(PaletteStyled):
         self._name.setObjectName("name")
         self._badge = QtWidgets.QLabel("1 selected", block)
         self._badge.setObjectName("badge")
-        self._badge.setFont(mono_font())
+        self._badge.setFont(Parts.mono_font())
         layout = QtWidgets.QHBoxLayout()
         layout.setSpacing(self._HEADER_GAP)
         layout.addWidget(self._icon)
@@ -331,7 +321,7 @@ class DesignPage(PaletteStyled):
             self._icon_name = kind if kind in _icons.ICONS else None
             self._name.setText(f"{kind.title()} {shape}")
             self._badge.setVisible(True)
-            metrics = obb_metrics(world.shape_obb(shape))
+            metrics = Parts.obb_metrics(world.shape_obb(shape))
             for (letter, _editable), value in zip(self._POSITION, metrics):
                 self.fields[letter].setEnabled(True)
                 self.fields[letter].set_value(value)
@@ -344,7 +334,7 @@ class DesignPage(PaletteStyled):
             self._icon.setVisible(False)
             return
         self._icon.setPixmap(_icons.render(
-            self._icon_name, self.palette().color(QtGui.QPalette.Highlight),
+            self._icon_name, Shades(self).accent,
             self._ICON_PX, self.devicePixelRatioF()))
         self._icon.setVisible(True)
 
@@ -354,7 +344,7 @@ class DesignPage(PaletteStyled):
         if world is None:
             return
         obb = world.shape_obb(shape)
-        center_x, center_y = obb_metrics(obb)[:2]
+        center_x, center_y = Parts.obb_metrics(obb)[:2]
         if "X" == axis:
             delta = (value - center_x, 0.0)
         else:
@@ -377,43 +367,8 @@ class DesignPage(PaletteStyled):
 
     def _apply_style(self):
         """Color the header, the badge, and the fields from the palette."""
-        palette = self.palette()
-        text = palette.color(QtGui.QPalette.WindowText)
-        panel = palette.color(QtGui.QPalette.Window)
-        muted = blend(text, panel, self._MUTED_MIX)
-        greyed = blend(text, panel, self._GREYED_MIX)
-        self.setStyleSheet(f"""
-            QLabel#name {{
-                font-size: {self._NAME_PX}px;
-            }}
-            QLabel#axis {{
-                font-size: {self._SMALL_PX}px;
-                color: {muted.name()};
-            }}
-            QLabel#axis:disabled {{
-                color: {greyed.name()};
-            }}
-            QLabel#badge {{
-                border-radius: 4px;
-                padding: 2px 6px;
-                font-size: {self._SMALL_PX}px;
-                background: {shade(self, self._BADGE_MIX).name()};
-                color: {muted.name()};
-            }}
-            QFrame#field {{
-                border: 1px solid {shade(self, self._BORDER_MIX).name()};
-                border-radius: {self._RADIUS}px;
-                background: {palette.color(QtGui.QPalette.Base).name()};
-            }}
-            QLineEdit {{
-                border: none;
-                background: transparent;
-                font-size: {self._VALUE_PX}px;
-            }}
-            QLineEdit:read-only {{
-                color: {muted.name()};
-            }}
-            """)
+        self.setStyleSheet(
+            Rules.sheet(self, "name", "axis", "badge", "box", "editor"))
         self._show_icon()
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_gui.py
+++ b/solvcon/pilot/painter/_gui.py
@@ -7,11 +7,12 @@ Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from .._style import PaletteStyled, Shades
 from . import _icons
 from ._canvas import CanvasPage
 from ._design import DesignPage
 from ._layers import LayersPage
-from ._style import blend, rule, shade, PaletteStyled
+from ._style import Parts, Rules
 from ..base import _gui_common
 from .._pilot_core import draw_tool_names, default_draw_tool_name
 
@@ -76,7 +77,7 @@ class _SelectorRule(QtWidgets.QWidget):
     def paintEvent(self, _event):
         painter = QtGui.QPainter(self)
         painter.fillRect(0, self._MARGIN, self.width(), 1,
-                         shade(self, self._MIX))
+                         Shades(self).raised(self._MIX))
 
 
 class _DrawToolSelector(PaletteStyled):
@@ -98,21 +99,13 @@ class _DrawToolSelector(PaletteStyled):
         "grid": ("Grid", "grid and snap options"),
     }
 
-    # How far the column shade sits from the inspector panel color, and how
-    # far a hovered entry sits from the column.
+    # How far the column shade sits from the inspector panel color.
     _SHADE_MIX = 0.06
-    _HOVER_MIX = 0.12
-
-    # How far an entry's label moves back toward the column.
-    _LABEL_MIX = 0.25
-    _MUTED_MIX = 0.55
 
     # Column and entry geometry from the design, in device-independent pixels.
     _WIDTH = 64
     _ENTRY_WIDTH = 52
     _ICON_PX = 17
-    _FONT_PX = 9
-    _RADIUS = 7
     _GAP = 2
     _PAD_Y = 8
 
@@ -148,7 +141,7 @@ class _DrawToolSelector(PaletteStyled):
 
     def paintEvent(self, _event):
         painter = QtGui.QPainter(self)
-        painter.fillRect(self.rect(), shade(self, self._SHADE_MIX))
+        painter.fillRect(self.rect(), Shades(self).raised(self._SHADE_MIX))
 
     def _new_entry(self):
         return _SelectorEntry(self._ENTRY_WIDTH, self._ICON_PX, self)
@@ -178,36 +171,8 @@ class _DrawToolSelector(PaletteStyled):
 
     def _apply_style(self):
         """Color the entries and their icons from the current palette."""
-        palette = self.palette()
-        text = palette.color(QtGui.QPalette.WindowText)
-        panel = palette.color(QtGui.QPalette.Window)
-        label = blend(text, panel, self._LABEL_MIX)
-        muted = blend(text, panel, self._MUTED_MIX)
-        on_accent = palette.color(QtGui.QPalette.HighlightedText)
-        # The disabled rule comes last so a greyed entry keeps its color even
-        # under the pointer, where the hover rule would otherwise light it up.
-        self.setStyleSheet(f"""
-            QToolButton {{
-                border: none;
-                border-radius: {self._RADIUS}px;
-                padding: 7px 0 6px;
-                font-size: {self._FONT_PX}px;
-                background: transparent;
-                color: {label.name()};
-            }}
-            QToolButton:hover {{
-                background: {shade(self, self._HOVER_MIX).name()};
-                color: {text.name()};
-            }}
-            QToolButton:checked {{
-                background: {palette.color(QtGui.QPalette.Highlight).name()};
-                color: {on_accent.name()};
-            }}
-            QToolButton:disabled {{
-                background: transparent;
-                color: {muted.name()};
-            }}
-            """)
+        self.setStyleSheet(Rules.sheet(self, "entry"))
+        label, disabled, on_accent = Rules.entry_icon_colors(self)
         ratio = self.devicePixelRatioF()
         for name, entry in self.buttons.items():
             # A tool the icon set does not draw yet keeps its label alone.
@@ -216,7 +181,7 @@ class _DrawToolSelector(PaletteStyled):
                     name, self._ICON_PX, label, on_accent, ratio))
         for name, entry in self.placeholders.items():
             entry.set_entry_icon(_icons.placeholder_icon(
-                name, self._ICON_PX, muted, ratio))
+                name, self._ICON_PX, disabled, ratio))
 
 
 class _SegmentedTabs(PaletteStyled):
@@ -235,13 +200,6 @@ class _SegmentedTabs(PaletteStyled):
     # Row and segment geometry from the design, in device-independent pixels.
     _MARGINS = (10, 8, 10, 8)
     _GAP = 4
-    _RADIUS = 5
-    _FONT_PX = 11
-
-    # How far the checked pill and the unchecked labels move toward the text
-    # color: enough for the pill to read as raised and the rest as secondary.
-    _PILL_MIX = 0.15
-    _LABEL_MIX = 0.45
 
     def __init__(self, names, parent=None):
         super().__init__(parent)
@@ -265,28 +223,7 @@ class _SegmentedTabs(PaletteStyled):
 
     def _apply_style(self):
         """Color the segments from the current palette."""
-        palette = self.palette()
-        panel = palette.color(QtGui.QPalette.Window)
-        text = palette.color(QtGui.QPalette.WindowText)
-        pill = shade(self, self._PILL_MIX)
-        self.setStyleSheet(f"""
-            QPushButton {{
-                border: none;
-                border-radius: {self._RADIUS}px;
-                padding: 5px 0;
-                font-size: {self._FONT_PX}px;
-                background: transparent;
-                color: {blend(text, panel, self._LABEL_MIX).name()};
-            }}
-            QPushButton:hover {{
-                color: {text.name()};
-            }}
-            QPushButton:checked {{
-                background: {pill.name()};
-                color: {text.name()};
-                font-weight: 500;
-            }}
-            """)
+        self.setStyleSheet(Rules.sheet(self, "tab"))
 
 
 class PainterPanel(QtWidgets.QWidget):
@@ -334,7 +271,7 @@ class PainterPanel(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self._tools)
-        layout.addWidget(rule(QtWidgets.QFrame.VLine))
+        layout.addWidget(Parts.rule(QtWidgets.QFrame.VLine))
         layout.addWidget(self._inspector, 1)
 
     @property
@@ -416,7 +353,7 @@ class PainterPanel(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self._tabs)
-        layout.addWidget(rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(Parts.rule(QtWidgets.QFrame.HLine))
         layout.addWidget(self._stack, 1)
         return inspector
 

--- a/solvcon/pilot/painter/_layers.py
+++ b/solvcon/pilot/painter/_layers.py
@@ -7,12 +7,12 @@ The Layers page of the Painter inspector: every object the world holds.
 
 import json
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
+from .._style import PaletteStyled, Shades
 from . import _icons
 from . import _rows
-from ._style import (blend, mono_font, obb_metrics, rule, shade,
-                     PaletteStyled)
+from ._style import Parts, Rules
 
 __all__ = [
     'LayersPage',
@@ -59,7 +59,6 @@ class _Filters(QtWidgets.QWidget):
         self._glass = QtWidgets.QLabel(self.search)
         self._glass.setFixedWidth(self._ICON_PX)
         edit = QtWidgets.QLineEdit(self.search)
-        edit.setObjectName("query")
         edit.setPlaceholderText("Search objects")
         inside = QtWidgets.QHBoxLayout(self.search)
         inside.setContentsMargins(*self._SEARCH_PADDING)
@@ -103,7 +102,7 @@ class _Footer(QtWidgets.QWidget):
         self.buttons = {}
         self.count = QtWidgets.QLabel(self)
         self.count.setObjectName("count")
-        self.count.setFont(mono_font())
+        self.count.setFont(Parts.mono_font())
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(*self._MARGINS)
         layout.setSpacing(self._GAP)
@@ -161,19 +160,7 @@ class LayersPage(PaletteStyled):
 
     _LIST_MARGINS = (6, 0, 6, 0)
     _EMPTY_MARGINS = (12, 4, 12, 4)
-    _EMPTY_PX = 12
-    _COUNT_PX = 10
-    _CHIP_PX = 10
-    _SEARCH_PX = 11
-    _RADIUS = 5
-    _CHIP_RADIUS = 11
     _ICON_PX = 12
-
-    # How far each of these sits from the panel color.
-    _MUTED_MIX = 0.35
-    _GREYED_MIX = 0.6
-    _CHIP_MIX = 0.15
-    _BORDER_MIX = 0.25
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -265,7 +252,7 @@ class LayersPage(PaletteStyled):
         layout.setSpacing(0)
         layout.addWidget(self._filters)
         layout.addWidget(self._build_list(), 1)
-        layout.addWidget(rule(QtWidgets.QFrame.HLine))
+        layout.addWidget(Parts.rule(QtWidgets.QFrame.HLine))
         layout.addWidget(self._footer)
 
     def _build_list(self):
@@ -366,7 +353,7 @@ class LayersPage(PaletteStyled):
         Both come from the shape's own oriented box, because the serialized
         box is axis-aligned and reads wider than a rotated shape really is.
         """
-        width, height = obb_metrics(world.shape_obb(shape["id"]))[2:]
+        width, height = Parts.obb_metrics(world.shape_obb(shape["id"]))[2:]
         if "circle" == shape["type"]:
             return f"r {0.5 * width:g}"
         return f"{width:g} x {height:g}"
@@ -387,53 +374,16 @@ class LayersPage(PaletteStyled):
         key = (name, selected, ratio)
         if key not in self._pixmaps:
             self._pixmaps[key] = _icons.render(
-                name, _rows.icon_color(self, selected),
+                name, Rules.row_icon_color(self, selected),
                 _rows.ICON_PX, ratio)
         return self._pixmaps[key]
 
     def _apply_style(self):
         """Color the rows, the placeholders, and the footer from the
         palette."""
-        palette = self.palette()
-        text = palette.color(QtGui.QPalette.WindowText)
-        panel = palette.color(QtGui.QPalette.Window)
-        greyed = blend(text, panel, self._GREYED_MIX)
-        self.setStyleSheet(_rows.rules(self) + f"""
-            QLabel#empty {{
-                font-size: {self._EMPTY_PX}px;
-                color: {greyed.name()};
-            }}
-            QLabel#count {{
-                font-size: {self._COUNT_PX}px;
-                color: {blend(text, panel, self._MUTED_MIX).name()};
-            }}
-            QFrame#search {{
-                border: 1px solid {shade(self, self._BORDER_MIX).name()};
-                border-radius: {self._RADIUS}px;
-                background: {palette.color(QtGui.QPalette.Base).name()};
-            }}
-            QLineEdit#query {{
-                border: none;
-                background: transparent;
-                font-size: {self._SEARCH_PX}px;
-            }}
-            QPushButton#chip {{
-                border: none;
-                border-radius: {self._CHIP_RADIUS}px;
-                padding: 3px 8px;
-                font-size: {self._CHIP_PX}px;
-                background: transparent;
-                color: {greyed.name()};
-            }}
-            QPushButton#chip:checked {{
-                background: {shade(self, self._CHIP_MIX).name()};
-            }}
-            QToolButton#footer {{
-                border: 1px solid {shade(self, self._BORDER_MIX).name()};
-                border-radius: {self._RADIUS}px;
-                background: {palette.color(QtGui.QPalette.Base).name()};
-            }}
-            """)
+        self.setStyleSheet(Rules.sheet(self, "row", "name", "empty",
+                                       "count", "box", "editor", "chip"))
+        greyed = Shades(self).greyed
         ratio = self.devicePixelRatioF()
         self._filters.set_icon(
             _icons.render("search", greyed, self._ICON_PX, ratio))

--- a/solvcon/pilot/painter/_rows.py
+++ b/solvcon/pilot/painter/_rows.py
@@ -5,20 +5,18 @@
 The object row the Painter inspector lists.
 
 The design draws the same row twice, filling the Layers page and the short
-list at the foot of the Design page, so the widget and the rules that color it
-live together here rather than in either page.
+list the Design page still stands in for, so the widget lives here rather
+than in either page.
 """
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ._style import blend, mono_font
+from ._style import Parts
 
 __all__ = [
     'ICON_PX',
     'HEIGHT',
     'ObjectRow',
-    'icon_color',
-    'rules',
 ]
 
 #: The type icon's size and the row's own, in device-independent pixels.
@@ -27,14 +25,6 @@ HEIGHT = 30
 
 _MARGINS = (8, 0, 8, 0)
 _GAP = 8
-_NAME_PX = 12
-_METRIC_PX = 10
-_RADIUS = 5
-
-# How far the type icon and the metric sit from the panel color, and how far
-# the selected row's tint sits from it.
-_MUTED_MIX = 0.35
-_SELECTED_MIX = 0.15
 
 
 class ObjectRow(QtWidgets.QFrame):
@@ -63,7 +53,7 @@ class ObjectRow(QtWidgets.QFrame):
         self._name.setObjectName("name")
         self._metric = QtWidgets.QLabel(self)
         self._metric.setObjectName("metric")
-        self._metric.setFont(mono_font())
+        self._metric.setFont(Parts.mono_font())
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(*_MARGINS)
         layout.setSpacing(_GAP)
@@ -121,45 +111,5 @@ class ObjectRow(QtWidgets.QFrame):
         super().mousePressEvent(event)
         if QtCore.Qt.LeftButton == event.button():
             self.picked.emit(self._shape_id)
-
-
-def icon_color(widget, selected):
-    """The color a row on ``widget`` strokes its type icon in."""
-    palette = widget.palette()
-    if selected:
-        return palette.color(QtGui.QPalette.Highlight)
-    return blend(palette.color(QtGui.QPalette.WindowText),
-                 palette.color(QtGui.QPalette.Window), _MUTED_MIX)
-
-
-def rules(widget):
-    """The style rules ``widget`` carries for the rows it holds.
-
-    They travel with the row rather than sitting in each page's own sheet, so
-    the two lists the design draws cannot drift apart. A page appends them to
-    its sheet, which keeps one sheet covering every row it holds.
-    """
-    palette = widget.palette()
-    text = palette.color(QtGui.QPalette.WindowText)
-    panel = palette.color(QtGui.QPalette.Window)
-    accent = palette.color(QtGui.QPalette.Highlight)
-    return f"""
-        QFrame#row {{
-            border-radius: {_RADIUS}px;
-        }}
-        QFrame#row[selected="true"] {{
-            background: {blend(panel, accent, _SELECTED_MIX).name()};
-        }}
-        QLabel#name {{
-            font-size: {_NAME_PX}px;
-        }}
-        QLabel#metric {{
-            font-size: {_METRIC_PX}px;
-            color: {blend(text, panel, _MUTED_MIX).name()};
-        }}
-        QFrame#row[selected="true"] QLabel#metric {{
-            color: {accent.name()};
-        }}
-        """
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_style.py
+++ b/solvcon/pilot/painter/_style.py
@@ -2,112 +2,313 @@
 # BSD 3-Clause License, see COPYING
 
 """
-Palette-derived styling shared by the pieces of the Painter panel, with the
-small conversions its pages share.
+The style rules the Painter is drawn with, and the small conversions its pages
+share.
 
-The design's greys are all a step from the panel color toward the text color,
-so a piece that mixes its own shades follows a light/dark switch without
-naming a single hex value.
+The design draws the same handful of things on every page: an object row, a
+boxed value, a section head, a pill. Each is a role here, so two pages that
+draw one of them cannot drift apart.
 """
 
 import math
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
+
+from .._style import RuleCatalog, Shades
 
 __all__ = [
-    'blend',
-    'shade',
-    'rule',
-    'mono_font',
-    'obb_metrics',
-    'PaletteStyled',
+    'Parts',
+    'Rules',
 ]
 
+# Text sizes from the design, in device-independent pixels.
+_NAME_PX = 12
+_VALUE_PX = 11
+_SMALL_PX = 10
+_ENTRY_PX = 9
 
-# Qt 6.6 added this event, and the theme backends still guard for older Qt.
-# Naming it in a class body would fail the import of the whole pilot there.
-_DPR_CHANGE_EVENT = getattr(QtCore.QEvent, 'DevicePixelRatioChange', None)
+_RADIUS = 5
+_BADGE_RADIUS = 4
+_CHIP_RADIUS = 11
+_ENTRY_RADIUS = 7
 
-
-def rule(shape):
-    """A hairline divider between two areas of the panel."""
-    line = QtWidgets.QFrame()
-    line.setFrameShape(shape)
-    line.setFrameShadow(QtWidgets.QFrame.Sunken)
-    return line
-
-
-def mono_font():
-    """The stand-in for the mono font the design gives every number."""
-    return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
-
-
-def obb_metrics(obb):
-    """Return the center, width, and height of an oriented bounding box.
-
-    The corners run top-left, top-right, bottom-right, bottom-left, so the two
-    sides give the shape's own width and height rather than the wider span a
-    rotated shape covers along the axes.
-    """
-    xs = obb[0::2]
-    ys = obb[1::2]
-    # Divided before summed: four corners far enough out add up past the
-    # double range, and the center would come back infinite.
-    return (sum(x / 4 for x in xs), sum(y / 4 for y in ys),
-            math.hypot(xs[1] - xs[0], ys[1] - ys[0]),
-            math.hypot(xs[3] - xs[0], ys[3] - ys[0]))
+# The pill and the unchecked tab label move far enough for the pill to read
+# as raised and the rest as secondary.
+_PILL_MIX = 0.15
+_SELECTED_MIX = 0.15
+_HOVER_MIX = 0.08
+_ENTRY_HOVER_MIX = 0.12
+_TAB_LABEL_MIX = 0.45
+_ENTRY_LABEL_MIX = 0.25
+_ENTRY_OFF_MIX = 0.55
 
 
-def blend(color, other, ratio):
-    """Mix ``ratio`` of ``other`` into ``color``."""
-    keep = 1.0 - ratio
-    return QtGui.QColor(
-        round(color.red() * keep + other.red() * ratio),
-        round(color.green() * keep + other.green() * ratio),
-        round(color.blue() * keep + other.blue() * ratio))
+class Parts:
+    """The widgets and measurements a page builds itself out of."""
+
+    @staticmethod
+    def rule(shape):
+        """A hairline divider between two areas of the panel."""
+        line = QtWidgets.QFrame()
+        line.setFrameShape(shape)
+        line.setFrameShadow(QtWidgets.QFrame.Sunken)
+        return line
+
+    @staticmethod
+    def mono_font():
+        """The stand-in for the mono font the design gives every number."""
+        return QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
+
+    @staticmethod
+    def obb_metrics(obb):
+        """Return the center, width, and height of an oriented bounding box.
+
+        The corners run top-left, top-right, bottom-right, bottom-left, so the
+        two sides give the shape's own width and height rather than the wider
+        span a rotated shape covers along the axes.
+        """
+        xs = obb[0::2]
+        ys = obb[1::2]
+        # Divided before summed: four corners far enough out add up past the
+        # double range, and the center would come back infinite.
+        return (sum(x / 4 for x in xs), sum(y / 4 for y in ys),
+                math.hypot(xs[1] - xs[0], ys[1] - ys[0]),
+                math.hypot(xs[3] - xs[0], ys[3] - ys[0]))
 
 
-def shade(widget, ratio):
-    """The panel color of ``widget`` moved ``ratio`` toward its text color.
+class Rules(RuleCatalog):
+    """The Painter's roles, and the icon colors that must match them."""
 
-    Blending toward the text is what makes a shade follow the theme: it steps
-    darker under a light palette and lighter under a dark one, which is how the
-    design separates the selector from the inspector and the checked tab from
-    both.
-    """
-    palette = widget.palette()
-    return blend(palette.color(QtGui.QPalette.Window),
-                 palette.color(QtGui.QPalette.WindowText), ratio)
+    @staticmethod
+    def name(shades):
+        """The object name a row and the Design header both write."""
+        return f"""
+            QLabel#name {{
+                font-size: {_NAME_PX}px;
+            }}
+            """
 
+    @staticmethod
+    def row(shades):
+        """The object row the Layers list is filled with."""
+        return f"""
+            QFrame#row {{
+                border-radius: {_RADIUS}px;
+            }}
+            QFrame#row[selected="true"] {{
+                background: {shades.tinted(_SELECTED_MIX).name()};
+            }}
+            QLabel#metric {{
+                font-size: {_SMALL_PX}px;
+                color: {shades.muted.name()};
+            }}
+            QFrame#row[selected="true"] QLabel#metric {{
+                color: {shades.accent.name()};
+            }}
+            """
 
-class PaletteStyled(QtWidgets.QWidget):
-    """A widget whose child controls are styled from the palette.
+    @staticmethod
+    def box(shades):
+        """The bordered box the design lays on the base color."""
+        return f"""
+            QFrame#field, QFrame#search, QFrame#box, QToolButton#footer {{
+                border: 1px solid {shades.border.name()};
+                border-radius: {_RADIUS}px;
+                background: {shades.base.name()};
+            }}
+            """
 
-    A subclass builds its style sheet in :meth:`_apply_style` and calls it once
-    its children exist; the base re-applies it whenever the application palette
-    changes, so the piece follows a light/dark switch.
-    """
+    @staticmethod
+    def editor(shades):
+        """The text editor inside a box, which draws the border around it."""
+        return f"""
+            QLineEdit {{
+                border: none;
+                background: transparent;
+                font-size: {_VALUE_PX}px;
+            }}
+            QLineEdit:read-only {{
+                color: {shades.muted.name()};
+            }}
+            """
 
-    # Both palette events matter. The theme manager pairs a new application
-    # palette with a fresh global style sheet, whose re-polish arrives here as
-    # PaletteChange; under the system look it sets the palette alone, and
-    # ApplicationPaletteChange is what carries that.
-    #
-    # The icons rasterize for the screen they are on, so a move between screens
-    # of different scale has to re-render them just as a theme switch does.
-    # Where Qt cannot report that move, the icons keep the scale they were
-    # rendered at until the next palette change.
-    _RESTYLE_EVENTS = (
-        (QtCore.QEvent.PaletteChange, QtCore.QEvent.ApplicationPaletteChange)
-        + ((_DPR_CHANGE_EVENT,) if _DPR_CHANGE_EVENT is not None else ()))
+    @staticmethod
+    def axis(shades):
+        """The axis letter heading a position field."""
+        return f"""
+            QLabel#axis {{
+                font-size: {_SMALL_PX}px;
+                color: {shades.muted.name()};
+            }}
+            QLabel#axis:disabled {{
+                color: {shades.greyed.name()};
+            }}
+            """
 
-    def event(self, event):
-        if event.type() in self._RESTYLE_EVENTS:
-            self._apply_style()
-            self.update()
-        return super().event(event)
+    @staticmethod
+    def badge(shades):
+        """The selection count beside the Design header."""
+        return f"""
+            QLabel#badge {{
+                border-radius: {_BADGE_RADIUS}px;
+                padding: 2px 6px;
+                font-size: {_SMALL_PX}px;
+                background: {shades.raised(_PILL_MIX).name()};
+                color: {shades.muted.name()};
+            }}
+            """
 
-    def _apply_style(self):
-        raise NotImplementedError
+    @staticmethod
+    def section(shades):
+        """The small uppercase head over one section of a page."""
+        return f"""
+            QLabel#section {{
+                color: {shades.muted.name()};
+            }}
+            QLabel#section:disabled {{
+                color: {shades.greyed.name()};
+            }}
+            """
+
+    @staticmethod
+    def readout(shades):
+        """What a Canvas box measures, then the number it reads."""
+        return f"""
+            QLabel#label {{
+                font-size: {_SMALL_PX}px;
+                color: {shades.muted.name()};
+            }}
+            QLabel#value {{
+                font-size: {_VALUE_PX}px;
+            }}
+            """
+
+    @staticmethod
+    def action(shades):
+        """A Canvas button that acts on the view."""
+        return f"""
+            QPushButton#action {{
+                border: 1px solid {shades.border.name()};
+                border-radius: {_RADIUS}px;
+                font-size: {_VALUE_PX}px;
+                background: {shades.base.name()};
+            }}
+            QPushButton#action:hover {{
+                background: {shades.raised(_HOVER_MIX).name()};
+            }}
+            QPushButton#action:disabled {{
+                color: {shades.greyed.name()};
+            }}
+            """
+
+    @staticmethod
+    def chip(shades):
+        """A Layers filter chip."""
+        return f"""
+            QPushButton#chip {{
+                border: none;
+                border-radius: {_CHIP_RADIUS}px;
+                padding: 3px 8px;
+                font-size: {_SMALL_PX}px;
+                background: transparent;
+                color: {shades.greyed.name()};
+            }}
+            QPushButton#chip:checked {{
+                background: {shades.raised(_PILL_MIX).name()};
+            }}
+            """
+
+    @staticmethod
+    def empty(shades):
+        """The line the Layers list shows while it holds no rows."""
+        return f"""
+            QLabel#empty {{
+                font-size: {_NAME_PX}px;
+                color: {shades.greyed.name()};
+            }}
+            """
+
+    @staticmethod
+    def count(shades):
+        """The object count in the Layers footer."""
+        return f"""
+            QLabel#count {{
+                font-size: {_SMALL_PX}px;
+                color: {shades.muted.name()};
+            }}
+            """
+
+    @staticmethod
+    def tab(shades):
+        """One segment of the inspector's page selector."""
+        return f"""
+            QPushButton {{
+                border: none;
+                border-radius: {_RADIUS}px;
+                padding: 5px 0;
+                font-size: {_VALUE_PX}px;
+                background: transparent;
+                color: {shades.dimmed(_TAB_LABEL_MIX).name()};
+            }}
+            QPushButton:hover {{
+                color: {shades.text.name()};
+            }}
+            QPushButton:checked {{
+                background: {shades.raised(_PILL_MIX).name()};
+                color: {shades.text.name()};
+                font-weight: 500;
+            }}
+            """
+
+    @staticmethod
+    def entry(shades):
+        """One entry of the draw tool selector.
+
+        The disabled rule comes last so a greyed entry keeps its color even
+        under the pointer, where the hover rule would otherwise light it up.
+        """
+        return f"""
+            QToolButton {{
+                border: none;
+                border-radius: {_ENTRY_RADIUS}px;
+                padding: 7px 0 6px;
+                font-size: {_ENTRY_PX}px;
+                background: transparent;
+                color: {shades.dimmed(_ENTRY_LABEL_MIX).name()};
+            }}
+            QToolButton:hover {{
+                background: {shades.raised(_ENTRY_HOVER_MIX).name()};
+                color: {shades.text.name()};
+            }}
+            QToolButton:checked {{
+                background: {shades.accent.name()};
+                color: {shades.on_accent.name()};
+            }}
+            QToolButton:disabled {{
+                background: transparent;
+                color: {shades.dimmed(_ENTRY_OFF_MIX).name()};
+            }}
+            """
+
+    @staticmethod
+    def row_icon_color(widget, selected):
+        """The color a row on ``widget`` strokes its type icon in."""
+        shades = Shades(widget)
+        return shades.accent if selected else shades.muted
+
+    @staticmethod
+    def entry_icon_colors(widget):
+        """The colors a draw tool entry on ``widget`` strokes its icon in.
+
+        They come from here rather than from the selector so that an icon
+        reads in the color the "entry" role gives the label beside it.
+
+        :return: The label color, the greyed-out one, and the one an entry
+            wears over the accent pill.
+        :rtype: tuple
+        """
+        shades = Shades(widget)
+        return (shades.dimmed(_ENTRY_LABEL_MIX), shades.dimmed(_ENTRY_OFF_MIX),
+                shades.on_accent)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/panel/_profiling.py
+++ b/solvcon/pilot/panel/_profiling.py
@@ -8,6 +8,8 @@ import itertools
 import importlib.util
 
 from ..base import _gui_common
+from .._style import PaletteStyle
+from ._style import Rules
 
 from ... import call_profiler
 from ... import apputil
@@ -32,6 +34,18 @@ from PySide6.QtGui import (
 )
 
 __all__ = ["Profiling"]
+
+
+class _ResultTree(PaletteStyle, QTreeView):
+    """The tree a profiling result is listed in."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._apply_style()
+
+    def _apply_style(self):
+        self.setStyleSheet(Rules.sheet(self, "tree"))
 
 
 class Profiling(_gui_common.PilotFeature):
@@ -73,7 +87,7 @@ class Profiling(_gui_common.PilotFeature):
     def _add_result_window(self, result: list[dict[str, typing.Any]]):
         self._table = self._mgr.addSubWindow(QWidget())
         self._table.setWindowTitle("Profiling result")
-        self._tree_view = QTreeView(self._table)
+        self._tree_view = _ResultTree(self._table)
 
         self._model = QStandardItemModel(self._tree_view)
         self._model.setHorizontalHeaderLabels(
@@ -106,30 +120,9 @@ class Profiling(_gui_common.PilotFeature):
             for child_data in data["children"]:
                 _recursive_add_item(first_item, child_data, data['total_time'])
 
-        self._tree_view.setStyleSheet(
-            """
-            QTreeView {
-                background-color: #2e2e2e;
-                color: #dcdcdc;
-                border: 1px solid #555555;
-            }
-            QTreeView::item {
-                border: 1px solid #3c3c3c;
-                border-right: none;
-                border-bottom: none;
-            }
-            QTreeView::item:selected {
-                background-color: #4f4f4f;
-                color: white;
-            }
-            """
-        )
-
         self._tree_view.setModel(self._model)
         self._tree_view.setColumnWidth(0, 400)
         self._tree_view.setColumnWidth(1, 200)
-        self._tree_view.setEditTriggers(
-            QAbstractItemView.NoEditTriggers)
 
         self._table.setWidget(self._tree_view)
         self._table.showMaximized()
@@ -267,7 +260,7 @@ class RunProfiling(_gui_common.PilotFeature):
     def _add_result_window(self, result):
         self._table = self._mgr.addSubWindow(QWidget())
         self._table.setWindowTitle("Profiling result")
-        self._tree_view = QTreeView(self._table)
+        self._tree_view = _ResultTree(self._table)
 
         self._model = QStandardItemModel(self._tree_view)
         self._model.setHorizontalHeaderLabels(
@@ -302,31 +295,10 @@ class RunProfiling(_gui_common.PilotFeature):
             for child_data in data["children"]:
                 _recursive_add_item(first, child_data, data['total_time'])
 
-        self._tree_view.setStyleSheet(
-            """
-            QTreeView {
-                background-color: #2e2e2e;
-                color: #dcdcdc;
-                border: 1px solid #555555;
-            }
-            QTreeView::item {
-                border: 1px solid #3c3c3c;
-                border-right: none;
-                border-bottom: none;
-            }
-            QTreeView::item:selected {
-                background-color: #4f4f4f;
-                color: white;
-            }
-            """
-        )
-
         self._tree_view.setModel(self._model)
         self._tree_view.setColumnWidth(0, 200)
         self._tree_view.setColumnWidth(1, 200)
         self._tree_view.setColumnWidth(1, 200)
-        self._tree_view.setEditTriggers(
-            QAbstractItemView.NoEditTriggers)
 
         self._table.setWidget(self._tree_view)
         self._table.show()

--- a/solvcon/pilot/panel/_style.py
+++ b/solvcon/pilot/panel/_style.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The style rules the pilot's dock panels are drawn with.
+
+A rule here says only what the palette does not already give the widget.
+"""
+
+from .._style import RuleCatalog, Shades
+
+__all__ = [
+    'Rules',
+]
+
+_TITLE_PX = 14
+
+# How far a hovered section header sits from the panel.
+_GRID_MIX = 0.12
+_HOVER_MIX = 0.12
+
+
+class Rules(RuleCatalog):
+    """One method per role the pilot's dock panels draw."""
+
+    @staticmethod
+    def tree(shades):
+        """The grid and the selection a profiling result is read against.
+
+        The surface and the text are left to the palette a view already
+        draws itself from, so the rules add only the grid the numbers are
+        read against and the accent on the selected row. The grid is a border
+        on each item, so its shade is mixed off that surface rather than off
+        the panel around it.
+        """
+        grid = Shades.blend(shades.base, shades.on_base, _GRID_MIX)
+        return f"""
+            QTreeView {{
+                border: 1px solid {shades.border.name()};
+            }}
+            QTreeView::item {{
+                border: 1px solid {grid.name()};
+                border-right: none;
+                border-bottom: none;
+            }}
+            QTreeView::item:selected {{
+                background-color: {shades.accent.name()};
+                color: {shades.on_accent.name()};
+            }}
+            """
+
+    @staticmethod
+    def fold(shades):
+        """The header a collapsible section folds from."""
+        return f"""
+            QPushButton {{
+                border: none;
+                font-weight: bold;
+                font-size: {_TITLE_PX}px;
+                padding: 4px 6px;
+                text-align: left;
+            }}
+            QPushButton:hover {{
+                background: {shades.raised(_HOVER_MIX).name()};
+            }}
+            """
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -18,8 +18,10 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget,
                                QSizePolicy, QAbstractButton)
 
 from ... import core
+from .._style import PaletteStyled
 from ..base import _gui_common
 from ..visual import _mesh
+from ._style import Rules
 
 __all__ = [  # noqa: F822
     'TreePanelBase',
@@ -271,7 +273,7 @@ class MeshInfoTree(TreePanelBase):
             self.normals_toggled(checked)
 
 
-class _CollapsibleSection(QWidget):
+class _CollapsibleSection(PaletteStyled):
     """A titled block that folds to just its header when the header is clicked.
 
     Toggling the header shows or hides the body and emits :attr:`toggled`. A
@@ -294,19 +296,7 @@ class _CollapsibleSection(QWidget):
         self._toggle.setChecked(True)
         self._toggle.setFlat(True)
         self._toggle.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        self._toggle.setStyleSheet(
-            """
-            QPushButton {
-                border: none;
-                font-weight: bold;
-                font-size: 14px;
-                padding: 4px 6px;
-                text-align: left;
-            }
-            QPushButton:hover {
-                background: rgba(127, 127, 127, 40);
-            }
-            """)
+        self._apply_style()
         self._sync_toggle_text(True)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -314,6 +304,9 @@ class _CollapsibleSection(QWidget):
         layout.addWidget(self._toggle)
         layout.addWidget(self._body, 1 if fill else 0)
         self._toggle.toggled.connect(self._on_toggled)
+
+    def _apply_style(self):
+        self._toggle.setStyleSheet(Rules.sheet(self, "fold"))
 
     def _sync_toggle_text(self, expanded):
         arrow = self._ARROW_OPEN if expanded else self._ARROW_SHUT

--- a/tests/test_pilot_panel_style.py
+++ b/tests/test_pilot_panel_style.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests that the pilot's dock panels take their colors from the palette.
+"""
+
+import re
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.panel import _profiling, _tree_panel
+    from PySide6 import QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+#: Two palettes far enough apart that no shade mixed from one can fall in the
+#: other, so a color the rules name themselves shows up in both.
+LIGHT = ("#f4f4f4", "#101010", "#ffffff", "#1a5fd0", "#ffffff")
+DARK = ("#242424", "#e8e8e8", "#1a1a1a", "#6ea8ff", "#08121f")
+
+
+def _palette(window, text, base, accent, on_accent):
+    """A palette of the colors the panel rules are mixed from."""
+    palette = QtGui.QPalette()
+    for role, color in ((QtGui.QPalette.Window, window),
+                        (QtGui.QPalette.WindowText, text),
+                        (QtGui.QPalette.Base, base),
+                        (QtGui.QPalette.Text, text),
+                        (QtGui.QPalette.Highlight, accent),
+                        (QtGui.QPalette.HighlightedText, on_accent)):
+        palette.setColor(role, QtGui.QColor(color))
+    return palette
+
+
+def _colors(sheet):
+    """Every color the style rules name."""
+    return set(re.findall(r"#[0-9a-fA-F]{6}", sheet.lower()))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class ProfilingResultTreeTC(unittest.TestCase):
+    """That a profiling result is colored by the theme it is read under."""
+
+    @classmethod
+    def setUpClass(cls):
+        # No window needed, only a live QGuiApplication to hold a widget.
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.app = QtWidgets.QApplication.instance()
+        self.mgr = pilot.RManager.instance
+        self.addCleanup(self.mgr.set_theme, self.mgr.theme_mode)
+        self.tree = _profiling._ResultTree()
+
+    def _sheet(self, mode):
+        """The rules the tree wears under the ``mode`` theme."""
+        self.mgr.set_theme(mode)
+        self.app.processEvents()
+        return self.tree.styleSheet()
+
+    def _accents(self):
+        palette = self.app.palette()
+        return {palette.color(role).name().lower()
+                for role in (QtGui.QPalette.Highlight,
+                             QtGui.QPalette.HighlightedText)}
+
+    def _shades(self, mode):
+        """The colors the rules mix off the surface under ``mode``.
+
+        The accent pair is left out because the curated themes carry one
+        accent through a light/dark switch, so only a mixed shade has to
+        move.
+        """
+        return _colors(self._sheet(mode)) - self._accents()
+
+    def test_the_tree_mixes_its_shades_from_the_theme(self):
+        # A color the rules name themselves survives a theme switch, so it
+        # shows up on both sides of this and the sets intersect.
+        self.assertFalse(self._shades("light") & self._shades("dark"))
+
+    def test_the_selected_row_wears_the_accent(self):
+        sheet = self._sheet("dark")
+        accent = self.app.palette().color(QtGui.QPalette.Highlight)
+        self.assertIn(accent.name().lower(), _colors(sheet))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class CollapsibleSectionTC(unittest.TestCase):
+    """That the section header is colored by the palette it sits on."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.section = _tree_panel._CollapsibleSection(
+            "Mesh", QtWidgets.QWidget())
+
+    def _sheet(self, palette):
+        self.section.setPalette(_palette(*palette))
+        return self.section._toggle.styleSheet()
+
+    def test_the_header_takes_its_hover_from_the_palette(self):
+        # A translucent grey would read as a hover on either palette while
+        # Qt mixed it against whatever sat behind it, not against the theme.
+        self.assertNotIn("rgba", self._sheet(LIGHT))
+        self.assertFalse(_colors(self._sheet(LIGHT))
+                         & _colors(self._sheet(DARK)))
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Every pilot widget that wanted a look wrote its own style sheet inline, and the panel sheets named dark hex values directly, so the profiling tree stayed dark under a light theme.

`solvcon/pilot/_style` now holds the shared pieces: `Shades` for the colors a widget reads off its palette, `RuleCatalog` for composing a sheet out of named roles, and the `PaletteStyle` mixin that re-applies a sheet when the palette changes. `painter/_style` and `panel/_style` subclass `RuleCatalog` with one method per role, and a widget asks `Rules.sheet()` for the roles it draws.

The painter pages come out at the colors and metrics they had. The profiling result trees and the collapsible section header change on screen: they now mix every color from the palette and follow a theme switch.

Related to #1233.
