### PR TITLE
Give the agent a scene inventory and a replayed conversation (step 2)

### DIFF
--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -13,19 +13,24 @@ applied command into a transcript a caller can render.  No Qt is imported.
 import json
 import dataclasses
 
+from . import _backend
+from . import _command
+
 
 @dataclasses.dataclass
 class TranscriptTurn:
     """One transcript entry: a ``role`` with its text, commands, and results.
 
     ``results`` holds ``CommandResult`` objects (or any object with an ``ok``
-    attribute).
+    attribute).  ``failed`` marks a turn that went wrong before any command
+    ran, which no result can record.
     """
 
     role: str
     text: str = ""
     commands: list = dataclasses.field(default_factory=list)
     results: list = dataclasses.field(default_factory=list)
+    failed: bool = False
 
 
 @dataclasses.dataclass
@@ -50,22 +55,40 @@ class AgentSession:
     to a lazily built command executor for ``world``.  ``backend`` is an
     :class:`~solvcon.agent.AgentBackend` or ``None``.  Delete commands are
     hidden from the backend and rejected unless ``allow_destructive`` is true.
+    ``hidden_ops`` names the ops to keep off the tool surface, defaulting to
+    :attr:`HIDDEN_OPS`.
     """
 
+    INVENTORY_LIMIT = 40
+    HIDDEN_OPS = frozenset({"render_png"})
+
     def __init__(self, world=None, backend=None, runner=None, renderer=None,
-                 allow_destructive=False):
+                 allow_destructive=False, hidden_ops=None):
         self.world = world
         self.backend = backend
         self._renderer = renderer
         self._runner = runner
         self._runner_injected = runner is not None
         self.allow_destructive = allow_destructive
+        self.hidden_ops = frozenset(
+            self.HIDDEN_OPS if hidden_ops is None else hidden_ops)
         self._transcript = []
 
     @property
     def transcript(self):
         """The recorded turns, oldest first (a copy)."""
         return list(self._transcript)
+
+    def history(self):
+        """The turns to replay to the backend, oldest first.
+
+        Trailing user turns are left out: the composed request already carries
+        the current prompt.
+        """
+        end = len(self._transcript)
+        while end and self._transcript[end - 1].role == "user":
+            end -= 1
+        return self._transcript[:end]
 
     @property
     def runner(self):
@@ -77,10 +100,26 @@ class AgentSession:
     def bind_world(self, world):
         """Point the session at ``world`` for later turns, dropping a lazily
         built runner so the next command batch targets the new world.  A runner
-        passed to the constructor is kept."""
+        passed to the constructor is kept.
+
+        A switch to a different world marks the transcript.  The shape ids in
+        the turns before it name shapes in the world that was open then, so
+        replaying them unmarked beside the new world's inventory would invite
+        a command aimed at an id that now belongs to something else.
+        """
+        if world is not self.world and self._transcript:
+            self._mark("canvas switched")
         self.world = world
         if not self._runner_injected:
             self._runner = None
+
+    def _mark(self, text):
+        """Record ``text`` as a marker turn, unless one already closes the
+        transcript: consecutive markers say nothing the first did not."""
+        role = _backend.HistoryFormatter.MARKER_ROLE
+        if self._transcript[-1].role == role:
+            return
+        self._transcript.append(TranscriptTurn(role=role, text=text))
 
     def _command_provider(self):
         """What answers ``tool_definitions`` and ``commands_by_category``: the
@@ -94,8 +133,16 @@ class AgentSession:
 
     def tool_surface(self):
         """The command tool definitions to hand the backend, with delete ops
-        dropped unless this session allows them."""
-        tools = self._command_provider().tool_definitions()
+        dropped unless this session allows them and :attr:`hidden_ops` dropped
+        always.
+
+        ``render_png`` is hidden by default: a session with no renderer cannot
+        run it, and its inline base64 result fits no prompt budget.  A caller
+        that does inject a renderer passes its own ``hidden_ops`` to get the op
+        back.
+        """
+        tools = [tool for tool in self._command_provider().tool_definitions()
+                 if tool["name"] not in self.hidden_ops]
         if self.allow_destructive:
             return tools
         return [tool for tool in tools if tool["category"] != "delete"]
@@ -106,10 +153,37 @@ class AgentSession:
         by_category = self._command_provider().commands_by_category()
         return set(by_category.get("delete", ()))
 
+    @staticmethod
+    def _bbox_text(bbox):
+        """One shape's bounding box, or ``[?]`` when it has none to report."""
+        try:
+            x_min, y_min, x_max, y_max = bbox
+            return "[%g, %g, %g, %g]" % (x_min, y_min, x_max, y_max)
+        except (TypeError, ValueError):
+            return "[?]"
+
+    @classmethod
+    def _inventory(cls, shapes):
+        """Per-shape id, type, and bounding box; geometry from
+        ``describe_state`` is omitted for prompt size.  A crowded world keeps
+        the newest :attr:`INVENTORY_LIMIT` shapes and counts the rest."""
+        if not shapes:
+            return []
+        lines = ["shapes (#id type [x_min, y_min, x_max, y_max]):"]
+        hidden = len(shapes) - cls.INVENTORY_LIMIT
+        if hidden > 0:
+            lines.append("  ... %d earlier shapes" % hidden)
+        for shape in shapes[-cls.INVENTORY_LIMIT:]:
+            lines.append("  #%s %s %s"
+                         % (shape.get("id", "?"), shape.get("type", "?"),
+                            cls._bbox_text(shape.get("bbox"))))
+        return lines
+
     def scene_context(self, level="basic"):
-        """A short text summary of the world for the model: the shape count
-        and distinct types from ``world.describe_state(...)`` (JSON), or a
-        plain count when it cannot be described."""
+        """A text summary of the world for the model: the shape count and
+        distinct types from ``world.describe_state(...)`` (JSON) followed by
+        the per-shape inventory, or a plain count when it cannot be
+        described."""
         world = self.world
         if world is None:
             return "no active world"
@@ -120,15 +194,9 @@ class AgentSession:
         shapes = state.get("shapes", [])
         types = sorted({s["type"] for s in shapes if "type" in s})
         kinds = ", ".join(types) if types else "none"
-        return "world with %d shapes (types: %s)" % (len(shapes), kinds)
-
-    @staticmethod
-    def _op_of(command):
-        """The command's declared ``op``, or ``"?"`` when it names none."""
-        if not isinstance(command, dict):
-            return "?"
-        op = command.get("op")
-        return op if isinstance(op, str) else "?"
+        lines = ["world with %d shapes (types: %s)" % (len(shapes), kinds)]
+        lines.extend(self._inventory(shapes))
+        return "\n".join(lines)
 
     def _execute(self, commands):
         """Run each command in order and return one result per command.
@@ -144,21 +212,21 @@ class AgentSession:
             return []
         blocked = set() if self.allow_destructive else self._gated_ops()
         allowed = [command for command in commands
-                   if self._op_of(command) not in blocked]
+                   if _command.op_of(command) not in blocked]
         if not allowed:
             return [_OutcomeStub(
-                self._op_of(command),
+                _command.op_of(command),
                 error="destructive command %r is disabled for this session"
-                % self._op_of(command)) for command in commands]
+                % _command.op_of(command)) for command in commands]
         try:
             runner = self.runner
         except Exception as exc:
             error = "%s: %s" % (type(exc).__name__, exc)
-            return [_OutcomeStub(self._op_of(c), error=error)
+            return [_OutcomeStub(_command.op_of(c), error=error)
                     for c in commands]
         results = []
         for command in commands:
-            op = self._op_of(command)
+            op = _command.op_of(command)
             if op in blocked:
                 results.append(_OutcomeStub(
                     op, error="destructive command %r is disabled for this "
@@ -168,15 +236,15 @@ class AgentSession:
                 results.append(runner.run(command))
             except Exception as exc:
                 results.append(_OutcomeStub(
-                    self._op_of(command),
+                    _command.op_of(command),
                     error="%s: %s" % (type(exc).__name__, exc)))
         return results
 
-    def _record_agent(self, text, commands=(), results=()):
+    def _record_agent(self, text, commands=(), results=(), failed=False):
         """Append and return one agent turn."""
         turn = TranscriptTurn(
-            role="agent", text=text,
-            commands=list(commands), results=list(results))
+            role="agent", text=text, commands=list(commands),
+            results=list(results), failed=failed)
         self._transcript.append(turn)
         return turn
 
@@ -208,30 +276,31 @@ class AgentSession:
             parts.append("[error] %s" % response.error)
         commands = list(response.commands)
         return self._record_agent(
-            "\n".join(parts), commands, self._execute(commands))
+            "\n".join(parts), commands, self._execute(commands),
+            failed=bool(response.error))
 
     def fail_turn(self, error):
         """Record a failed agent turn for a backend that raised, so the turn
         still lands in the transcript instead of propagating."""
-        return self._record_agent("[error] %s" % error)
+        return self._record_agent("[error] %s" % error, failed=True)
 
     def run_turn(self, prompt):
-        """Drive one request end to end for a single-turn chat.
+        """Drive one user request end to end.
 
         Record the user's ``prompt``, ask the backend for commands against the
-        current scene and tool surface, run them, and record one agent turn
-        carrying the reply text, the commands, and their results.  With no
-        backend, record only the user turn and return ``None``.  A backend that
-        raises is recorded as a failed agent turn rather than propagated, so a
-        headless caller always gets a turn back.  No prior turns are replayed:
-        multi-turn chat history is a later addition.
+        current scene, tool surface, and the turns so far, run them, and record
+        one agent turn carrying the reply text, the commands, and their
+        results.  With no backend, record only the user turn and return
+        ``None``.  A backend that raises is recorded as a failed agent turn
+        rather than propagated, so a headless caller always gets a turn back.
         """
         self.record_prompt(prompt)
         if self.backend is None:
             return None
         try:
             response = self.backend.send(
-                prompt, self.scene_context(), self.tool_surface())
+                prompt, self.scene_context(), self.tool_surface(),
+                self.history())
         except Exception as exc:
             return self.fail_turn("%s: %s" % (type(exc).__name__, exc))
         return self.complete_turn(response)

--- a/solvcon/pilot/agent/_agent_control.py
+++ b/solvcon/pilot/agent/_agent_control.py
@@ -209,11 +209,12 @@ def build_control_dispatcher(mgr, renderer=None):
 def pilot_scene_context(dispatcher, base):
     """Append a snapshot of the open windows and the active view to ``base``.
 
-    A one-shot backend never sees a command's result, so window ids stay
-    invisible unless the scene carries them; this lists every open window with
-    its id and the active view so the model can target ``activate_window``,
-    ``close_window``, or ``save_image`` without guessing.  The read commands
-    route through ``dispatcher`` so the ids match what the executors assign.
+    A window a request never touched leaves no result to learn its id from, so
+    the ids stay invisible unless the scene carries them; this lists every open
+    window with its id and the active view so the model can target
+    ``activate_window``, ``close_window``, or ``save_image`` without guessing.
+    The read commands route through ``dispatcher`` so the ids match what the
+    executors assign.
     """
     lines = [base]
     windows = dispatcher.run({"op": "list_windows"}).value["windows"]

--- a/solvcon/pilot/agent/_agent_gui.py
+++ b/solvcon/pilot/agent/_agent_gui.py
@@ -7,8 +7,9 @@
 The console sits at the bottom-right, beside the Python console, and runs the
 selected AI backend on the active canvas world for one request at a time.  It
 reuses the headless :class:`~solvcon.agent.AgentSession`, so the drawing logic
-stays Qt-free and testable.  Multi-turn chat history is a later addition: each
-prompt is an independent single turn.
+stays Qt-free and testable.  The session keeps the conversation, so each
+request replays the turns before it; driving several backend steps within one
+request is a later addition.
 """
 
 from itertools import zip_longest
@@ -18,7 +19,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
                                QLabel, QComboBox, QTextEdit, QLineEdit,
                                QPushButton)
 
-from ...agent import AgentSession, BackendRegistry
+from ...agent import AgentBackend, AgentSession, BackendRegistry, op_of
 from . import _agent_control
 from ..base import _gui_common
 
@@ -34,6 +35,8 @@ class AgentBackendWorker(QThread):
 
     Only the backend call runs here, the slow subprocess or HTTP round trip;
     it reads neither Qt nor the world, so it is safe off the main thread.  The
+    turns it replays are snapshotted on the main thread at construction, so a
+    turn recorded meanwhile cannot land in the request being composed.  The
     reply returns through :attr:`succeeded` (a ``BackendResponse``) or
     :attr:`failed` (an error string); the owning panel applies the commands and
     repaints on the main thread, where the connected slots run.
@@ -43,17 +46,19 @@ class AgentBackendWorker(QThread):
     failed = Signal(str)
 
     def __init__(self, backend, prompt, scene_context, tool_surface,
-                 parent=None):
+                 history=(), parent=None):
         super().__init__(parent)
         self._backend = backend
         self._prompt = prompt
         self._scene_context = scene_context
         self._tool_surface = tool_surface
+        self._history = list(history)
 
     def run(self):
         try:
             response = self._backend.send(
-                self._prompt, self._scene_context, self._tool_surface)
+                self._prompt, self._scene_context, self._tool_surface,
+                self._history)
         except Exception as exc:
             self.failed.emit("%s: %s" % (type(exc).__name__, exc))
         else:
@@ -241,11 +246,15 @@ class AgentPanel(_gui_common.PilotFeature):
         self._active_widget = widget
         self._panel.set_busy(True)
         self._panel.start_working()
+        history = session.history()
         scene = _agent_control.pilot_scene_context(
             session.runner, session.scene_context())
+        tool_surface = session.tool_surface()
+        self._write_history_payload(session.backend, prompt, scene,
+                                    tool_surface, history)
         self._worker = AgentBackendWorker(
-            session.backend, prompt, scene,
-            session.tool_surface(), parent=self._panel)
+            session.backend, prompt, scene, tool_surface,
+            history, parent=self._panel)
         self._worker.succeeded.connect(self._on_backend_succeeded)
         self._worker.failed.connect(self._on_backend_failed)
         self._worker.finished.connect(self._on_worker_finished)
@@ -281,22 +290,64 @@ class AgentPanel(_gui_common.PilotFeature):
         self._panel.stop_working()
         self._panel.set_busy(False)
 
+    def _write_history_payload(self, backend, prompt, scene, tool_surface,
+                               history):
+        """Log the conversation about to be replayed to the backend.
+
+        It goes to the Python console rather than the panel, whose transcript
+        already carries these turns.  The section is asked of ``backend``, not
+        of the base class, so a backend that composes its own payload logs the
+        section it will really send; a duck-typed backend that offers none
+        falls back to the standard layout.
+        """
+        compose = getattr(backend, "history_section",
+                          AgentBackend.history_section)
+        formatted = compose(prompt, scene, tool_surface, history)
+        if not formatted:
+            return
+        self._pycon.writeToHistory(
+            "History (before send):\n%s\n\n" % formatted)
+
+    @staticmethod
+    def _turn_log_messages(turn):
+        """The messages of the ``log`` commands that ran.
+
+        A log whose command failed is dropped: its message describes work the
+        turn went on to plan, and printing it as the reply would announce what
+        never happened.
+        """
+        messages = []
+        for command, result in zip_longest(turn.commands, turn.results):
+            if op_of(command) != "log" or not getattr(result, "ok", False):
+                continue
+            message = command.get("message")
+            if message is not None:
+                messages.append(str(message))
+        return messages
+
+    @staticmethod
+    def _turn_error_lines(turn):
+        """One indented line per command that failed or never ran.  A command
+        that worked stays silent: the canvas already shows it."""
+        lines = []
+        for command, result in zip_longest(turn.commands, turn.results):
+            if result is None:
+                lines.append("  - %s: not run" % op_of(command))
+            elif not getattr(result, "ok", False):
+                lines.append("  - %s: %s"
+                             % (op_of(command),
+                                getattr(result, "error", None) or "failed"))
+        return lines
+
     @staticmethod
     def _format_turn(turn):
-        """One block of reply text followed by an indented line per command,
-        marked ``ok`` or with its error."""
+        """The user-facing reply: the ``log`` messages that ran (else backend
+        prose), followed by a line per command that did not succeed, so a turn
+        whose commands all failed cannot read as a turn that worked."""
         if turn is None:
             return "(no backend selected)"
-        lines = [turn.text or "(no reply)"]
-        for command, result in zip_longest(turn.commands, turn.results):
-            op = command.get("op", "?") if isinstance(command, dict) else "?"
-            if result is None:
-                lines.append("  - %s" % op)
-            elif getattr(result, "ok", False):
-                lines.append("  - %s: ok" % op)
-            else:
-                lines.append(
-                    "  - %s: %s" % (op, getattr(result, "error", "failed")))
-        return "\n".join(lines)
+        logs = AgentPanel._turn_log_messages(turn)
+        lines = logs if logs else [turn.text or "(no reply)"]
+        return "\n".join(lines + AgentPanel._turn_error_lines(turn))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -29,8 +29,9 @@ class _CircleBackend:
     def available(self):
         return True
 
-    def send(self, prompt, scene_context, tool_surface):
+    def send(self, prompt, scene_context, tool_surface, history=()):
         return agent.BackendResponse(text="circle added", commands=[
+            {"op": "log", "message": "Add a unit circle at the origin"},
             {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}])
 
 
@@ -48,11 +49,77 @@ class _TranslateBackend:
     def available(self):
         return True
 
-    def send(self, prompt, scene_context, tool_surface):
+    def send(self, prompt, scene_context, tool_surface, history=()):
         return agent.BackendResponse(
             text="translating", commands=[
                 {"op": "translate_shape", "shape_id": self._shape_id,
                  "dx": 1.0, "dy": 0.0}])
+
+
+@unittest.skipIf(not solvcon.HAS_PILOT, "pilot is not built")
+class AgentTurnFormatTC(unittest.TestCase):
+    def test_log_messages_are_the_user_facing_reply(self):
+        turn = agent.TranscriptTurn(
+            role="agent", text="ignored prose",
+            commands=[{"op": "log", "message": "Shift car right by 25"},
+                      {"op": "translate_shape", "shape_id": 0,
+                       "dx": 25, "dy": 0}],
+            results=[agent.CommandResult("log", True),
+                     agent.CommandResult("translate_shape", True)])
+        self.assertEqual(
+            _agent_gui.AgentPanel._format_turn(turn),
+            "Shift car right by 25")
+
+    def test_a_failed_command_is_reported_under_the_reply(self):
+        turn = agent.TranscriptTurn(
+            role="agent", text="moving the car",
+            commands=[{"op": "translate_shape", "shape_id": 0,
+                       "dx": 25, "dy": 0}, {"op": "add_circle"}],
+            results=[agent.CommandResult(
+                "translate_shape", False, error="shape 0 is not live")])
+        self.assertEqual(
+            _agent_gui.AgentPanel._format_turn(turn).splitlines(),
+            ["moving the car",
+             "  - translate_shape: shape 0 is not live",
+             "  - add_circle: not run"])
+
+    def test_a_log_that_failed_is_not_announced_as_the_reply(self):
+        # The message describes work the turn went on to plan; with the batch
+        # dead it would announce something that never happened.
+        turn = agent.TranscriptTurn(
+            role="agent", text="drawing a car",
+            commands=[{"op": "log", "message": "body, roof, wheels"},
+                      {"op": "add_circle"}],
+            results=[agent.CommandResult("log", False, error="no canvas"),
+                     agent.CommandResult("add_circle", False,
+                                         error="no canvas")])
+        self.assertEqual(
+            _agent_gui.AgentPanel._format_turn(turn).splitlines()[0],
+            "drawing a car")
+
+    def test_successful_commands_stay_out_of_the_reply(self):
+        turn = agent.TranscriptTurn(
+            role="agent", text="drew it",
+            commands=[{"op": "add_line", "x0": 0, "y0": 0, "x1": 1, "y1": 1}],
+            results=[agent.CommandResult("add_line", True, {"shape_id": 0})])
+        self.assertEqual(_agent_gui.AgentPanel._turn_error_lines(turn), [])
+        self.assertEqual(_agent_gui.AgentPanel._format_turn(turn), "drew it")
+
+    def test_a_log_message_does_not_hide_a_later_failure(self):
+        turn = agent.TranscriptTurn(
+            role="agent", text="",
+            commands=[{"op": "log", "message": "Car plan"},
+                      {"op": "add_line"}],
+            results=[agent.CommandResult("log", True),
+                     agent.CommandResult("add_line", False,
+                                         error="x0 is required")])
+        self.assertEqual(
+            _agent_gui.AgentPanel._format_turn(turn).splitlines(),
+            ["Car plan", "  - add_line: x0 is required"])
+
+    def test_backend_prose_fills_in_when_there_is_no_log(self):
+        turn = agent.TranscriptTurn(role="agent", text="echo: hi")
+        self.assertEqual(_agent_gui.AgentPanel._format_turn(turn), "echo: hi")
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
@@ -134,8 +201,8 @@ class AgentPanelTC(unittest.TestCase):
         self.assertEqual(world.nshape, 1)
         text = panel._transcript.toPlainText()
         self.assertIn("You: draw a circle", text)
-        self.assertIn("circle added", text)
-        self.assertIn("add_circle: ok", text)
+        self.assertIn("Add a unit circle at the origin", text)
+        self.assertNotIn("add_circle", text)
 
     def test_turn_runs_off_the_main_thread(self):
         feature = self._panel_on()
@@ -210,8 +277,8 @@ class AgentPanelTC(unittest.TestCase):
         panel._emit()
         self._finish_turn(feature)
         text = panel._transcript.toPlainText()
-        self.assertIn("translate_shape", text)
-        self.assertNotIn("ok", text.split("translate_shape", 1)[1])
+        self.assertIn("- translate_shape:", text)
+        self.assertIn("4242", text)
         self.assertTrue(panel._input.isEnabled())
 
     def test_blank_prompt_is_ignored(self):

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -48,7 +48,9 @@ class _FakeWorld:
         return len(self._types)
 
     def describe_state(self, level="basic"):
-        shapes = [{"id": i, "type": t} for i, t in enumerate(self._types)]
+        shapes = [{"id": i, "type": t, "bbox": [i, 0, i + 1, 1],
+                   "segments": [[i, 0, i + 1, 1]], "curves": []}
+                  for i, t in enumerate(self._types)]
         return json.dumps({"shapes": shapes})
 
 
@@ -111,8 +113,8 @@ class _FakeBackend:
         self._response = response
         self.seen = None
 
-    def send(self, prompt, scene_context, tool_surface):
-        self.seen = (prompt, scene_context, tool_surface)
+    def send(self, prompt, scene_context, tool_surface, history=()):
+        self.seen = (prompt, scene_context, tool_surface, list(history))
         return self._response
 
 
@@ -206,6 +208,76 @@ class SceneContextTC(unittest.TestCase):
         self.assertIn("circle", context)
         self.assertIn("rectangle", context)
 
+    def test_inventory_lists_each_shape_by_id_type_and_box(self):
+        session = agent.AgentSession(world=_FakeWorld(["circle", "rectangle"]))
+        context = session.scene_context()
+        self.assertEqual(context.splitlines()[2:],
+                         ["  #0 circle [0, 0, 1, 1]",
+                          "  #1 rectangle [1, 0, 2, 1]"])
+        # describe_state also carries the geometry, which would swamp the
+        # prompt budget the inventory has to fit in.
+        self.assertNotIn("segments", context)
+
+    def test_empty_world_has_no_inventory(self):
+        session = agent.AgentSession(world=_FakeWorld([]))
+        self.assertEqual(session.scene_context(),
+                         "world with 0 shapes (types: none)")
+
+    def test_crowded_world_keeps_the_newest_shapes_and_counts_the_rest(self):
+        limit = agent.AgentSession.INVENTORY_LIMIT
+        world = _FakeWorld(["circle"] * (limit + 3))
+        lines = agent.AgentSession(world=world).scene_context().splitlines()
+        self.assertEqual(len(lines), limit + 3)
+        self.assertIn("%d shapes" % (limit + 3), lines[0])
+        self.assertEqual(lines[2], "  ... 3 earlier shapes")
+        self.assertEqual(lines[3], "  #3 circle [3, 0, 4, 1]")
+        self.assertEqual(lines[-1], "  #%d circle" % (limit + 2)
+                         + " [%d, 0, %d, 1]" % (limit + 2, limit + 3))
+
+    def test_shape_without_a_box_still_lists(self):
+        class _BoxlessWorld:
+            def describe_state(self, level="basic"):
+                return json.dumps({"shapes": [{"id": 7, "type": "blob"}]})
+
+        session = agent.AgentSession(world=_BoxlessWorld())
+        self.assertIn("  #7 blob [?]", session.scene_context())
+
+
+class HistoryTC(unittest.TestCase):
+    def test_trailing_user_turn_is_left_out(self):
+        # The composed request already carries the current prompt; replaying
+        # it would ask the model to answer the same thing twice.
+        session = agent.AgentSession()
+        session.record_prompt("draw a truck")
+        self.assertEqual(session.history(), [])
+
+    def test_a_canvas_switch_is_marked_in_the_replayed_turns(self):
+        # The ids in the earlier turns belong to the old world; unmarked they
+        # would read as shapes the new world's inventory should also list.
+        session = agent.AgentSession(world=_FakeWorld(["circle"]))
+        session.record_prompt("draw a circle")
+        session.bind_world(_FakeWorld(["rectangle"]))
+        session.bind_world(session.world)
+        self.assertEqual([turn.role for turn in session.transcript],
+                         ["user", "marker"])
+        self.assertIn("... canvas switched",
+                      agent.format_history(session.history()))
+
+    def test_the_first_world_is_not_a_switch(self):
+        session = agent.AgentSession()
+        session.bind_world(_FakeWorld(["circle"]))
+        self.assertEqual(session.transcript, [])
+
+    def test_run_turn_hands_the_earlier_turns_to_the_backend(self):
+        backend = _FakeBackend(agent.BackendResponse(text="ok"))
+        session = agent.AgentSession(backend=backend)
+        session.run_turn("draw a truck")
+        session.run_turn("move it right")
+        prompt, _, _, history = backend.seen
+        self.assertEqual(prompt, "move it right")
+        self.assertEqual([turn.text for turn in history],
+                         ["draw a truck", "ok"])
+
 
 class AgentDrawIntegrationTC(unittest.TestCase):
     def test_default_runner_mutates_world(self):
@@ -248,9 +320,21 @@ class AgentDrawIntegrationTC(unittest.TestCase):
         self.assertEqual(world.nshape, 0)
 
     def test_opt_in_tool_surface_matches_agent_draw(self):
+        hidden = agent.AgentSession.HIDDEN_OPS
         session = agent.AgentSession(allow_destructive=True)
         self.assertEqual(session.tool_surface(),
-                         draw.tool_definitions())
+                         [tool for tool in draw.tool_definitions()
+                          if tool["name"] not in hidden])
+
+    def test_render_png_is_hidden_unless_a_session_asks_for_it(self):
+        for session in (agent.AgentSession(),
+                        agent.AgentSession(allow_destructive=True)):
+            names = {tool["name"] for tool in session.tool_surface()}
+            self.assertNotIn("render_png", names)
+        self.assertIn("render_png", draw.commands)
+        opted_in = agent.AgentSession(hidden_ops=())
+        self.assertIn("render_png",
+                      {tool["name"] for tool in opted_in.tool_surface()})
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 2 of 2, on top of #1246. That branch added `HistoryFormatter` and widened `send()`, but no caller passed a history, so the request never carried a conversation section. This branch is what puts it there.

`AgentSession.history()` returns the recorded turns, dropping the trailing user turn the composed request already carries, and both `run_turn` and the panel worker hand it to the backend. Binding the session to a different world marks the transcript, so shape ids from the canvas that was open then are never replayed unmarked beside the new world inventory.

The scene told the model only how many shapes were on the canvas and which types, so it had no id to edit and redrew instead. Each shape is now listed as `#id type [x_min, y_min, x_max, y_max]`, the format the step 1 system prompt describes, keeping the newest `INVENTORY_LIMIT` and counting the rest. The geometry `describe_state` also carries is left out of the prompt.

In the panel, the reply is the log messages of the commands that ran, followed by a line per command that failed or never ran, so a turn whose batch died cannot read as a turn that worked. The conversation being replayed goes to the Python console.

Related to #1206. Related to #1136. Related to #966.