### PR TITLE
Take the panel style test off the application theme

### DIFF
--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -3,6 +3,7 @@
 
 
 import os
+import re
 import unittest
 
 import solvcon
@@ -10,6 +11,7 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
+    from solvcon.pilot.panel import _profiling
     from PySide6 import QtWidgets
     from PySide6.QtCore import QSettings, QStandardPaths
     from PySide6.QtGui import QColor, QPalette
@@ -319,6 +321,41 @@ class ThemeConsoleTC(unittest.TestCase):
         for edit in self._console_edits():
             self.assertLess(
                 edit.palette().color(QPalette.Text).lightness(), 100)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class ThemePanelTC(unittest.TestCase):
+    """A dock panel mixes the shades the palette does not give it into a
+    style sheet of its own, so it follows the theme only because the switch
+    reaches it as a palette change.
+
+    That the shades come off the palette at all is
+    ``tests/test_pilot_panel_style.py``'s subject; this is the switch.
+    """
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    @staticmethod
+    def _sheet_lightness(tree):
+        """The average lightness of the colors the tree's rules name."""
+        colors = re.findall(r"#[0-9a-fA-F]{6}", tree.styleSheet())
+        return sum(QColor(name).lightness() for name in colors) / len(colors)
+
+    def test_an_open_profiling_tree_follows_a_later_switch(self):
+        # The tree is built first and the theme changed after, the path that
+        # used to leave a dark tree sitting in a light panel.
+        tree = _profiling._ResultTree()
+        self.mgr.set_theme("dark")
+        dark = self._sheet_lightness(tree)
+        self.mgr.set_theme("light")
+        self.assertLess(dark, self._sheet_lightness(tree))
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_panel_style.py
+++ b/tests/test_pilot_panel_style.py
@@ -43,49 +43,41 @@ def _colors(sheet):
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class ProfilingResultTreeTC(unittest.TestCase):
-    """That a profiling result is colored by the theme it is read under."""
+    """That a profiling result is colored by the palette it is read under.
+
+    The palette is set on the tree rather than switched on the application,
+    which would repaint the whole pilot window; on macOS the native style
+    faults painting one into a backing store that no screen is behind. What
+    a theme switch does to the application palette is
+    ``tests/gui/test_theme.py``'s subject.
+    """
 
     @classmethod
     def setUpClass(cls):
         # No window needed, only a live QGuiApplication to hold a widget.
         pilot.RManager.instance.setUp()
 
-    def setUp(self):
-        self.app = QtWidgets.QApplication.instance()
-        self.mgr = pilot.RManager.instance
-        self.addCleanup(self.mgr.set_theme, self.mgr.theme_mode)
-        self.tree = _profiling._ResultTree()
+    def _tree(self, palette):
+        """A tree wearing the ``palette``.
 
-    def _sheet(self, mode):
-        """The rules the tree wears under the ``mode`` theme."""
-        self.mgr.set_theme(mode)
-        self.app.processEvents()
-        return self.tree.styleSheet()
-
-    def _accents(self):
-        palette = self.app.palette()
-        return {palette.color(role).name().lower()
-                for role in (QtGui.QPalette.Highlight,
-                             QtGui.QPalette.HighlightedText)}
-
-    def _shades(self, mode):
-        """The colors the rules mix off the surface under ``mode``.
-
-        The accent pair is left out because the curated themes carry one
-        accent through a light/dark switch, so only a mixed shade has to
-        move.
+        A fresh one each time, because the style sheet a tree applies for its
+        first palette pins the colors Qt re-polishes it with, and a second
+        palette on the same tree snaps back to them.
         """
-        return _colors(self._sheet(mode)) - self._accents()
+        tree = _profiling._ResultTree()
+        tree.setPalette(_palette(*palette))
+        return tree
 
-    def test_the_tree_mixes_its_shades_from_the_theme(self):
-        # A color the rules name themselves survives a theme switch, so it
+    def test_the_tree_mixes_its_shades_from_the_palette(self):
+        # A color the rules name themselves survives both palettes, so it
         # shows up on both sides of this and the sets intersect.
-        self.assertFalse(self._shades("light") & self._shades("dark"))
+        self.assertFalse(_colors(self._tree(LIGHT).styleSheet())
+                         & _colors(self._tree(DARK).styleSheet()))
 
     def test_the_selected_row_wears_the_accent(self):
-        sheet = self._sheet("dark")
-        accent = self.app.palette().color(QtGui.QPalette.Highlight)
-        self.assertIn(accent.name().lower(), _colors(sheet))
+        tree = self._tree(DARK)
+        accent = tree.palette().color(QtGui.QPalette.Highlight)
+        self.assertIn(accent.name().lower(), _colors(tree.styleSheet()))
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
The macOS `lint` job has segfaulted since #1242: `ProfilingResultTreeTC` switches `RManager`'s theme and pumps the event loop, which repaints the whole pilot window, and under `QT_QPA_PLATFORM=offscreen` the mac style faults painting one into a backing store that no screen is behind. The test only needs the tree's own palette, so it now sets that directly and never touches the theme. `ThemePanelTC` in `tests/gui/test_theme.py` keeps the switch itself covered, behind the `NO_LIVE_WINDOW` guard the rest of that file uses.

Related to #1233.
