### PR TITLE
Add a CMake user preset template for scdv

### DIFF
--- a/.claude/skills/cmake-user-presets/SKILL.md
+++ b/.claude/skills/cmake-user-presets/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: cmake-user-presets
+description: Install or refresh CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `scdv-rel` preset carries a real path. Use in a fresh checkout or worktree, when `scdv-rel` is missing from `cmake --list-presets`, or after the template changes.
+---
+
+# CMake User Presets (solvcon)
+
+`CMakeUserPresets.json` is gitignored, so every fresh checkout and every new
+worktree starts without it and without the `scdv-rel` preset. The `scdv`
+templates in `contrib/cmake/` name the prefix once, as `$penv{SCDV_USRDIR}` in
+the preset's `environment` map, and the three cache variables read it back
+from there as `$env{SCDV_USRDIR}`. Installing one is a copy with that single
+occurrence replaced by the prefix it names.
+
+Substituting rather than leaving the expansion in place is the whole point.
+An IDE started from the desktop inherits the session environment, not the
+shell where an scdv was activated, so `$penv{SCDV_USRDIR}` would expand to
+nothing there and the preset would configure against empty paths. A real path
+in the installed file works in a shell, in a desktop IDE, and in an agent
+session alike.
+
+## When to use
+
+A checkout has no `CMakeUserPresets.json`, `cmake --list-presets` does not
+offer `scdv-rel`, an IDE cannot find Qt6 or pybind11, or the template in
+`contrib/cmake/` changed and the installed copy is stale. The `worktree` skill
+calls this after creating a worktree.
+
+## 1. Resolve the scdv prefix
+
+The substitution needs a prefix, so resolve one before touching the file:
+`$SCDV_USRDIR` when a shell has an scdv activated, `$SCDV_BASE/usr` when the
+user names an environment, or the `usr` directory of a build under
+`~/var/scdv/`. Do not invent a path and do not fall back to a system prefix.
+
+Carry the result in a shell variable, because only the first of those three is
+already one:
+
+```bash
+PREFIX=${SCDV_USRDIR:-${SCDV_BASE:?resolve an scdv prefix first}/usr}
+```
+
+Report which environment was used. A machine often holds several, and the
+installed file pins the one that was resolved.
+
+Stop and ask when nothing resolves. An unsubstituted file is worse than no
+file: CMake reports missing packages rather than a missing environment.
+
+## 2. Install or refresh
+
+Work from the repository root (`git rev-parse --show-toplevel`), which in a
+worktree is the worktree, not the main checkout. Pick the template for the
+host: `CMakeUserPresets.scdv.json` on Linux and macOS,
+`CMakeUserPresets.win-scdv.json` on Windows. The `example` files beside them
+are for a prefix that is not an scdv and are hand-edited, not installed from
+here.
+
+```bash
+sed "s|\$penv{SCDV_USRDIR}|${PREFIX}|g" \
+    contrib/cmake/CMakeUserPresets.scdv.json > CMakeUserPresets.json
+```
+
+```powershell
+(Get-Content contrib\cmake\CMakeUserPresets.win-scdv.json -Raw).Replace(
+    '$penv{SCDV_USRDIR}', $prefix) |
+    Set-Content CMakeUserPresets.json
+```
+
+When the file already exists, render to a scratch path and compare. Identical
+output means the installed copy is current, so say so and stop. A difference
+is either a stale template or the user's own presets, which the diff tells
+apart: show it and ask before overwriting.
+
+Never commit the result and never move a machine path into
+`CMakePresets.json`.
+
+## 3. Verify
+
+The `SCDV_USRDIR` entry has to name a directory that exists. Checking for a
+leftover `penv{` is not enough: an empty `PREFIX` substitutes cleanly and
+leaves `"SCDV_USRDIR": ""`, which passes that grep and then fails a configure
+with missing packages instead of a missing environment.
+
+```bash
+test -d "$(sed -n 's/.*"SCDV_USRDIR": "\(.*\)".*/\1/p' CMakeUserPresets.json)"
+```
+
+The remaining `$env{SCDV_USRDIR}` in the cache variables is correct, and
+resolves from the `environment` map above them. Then `cmake --list-presets`
+has to show `scdv-rel`, and `cmake --list-presets=build` has to show
+`scdv-rel`, `scdv-rel-module`, and `scdv-rel-gtest`. Report the preset names
+and the prefix they carry; do not configure or build unless the user asked for
+it.
+
+Both listings have to work with the scdv deactivated, which is what an IDE
+sees. `env -u SCDV_USRDIR cmake --list-presets` is the cheap way to prove it.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -17,7 +17,11 @@ Based on the agent type, do one of the following:
 - **Cursor:**  use Cursors's builtin `/worktree` command instead. If the built-in command is unavailable, fall back like Codex below.
 - **Codex, otherwise:** run `git worktree add -b worktree-<name> .claude/worktrees/<name> origin/master`, then run all commands from it.
 
-## 2. Do the task
+## 2. Seed the local CMake presets
+
+A new worktree is a fresh checkout, so it has no `CMakeUserPresets.json` and no `scdv-rel` preset. Install one with the `cmake-user-presets` skill before the first configure. Skip it when the task touches no build.
+
+## 3. Do the task
 
 Implement `<description>` in the worktree. Follow normal project rules. Stop when done; do not auto-commit, open a PR, or remove the worktree unless asked.
 

--- a/contrib/cmake/CMakeUserPresets.example.json
+++ b/contrib/cmake/CMakeUserPresets.example.json
@@ -4,7 +4,7 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "local",
+      "name": "local-rel",
       "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
@@ -20,22 +20,22 @@
   ],
   "buildPresets": [
     {
-      "name": "local",
+      "name": "local-rel",
       "inherits": "dev-rel",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix"
+      "configurePreset": "local-rel",
+      "displayName": "local rel"
     },
     {
-      "name": "local-module",
+      "name": "local-rel-module",
       "inherits": "dev-rel-module",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix, module only"
+      "configurePreset": "local-rel",
+      "displayName": "local rel module"
     },
     {
-      "name": "local-gtest",
+      "name": "local-rel-gtest",
       "inherits": "dev-rel-gtest",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix, C++ test binary"
+      "configurePreset": "local-rel",
+      "displayName": "local rel gtest"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.scdv.json
+++ b/contrib/cmake/CMakeUserPresets.scdv.json
@@ -1,0 +1,44 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "configurePresets": [
+    {
+      "name": "scdv-rel",
+      "inherits": "dev-rel",
+      "displayName": "scdv dependency prefix",
+      "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
+      "environment": {
+        "SCDV_USRDIR": "$penv{SCDV_USRDIR}"
+      },
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "$env{SCDV_USRDIR}/bin/python3"
+        },
+        "pybind11_path": "$env{SCDV_USRDIR}/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "$env{SCDV_USRDIR}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "scdv-rel",
+      "inherits": "dev-rel",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel"
+    },
+    {
+      "name": "scdv-rel-module",
+      "inherits": "dev-rel-module",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel module"
+    },
+    {
+      "name": "scdv-rel-gtest",
+      "inherits": "dev-rel-gtest",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel gtest"
+    }
+  ]
+}

--- a/contrib/cmake/CMakeUserPresets.win-example.json
+++ b/contrib/cmake/CMakeUserPresets.win-example.json
@@ -4,14 +4,14 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "local",
+      "name": "local-rel",
       "inherits": "win-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
-          "value": "C:/path/to/prefix/python3.exe"
+          "value": "C:/path/to/prefix/python.exe"
         },
         "pybind11_path": "C:/path/to/prefix/Lib/site-packages/pybind11/share/cmake/pybind11",
         "CMAKE_PREFIX_PATH": "C:/path/to/prefix"
@@ -20,22 +20,22 @@
   ],
   "buildPresets": [
     {
-      "name": "local",
+      "name": "local-rel",
       "inherits": "win-rel",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix"
+      "configurePreset": "local-rel",
+      "displayName": "local rel"
     },
     {
-      "name": "local-module",
+      "name": "local-rel-module",
       "inherits": "win-rel-module",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix, module only"
+      "configurePreset": "local-rel",
+      "displayName": "local rel module"
     },
     {
-      "name": "local-gtest",
+      "name": "local-rel-gtest",
       "inherits": "win-rel-gtest",
-      "configurePreset": "local",
-      "displayName": "Local dependency prefix, C++ test binary"
+      "configurePreset": "local-rel",
+      "displayName": "local rel gtest"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.win-scdv.json
+++ b/contrib/cmake/CMakeUserPresets.win-scdv.json
@@ -1,0 +1,44 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "configurePresets": [
+    {
+      "name": "scdv-rel",
+      "inherits": "win-rel",
+      "displayName": "scdv dependency prefix",
+      "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
+      "environment": {
+        "SCDV_USRDIR": "$penv{SCDV_USRDIR}"
+      },
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "$env{SCDV_USRDIR}/python.exe"
+        },
+        "pybind11_path": "$env{SCDV_USRDIR}/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "$env{SCDV_USRDIR}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "scdv-rel",
+      "inherits": "win-rel",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel"
+    },
+    {
+      "name": "scdv-rel-module",
+      "inherits": "win-rel-module",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel module"
+    },
+    {
+      "name": "scdv-rel-gtest",
+      "inherits": "win-rel-gtest",
+      "configurePreset": "scdv-rel",
+      "displayName": "scdv rel gtest"
+    }
+  ]
+}

--- a/doc/source/devguide/cmake.md
+++ b/doc/source/devguide/cmake.md
@@ -117,7 +117,7 @@ no wrapper script to fall back on there.
 
 There is one template per host family, because the checked-in presets a user
 preset builds on are themselves split by host.  Copy the one for your host and
-edit the paths:
+edit the three paths:
 
 ```bash
 # Linux and macOS
@@ -126,16 +126,16 @@ cp contrib/cmake/CMakeUserPresets.example.json CMakeUserPresets.json
 cp contrib/cmake/CMakeUserPresets.win-example.json CMakeUserPresets.json
 ```
 
-Each template defines a configure preset named `local` that inherits a
-checked-in preset and adds the three variables, plus the three build presets
-that go with it:
+Each defines a configure preset named `local-rel` that inherits a checked-in
+preset and adds the three variables, plus the three build presets that go with
+it:
 
 ```json
 {
   "version": 10,
   "configurePresets": [
     {
-      "name": "local",
+      "name": "local-rel",
       "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "cacheVariables": {
@@ -149,27 +149,37 @@ that go with it:
     }
   ],
   "buildPresets": [
-    { "name": "local", "inherits": "dev-rel", "configurePreset": "local" }
+    { "name": "local-rel", "inherits": "dev-rel",
+      "configurePreset": "local-rel" }
   ]
 }
 ```
 
 Every `inherits` in the file names a preset of one host family, and they have
 to stay a matched set.  A `dev-` build preset carries a condition that
-disables it on Windows and a `win-` one carries the opposite, so a `local`
+disables it on Windows and a `win-` one carries the opposite, so a `local-rel`
 that inherits a `win-` configure preset and `dev-` build presets configures
 and then refuses to build.  Change them together, or start from the template
 for the family you want.
 
-`pybind11_path` is what `python3 -m pybind11 --cmakedir` prints for the
-interpreter named above it.  After that, `cmake --preset local` configures
-from a bare checkout, and `local` appears in the IDE preset pickers alongside
-the checked-in presets.
+`pybind11_path` names the directory holding `pybind11Config.cmake`, which is
+what `python3 -m pybind11 --cmakedir` prints for the interpreter named above
+it.  After that, `cmake --preset local-rel` configures from a bare checkout,
+and `local-rel` appears in the IDE preset pickers alongside the checked-in
+presets.
 
 In CLion the `enablePythonIntegration` key in the `jetbrains.com/clion` vendor
 map, already set in the checked-in presets, hands the IDE's selected
 interpreter to the configure step.  A CLion user can therefore drop the
 `PYTHON_EXECUTABLE` line and keep only the other two.
+
+`CMakeUserPresets.scdv.json` and `CMakeUserPresets.win-scdv.json` sit beside
+the two templates above for a prefix that `build-scdv.sh` built (see
+{doc}`/start/build_dep`).  Their configure preset is `scdv-rel`, and it names
+that prefix once rather than repeating it in three literal paths, so
+installing one substitutes a single value instead of editing three.  The
+`cmake-user-presets` skill under `.claude/skills/` states the substitution and
+what has to hold for it.
 
 ## IDE notes
 

--- a/doc/source/start/build_dep.md
+++ b/doc/source/start/build_dep.md
@@ -39,6 +39,10 @@ it to put the freshly built Python and Qt on your `PATH`, and run
 source ${HOME}/var/scdv/<platform>-py<pyver>-qt<qtver>/activate
 ```
 
+The activation exports `SCDV_USRDIR`, the prefix that
+`contrib/cmake/CMakeUserPresets.scdv.json` is installed with; see
+{doc}`/devguide/cmake` for what that file is for.
+
 Two toolchains sit outside the build sections, so `--print-deps` ends with
 them. The first is LaTeX. Building the documentation needs it even for plain
 HTML, because the `pstake` extension renders the PSTricks figures through


### PR DESCRIPTION
`CMakeUserPresets.json` names three directories that exist on one machine only, and the templates for it asked every checkout to type all three by hand. `contrib/dependency/build-scdv.sh` already knows them.

The PR adds `CMakeUserPresets.scdv.json` and `CMakeUserPresets.win-scdv.json` beside the example pair, which keeps its literal paths for a prefix built by hand.

Add a new skill `cmake-user-presets` to install the user presets.  Update the `worktree` skill to call it right after creating the worktree.