### PR TITLE
Rename the world change stamp to state_stamp and drop a stale Makefile comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,6 @@ pytest: buildext
 	env $(RUNENV) \
 		$(PYTEST) $(PYTEST_OPTS) tests/
 
-# The tests under tests/gui/ drive real top-level windows, so they are the
-# slow half of the suite and the half a headless machine cannot run at all.
-# pytest runs everything; these two run one side of that split. Use
-# pytest-fast while iterating on something that is not the GUI, and
-# pytest-gui when the change is.
 .PHONY: pytest-fast
 pytest-fast: buildext
 	env $(RUNENV) \

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -506,7 +506,7 @@ public:
 
     size_t nshape() const { return m_nshape; }
 
-    uint64_t version() const { return m_version; }
+    uint64_t state_stamp() const { return m_state_stamp; }
 
     /**
      * True if `shape_id` refers to a live (non-DEAD) shape. Unlike the
@@ -589,8 +589,8 @@ public:
 
 private:
 
-    /// Stamp the world as changed; see version().
-    void mark_changed() { ++m_version; }
+    /// Stamp the world as changed; see state_stamp().
+    void mark_changed() { ++m_state_stamp; }
 
     /// 2D endpoints of segment i, as [x0, y0, x1, y1].
     std::vector<double> segment_coords(size_t i) const
@@ -709,7 +709,7 @@ private:
     std::vector<ShapeRecord> m_shape_registry;
 
     size_t m_nshape = 0; ///< Count of live (non-DEAD) shapes.
-    uint64_t m_version = 0; ///< Moves on every change; see version().
+    uint64_t m_state_stamp = 0; ///< Moves on every change; see state_stamp().
     std::unique_ptr<rtree_type> m_rtree; ///< Spatial index for shapes for viewport query.
 
     /// The kind of an undoable shape change.

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -74,8 +74,8 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
     (*this)
         .def_property_readonly("nshape", &wrapped_type::nshape)
         .def_property_readonly(
-            "version",
-            &wrapped_type::version,
+            "state_stamp",
+            &wrapped_type::state_stamp,
             "A stamp that changes whenever what the world draws does. The "
             "number means nothing on its own; a different one is a different "
             "world.")

--- a/solvcon/pilot/painter/_layers.py
+++ b/solvcon/pilot/painter/_layers.py
@@ -299,7 +299,7 @@ class LayersPage(PaletteStyled):
         draws, the selection it marks, and the world's change stamp.
         """
         world, selected = self._selection()
-        return None if world is None else (world, selected, world.version)
+        return None if world is None else (world, selected, world.state_stamp)
 
     def _content(self):
         """What the rows show, read from the world the page is bound to."""

--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -670,7 +670,7 @@ class EntityTreeWidget(TreePanelBase):
 
     def _describe(self, world, level):
         """Return the cached ``describe_state`` JSON for ``level``."""
-        fingerprint = (world, world.version)
+        fingerprint = (world, world.state_stamp)
         if fingerprint != self._fingerprint:
             self._fingerprint = fingerprint
             self._cache = {}

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -360,7 +360,7 @@ class WorldPrimitivesTC(unittest.TestCase):
             self.w.add_polygon([[0, 0], [1, 1]])
 
 
-class WorldVersionTC(unittest.TestCase):
+class WorldStateStampTC(unittest.TestCase):
     """The stamp that tells a reader the world has changed."""
 
     def setUp(self):
@@ -368,9 +368,9 @@ class WorldVersionTC(unittest.TestCase):
 
     def _changed_by(self, act):
         """Return whether ``act`` moved the stamp."""
-        before = self.w.version
+        before = self.w.state_stamp
         act()
-        return self.w.version != before
+        return self.w.state_stamp != before
 
     def test_every_way_of_adding_geometry_moves_it(self):
         # A reader compares the stamp instead of the geometry, so anything the
@@ -417,13 +417,13 @@ class WorldVersionTC(unittest.TestCase):
         # Only edits move the stamp; a query that moved it would have every
         # reader redrawing on its own reads.
         sid = self.w.add_circle(0, 0, 1)
-        before = self.w.version
+        before = self.w.state_stamp
         self.w.describe_state()
         self.w.shape_bbox(sid)
         self.w.shape_obb(sid)
         self.w.pick_shape(0, 0, 0.1)
         self.w.shape_is_live(sid)
-        self.assertEqual(self.w.version, before)
+        self.assertEqual(self.w.state_stamp, before)
 
     def test_reaching_past_the_world_into_its_pads_is_not_seen(self):
         # The stamp covers what goes through the world. A caller that writes
@@ -431,17 +431,17 @@ class WorldVersionTC(unittest.TestCase):
         # what the accessors' own documentation warns of.
         self.w.add_segment(solvcon.Point3dFp64(0, 0, 0),
                            solvcon.Point3dFp64(1, 1, 0))
-        before = self.w.version
+        before = self.w.state_stamp
         self.w.segments.set_at(0, 5.0, 5.0, 6.0, 6.0)
-        self.assertEqual(self.w.version, before)
+        self.assertEqual(self.w.state_stamp, before)
 
     def test_an_edit_that_changes_nothing_leaves_it_alone(self):
         # A drag's first event often lands on the press point, and the world
         # takes that as no move at all.
         sid = self.w.add_rectangle(0, 0, 2, 1)
-        before = self.w.version
+        before = self.w.state_stamp
         self.w.translate_shape(sid, 0, 0)
-        self.assertEqual(self.w.version, before)
+        self.assertEqual(self.w.state_stamp, before)
 
 
 class WorldUndoRedoTC(unittest.TestCase):


### PR DESCRIPTION
The review of #1240 questioned `version` as the name for the world's change stamp. The name suggests a release number or a schema revision, and the value is neither: it counts edits to the world state so a reader can tell that what it drew is stale. This renames it to `state_stamp` across the accessor, the member, the pybind11 property, and the two pollers that read it (the Layers page's poll key and the entity tree's describe cache), along with the test case that covers it. The stamp's semantics are untouched.

The review of #1235 asked for the comment block over `pytest-fast` and `pytest-gui` to go, since the `tests/gui` path name already says what the split is. It is removed.

Related to #1222 and #1241.
