### PR TITLE
Let the user configure the agent backend from the console

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -39,6 +39,7 @@ list_of_core = [
 list_of_backend = [
     'AgentBackend',
     'BackendResponse',
+    'BackendSetting',
     'EchoBackend',
     'ToolSurfaceFormatter',
     'HistoryFormatter',

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -325,6 +325,19 @@ def format_history(history, used=0):
     return HistoryFormatter.render(history, used)
 
 
+@dataclasses.dataclass(frozen=True)
+class BackendSetting:
+    """One user-tunable knob a backend advertises to a settings editor.  An
+    empty ``choices`` means free text; otherwise the value must be one of the
+    listed strings."""
+
+    name: str
+    label: str
+    choices: tuple = ()
+    default: str = ""
+    tooltip: str = ""
+
+
 @dataclasses.dataclass
 class BackendResponse:
     """One backend reply: ``text`` prose, the proposed ``commands`` the
@@ -342,6 +355,10 @@ class AgentBackend(abc.ABC):
     system instruction (:attr:`_INSTRUCTIONS`, sent as a real system prompt)
     and one user-payload layout (:meth:`_compose_user`), so a CLI and an HTTP
     backend never drift apart in what they ask the model.
+
+    A backend may also advertise user-tunable knobs through
+    :meth:`settings_spec`; the base class stores and validates their values, so
+    a settings editor works the same for every backend.
     """
 
     # TODO: solvcon is an application platform for geometry-based computation:
@@ -419,6 +436,50 @@ class AgentBackend(abc.ABC):
     def name(self):
         """Short, stable identifier shown in the backend selector."""
 
+    def settings_spec(self):
+        """The knobs this backend exposes, as a sequence of
+        :class:`BackendSetting`.  Empty by default: a backend opts in."""
+        return ()
+
+    @property
+    def _settings(self):
+        """The stored values, filled with the declared defaults on first use.
+
+        Built on demand rather than in an ``__init__``, so a subclass that
+        writes its own constructor cannot lose the settings by forgetting to
+        chain up to this class.
+        """
+        values = self.__dict__.get("_setting_values")
+        if values is None:
+            values = {setting.name: setting.default
+                      for setting in self.settings_spec()}
+            self.__dict__["_setting_values"] = values
+        return values
+
+    def settings(self):
+        """The current value of every knob, as a ``name -> value`` dict."""
+        return dict(self._settings)
+
+    def get_setting(self, name):
+        return self._settings[name]
+
+    def set_setting(self, name, value):
+        """Store ``value`` for the knob ``name``, raising :class:`KeyError` for
+        an unknown knob and :class:`ValueError` for a value that is not a
+        string or falls outside the knob's choices."""
+        for setting in self.settings_spec():
+            if setting.name != name:
+                continue
+            if not isinstance(value, str):
+                raise ValueError(
+                    "%s: %s takes a string, not %r" % (self.name, name, value))
+            if setting.choices and value not in setting.choices:
+                raise ValueError(
+                    "%s: %r is not a valid %s" % (self.name, value, name))
+            self._settings[name] = value
+            return
+        raise KeyError("%s has no setting %r" % (self.name, name))
+
     @abc.abstractmethod
     def available(self):
         """Whether this backend can run now (CLI on PATH, key set, ...)."""
@@ -486,6 +547,10 @@ class BackendRegistry:
 
     _BACKENDS = []
 
+    #: The configuration key holding every backend's settings, as a
+    #: ``backend name -> {knob: value}`` mapping.
+    CONFIG_KEY = "agent_backend_settings"
+
     @classmethod
     def register(cls, backend):
         """Add a backend, replacing any with the same name (so a re-import does
@@ -516,6 +581,43 @@ class BackendRegistry:
             if backend.name == name:
                 return backend
         return None
+
+    @classmethod
+    def load_settings(cls, config):
+        """Apply the settings stored under :attr:`CONFIG_KEY` to the registered
+        backends.
+
+        An entry naming a backend, a knob, or a value the running code does not
+        know is dropped: the configuration file outlives any one version, and a
+        stale entry must not keep the console from starting.
+        """
+        stored = config.get(cls.CONFIG_KEY)
+        if not isinstance(stored, dict):
+            return
+        for backend in cls._BACKENDS:
+            values = stored.get(backend.name)
+            if not isinstance(values, dict):
+                continue
+            for name, value in values.items():
+                try:
+                    backend.set_setting(name, value)
+                except (KeyError, ValueError):
+                    continue
+
+    @classmethod
+    def save_settings(cls, config):
+        """Record every backend's settings under :attr:`CONFIG_KEY`.  Writing
+        the file is the caller's call, so a caller can batch several edits into
+        one :meth:`~solvcon.config.Config.save`."""
+        # Merge rather than replace: an entry belongs to a backend this process
+        # never registered (renamed, or from another build), and rewriting the
+        # key from the live list alone would delete settings the user still
+        # wants for it.
+        stored = config.get(cls.CONFIG_KEY)
+        stored = dict(stored) if isinstance(stored, dict) else {}
+        stored.update({backend.name: backend.settings()
+                       for backend in cls._BACKENDS if backend.settings()})
+        config.set(cls.CONFIG_KEY, stored)
 
 
 class EchoBackend(AgentBackend):

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -141,6 +141,9 @@ class SubprocessBackend(_backend.AgentBackend):
     #: The executable name a subclass discovers on ``PATH``.
     command = None
 
+    #: The selector label a subclass names itself with.
+    name = None
+
     #: The only environment variables the agent CLI receives: the process
     #: basics it needs to run, plus the credentials of the supported
     #: authentication modes (see the class docstring).
@@ -149,13 +152,14 @@ class SubprocessBackend(_backend.AgentBackend):
         "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
 
     def __init__(self, timeout=120):
+        super().__init__()
+        # Naming itself is the one thing the base cannot do for a subclass, and
+        # a nameless backend would reach the selector and the configuration
+        # file as a null entry.
+        if not self.name:
+            raise TypeError("%s must set name" % type(self).__name__)
         self._timeout = timeout
         self._proc = None
-
-    @property
-    def name(self):
-        """Selector label derived from the CLI, e.g. ``claude (cli)``."""
-        return "%s (cli)" % self.command
 
     def executable(self):
         """The resolved path to :attr:`command`, or ``None`` if not on PATH."""
@@ -243,16 +247,37 @@ class ClaudeCliBackend(SubprocessBackend):
     scene context into the prompt, and parses the model's JSON reply into
     commands.  No API key lives here: the CLI owns authentication.
 
-    The model is named explicitly because ``--setting-sources ""`` cuts the
-    CLI off from the config files it would otherwise pick one from, so the
-    same request would run on a different model as the CLI default moves.
+    The model and the reasoning effort are settings the user picks; each maps
+    to a CLI flag.  Naming the model matters because ``--setting-sources ""``
+    cuts the CLI off from the config files it would otherwise pick one from,
+    so :attr:`DEFAULT_CHOICE` leaves the flag out and the request runs on
+    whatever the CLI itself defaults to, which moves over time.
     """
 
     command = "claude"
+    name = "Claude Code"
+
+    DEFAULT_CHOICE = "default"
+
+    SETTINGS = (
+        _backend.BackendSetting(
+            name="model", label="Model",
+            choices=(DEFAULT_CHOICE, "fable", "opus", "sonnet", "haiku"),
+            default=DEFAULT_CHOICE,
+            tooltip="Model alias passed to the CLI as --model."),
+        _backend.BackendSetting(
+            name="effort", label="Effort",
+            choices=(DEFAULT_CHOICE, "low", "medium", "high", "xhigh", "max"),
+            default=DEFAULT_CHOICE,
+            tooltip="Reasoning effort passed to the CLI as --effort."),
+    )
+
+    def settings_spec(self):
+        return self.SETTINGS
 
     def _build_argv(self, exe, user_prompt, system_prompt):
         # TODO: provide more permission and config to the CLI sandbox later.
-        return [
+        argv = [
             exe, "-p", user_prompt, "--output-format", "json",
             "--append-system-prompt", system_prompt,
             "--tools", "",
@@ -262,6 +287,14 @@ class ClaudeCliBackend(SubprocessBackend):
             "--disable-slash-commands",  # no interactive slash commands
             "--no-session-persistence",  # no session files
         ]
+        for setting, flag in (("model", "--model"), ("effort", "--effort")):
+            value = self.get_setting(setting)
+            if value and value != self.DEFAULT_CHOICE:
+                # Joined rather than two elements, so a value that happens to
+                # start with a dash reaches the CLI as this flag's value and
+                # never as another option.
+                argv.append("%s=%s" % (flag, value))
+        return argv
 
     def _parse_output(self, stdout):
         """Pull the assistant text out of ``claude --output-format json``
@@ -296,6 +329,7 @@ class OpenAIHttpBackend(_backend.AgentBackend):
     _DEFAULT_MODEL = "qwen2.5vl:7b"
 
     def __init__(self, base_url=None, model=None, api_key=None, timeout=120):
+        super().__init__()
         self._base_url = base_url if base_url is not None else self._env_or(
             "SOLVCON_OPENAI_BASE_URL", self._DEFAULT_BASE_URL)
         self._model = model if model is not None else self._env_or(

--- a/solvcon/config.py
+++ b/solvcon/config.py
@@ -34,9 +34,24 @@ class Config(object):
     #: Basename of the settings file, which holds the GUI's configuration.
     FILENAME = "pilot.json"
 
+    _INSTANCE = None
+
     def __init__(self, path=None):
         self.path = self.default_path() if path is None else path
         self._data = {}
+
+    @classmethod
+    def instance(cls):
+        """The process-wide configuration, read from the file on first use.
+
+        Every part of the application shares this one object because
+        :meth:`save` writes the whole file: two separately loaded copies would
+        each hold a snapshot of the other's keys, and whichever saved last
+        would put back the values the other had already replaced.
+        """
+        if cls._INSTANCE is None:
+            cls._INSTANCE = cls().load()
+        return cls._INSTANCE
 
     @staticmethod
     def config_home():

--- a/solvcon/pilot/agent/_agent_gui.py
+++ b/solvcon/pilot/agent/_agent_gui.py
@@ -20,7 +20,9 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
                                QPushButton)
 
 from ...agent import AgentBackend, AgentSession, BackendRegistry, op_of
+from ...config import Config
 from . import _agent_control
+from ._agent_settings import AgentBackendSettingsDialog
 from ..base import _gui_common
 
 __all__ = [  # noqa: F822
@@ -68,18 +70,21 @@ class AgentBackendWorker(QThread):
 class AgentConsoleWidget(QWidget):
     """The console body: a backend selector, a transcript, and a prompt box.
 
-    Display-only.  It emits :attr:`submitted` with the typed prompt and exposes
-    the chosen backend; the owning feature runs the turn and calls back to
-    append the reply.
+    Display-only.  It emits :attr:`submitted` with the typed prompt and
+    :attr:`settings_requested` when the user asks to configure the selected
+    backend, and exposes the chosen backend; the owning feature runs the turn
+    and calls back to append the reply.
     """
 
     submitted = Signal(str)
+    settings_requested = Signal()
 
     def __init__(self, backends=(), parent=None):
         super().__init__(parent)
         self._backend_combo = QComboBox()
         for backend in backends:
             self._backend_combo.addItem(backend.name, backend)
+        self._settings = QPushButton("Settings")
 
         self._transcript = QTextEdit()
         self._transcript.setReadOnly(True)
@@ -96,6 +101,7 @@ class AgentConsoleWidget(QWidget):
         selector.setContentsMargins(4, 2, 4, 2)
         selector.addWidget(QLabel("Backend:"))
         selector.addWidget(self._backend_combo, 1)
+        selector.addWidget(self._settings)
 
         entry = QHBoxLayout()
         entry.setContentsMargins(4, 2, 4, 4)
@@ -116,6 +122,7 @@ class AgentConsoleWidget(QWidget):
 
         self._input.returnPressed.connect(self._emit)
         self._send.clicked.connect(self._emit)
+        self._settings.clicked.connect(self.settings_requested)
 
     def _emit(self):
         text = self._input.text().strip()
@@ -131,9 +138,12 @@ class AgentConsoleWidget(QWidget):
         self._input.clear()
 
     def set_busy(self, busy):
-        """Lock the prompt while a turn runs so a second one cannot overlap."""
+        """Lock the prompt and the settings button while a turn runs, so a
+        second turn cannot overlap and an edit cannot look like it reaches the
+        in-flight call, which already holds its configuration."""
         self._input.setEnabled(not busy)
         self._send.setEnabled(not busy)
+        self._settings.setEnabled(not busy)
 
     def start_working(self):
         """Show an animated ``working ...`` line while a turn runs, so a slow
@@ -177,6 +187,8 @@ class AgentPanel(_gui_common.PilotFeature):
         self._panel = None
         self._session = AgentSession(
             runner=_agent_control.build_control_dispatcher(self._mgr))
+        self._config = Config.instance()
+        BackendRegistry.load_settings(self._config)
         self._worker = None
         self._active_widget = None
         # Make sure the worker thread is joined before the main thread exits.
@@ -221,11 +233,33 @@ class AgentPanel(_gui_common.PilotFeature):
             return
         self._panel = AgentConsoleWidget(backends=BackendRegistry.available())
         self._panel.submitted.connect(self._on_submitted)
+        self._panel.settings_requested.connect(self._on_settings_requested)
         self._dock = QDockWidget("Agent")
         self._dock.setWidget(self._panel)
         self._mainWindow.addDockWidget(Qt.BottomDockWidgetArea, self._dock)
         # Keep the menu check in sync when the dock is closed by its button.
         self._dock.visibilityChanged.connect(self._action.setChecked)
+
+    def _on_settings_requested(self):
+        """Configure the selected backend.  The settings live on the registry's
+        backend instance, so an edit holds for every later turn, and the
+        accepted values go to the configuration file so they also outlive the
+        session."""
+        backend = self._panel.selected_backend()
+        if backend is None:
+            return
+        dialog = AgentBackendSettingsDialog(backend, parent=self._panel)
+        if not dialog.exec():
+            return
+        BackendRegistry.save_settings(self._config)
+        try:
+            self._config.save()
+        except OSError as exc:
+            # The edit still holds for this session; only the file is lost, and
+            # saying so beats a silent no-op the user finds out about later.
+            self._panel.append_message(
+                "agent", "settings not saved to %s: %s"
+                % (self._config.path, exc))
 
     def _on_submitted(self, prompt):
         """Start one turn on the active canvas without blocking the GUI."""

--- a/solvcon/pilot/agent/_agent_settings.py
+++ b/solvcon/pilot/agent/_agent_settings.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Backend settings dialog for the Agent Console.
+
+The dialog is built from whatever a backend advertises through
+``settings_spec()``, so a backend that grows a knob needs no change here.
+"""
+
+from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QComboBox, QLabel,
+                               QLineEdit, QFormLayout, QVBoxLayout)
+
+__all__ = [  # noqa: F822
+    'AgentBackendSettingsDialog',
+]
+
+
+class AgentBackendSettingsDialog(QDialog):
+    """Edit one backend's settings.  The editors start on the backend's current
+    values and are written back only on accept, so cancelling leaves a running
+    configuration untouched."""
+
+    def __init__(self, backend, parent=None):
+        super().__init__(parent)
+        self._backend = backend
+        self._editors = {}
+        self.setWindowTitle("Backend Settings")
+
+        form = QFormLayout()
+        spec = list(backend.settings_spec())
+        for setting in spec:
+            editor = self._build_editor(setting, backend.get_setting(
+                setting.name))
+            if setting.tooltip:
+                editor.setToolTip(setting.tooltip)
+            self._editors[setting.name] = editor
+            form.addRow(setting.label, editor)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Backend: %s" % backend.name))
+        if spec:
+            layout.addLayout(form)
+        else:
+            layout.addWidget(QLabel("This backend has no settings yet."))
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    @staticmethod
+    def _build_editor(setting, value):
+        """A combo box for a fixed set of choices, a line edit otherwise."""
+        if setting.choices:
+            editor = QComboBox()
+            editor.addItems(list(setting.choices))
+            index = editor.findText(value)
+            editor.setCurrentIndex(max(index, 0))
+            return editor
+        editor = QLineEdit()
+        editor.setText(value or "")
+        return editor
+
+    @staticmethod
+    def _editor_value(editor):
+        return (editor.currentText() if isinstance(editor, QComboBox)
+                else editor.text().strip())
+
+    def accept(self):
+        """Apply every editor, or none.  A knob the backend refuses would
+        otherwise leave the earlier ones already committed while the dialog
+        stays open, which is the opposite of what cancelling promises."""
+        restore = self._backend.settings()
+        try:
+            for name, editor in self._editors.items():
+                self._backend.set_setting(name, self._editor_value(editor))
+        except (KeyError, ValueError):
+            for name, value in restore.items():
+                self._backend.set_setting(name, value)
+            raise
+        super().accept()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/base/_ui_state.py
+++ b/solvcon/pilot/base/_ui_state.py
@@ -97,7 +97,7 @@ class UiState(_gui_common.PilotFeature):
         :type parts: iterable
         """
         super(UiState, self).__init__(*args, **kw)
-        self._config = Config() if config is None else config
+        self._config = Config.instance() if config is None else config
         if parts is None:
             parts = [WindowGeometry(self._mainWindow)]
         self._parts = list(parts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 
 
 """
-Keep the pilot GUI tests off the screen.
+Keep the pilot GUI tests off the screen and out of the user's configuration.
 
 The GUI tests drive real top-level windows, and every one that maps takes the
 desktop and the keyboard away from whoever is running the suite. Marking a
@@ -13,10 +13,16 @@ keep running against a live window surface. That is what the offscreen QPA
 platform cannot offer: the suite skips its window tests there. Export
 ``SOLVCON_TEST_SHOW_WINDOWS=ON`` to watch the windows instead, which hands them
 the desktop and the keyboard for the length of the run.
+
+The suite also points ``SOLVCON_CONFIG_HOME`` at a scratch directory, so a test
+that reads or writes the application configuration neither picks up the
+settings of whoever is running it nor overwrites them.
 """
 
 
 import os
+import shutil
+import tempfile
 
 try:
     from PySide6 import QtCore, QtWidgets
@@ -57,6 +63,37 @@ def _hide_windows():
         return
     _hider = _build_hider()
     app.installEventFilter(_hider)
+
+
+_config_home = None
+_saved_config_home = None
+
+
+def pytest_configure(config):
+    """Send the application configuration to a scratch directory for the run.
+
+    Set before any test imports the pilot, which reads the configuration as it
+    builds its panels.
+    """
+    global _config_home, _saved_config_home
+    _saved_config_home = os.environ.get("SOLVCON_CONFIG_HOME")
+    _config_home = tempfile.mkdtemp(prefix="solvcon-test-config-")
+    os.environ["SOLVCON_CONFIG_HOME"] = _config_home
+
+
+def pytest_unconfigure(config):
+    """Remove the directory this file created, and only that one.
+
+    Deleting whatever the variable happens to point at would follow a test
+    that repointed it and failed before restoring, and recursively delete a
+    real directory such as the developer's own configuration.
+    """
+    if _saved_config_home is None:
+        os.environ.pop("SOLVCON_CONFIG_HOME", None)
+    else:
+        os.environ["SOLVCON_CONFIG_HOME"] = _saved_config_home
+    if _config_home:
+        shutil.rmtree(_config_home, ignore_errors=True)
 
 
 def pytest_collection_finish(session):

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -11,6 +11,7 @@ try:
     from solvcon import pilot
     from solvcon import agent
     from solvcon.pilot.agent import _agent_gui
+    from solvcon.pilot.agent import _agent_settings
     from PySide6.QtCore import Qt, QCoreApplication
 except ImportError:
     pilot = None
@@ -287,6 +288,19 @@ class AgentPanelTC(unittest.TestCase):
         widget._input.setText("   ")
         widget._emit()
         self.assertEqual(widget._transcript.toPlainText(), "")
+
+    def test_backend_settings_reach_the_cli(self):
+        # The whole path in one go: the dialog is built from the backend's
+        # spec, accepting it stores the picks, and a later turn puts them on
+        # the CLI command line.
+        backend = agent.ClaudeCliBackend()
+        dialog = _agent_settings.AgentBackendSettingsDialog(backend)
+        dialog._editors["model"].setCurrentText("opus")
+        dialog._editors["effort"].setCurrentText("high")
+        dialog.accept()
+        argv = backend._build_argv("/usr/bin/claude", "draw", "system")
+        self.assertIn("--model=opus", argv)
+        self.assertIn("--effort=high", argv)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -9,10 +9,14 @@ GUI-free: only the pure-Python backend module is imported, never an
 """
 
 import json
+import os
+import shutil
+import tempfile
 import unittest
 
 from solvcon import agent
 from solvcon.agent import draw
+from solvcon.config import Config
 
 _literal = agent.ToolSurfaceFormatter.literal
 
@@ -533,6 +537,45 @@ class RegistryTC(unittest.TestCase):
         finally:
             # Restore the default for other tests.
             agent.BackendRegistry.register(agent.ClaudeCliBackend())
+
+
+class BackendSettingsConfigTC(unittest.TestCase):
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        self.path = os.path.join(tmpdir, Config.FILENAME)
+        # The registry hands out one shared instance, so put the knob back.
+        self.backend = agent.BackendRegistry.get(
+            agent.ClaudeCliBackend().name)
+        for knob, value in self.backend.settings().items():
+            self.addCleanup(self.backend.set_setting, knob, value)
+
+    def test_settings_survive_a_config_round_trip(self):
+        # The whole path: an accepted edit is written to the file, and a
+        # later run reads it back onto the same backend.
+        self.backend.set_setting("model", "opus")
+        config = Config(self.path)
+        agent.BackendRegistry.save_settings(config)
+        config.save()
+        self.backend.set_setting(
+            "model", agent.ClaudeCliBackend.DEFAULT_CHOICE)
+        agent.BackendRegistry.load_settings(Config(self.path).load())
+        self.assertEqual(self.backend.get_setting("model"), "opus")
+
+    def test_a_stale_file_leaves_the_backend_alone(self):
+        # Every shape an older or newer version can leave behind: a backend,
+        # a knob, a value, and a payload the running code cannot use.  Each is
+        # dropped, and the good knob beside them still applies.
+        json.dump({agent.BackendRegistry.CONFIG_KEY: {
+            self.backend.name: {"model": "opus", "effort": "warp",
+                                "gone_knob": "x", "bad_type": 12},
+            "Ghost CLI": {"model": "opus"},
+            "Broken CLI": "not a mapping",
+        }}, open(self.path, "w"))
+        agent.BackendRegistry.load_settings(Config(self.path).load())
+        self.assertEqual(self.backend.get_setting("model"), "opus")
+        self.assertEqual(self.backend.get_setting("effort"),
+                         agent.ClaudeCliBackend.DEFAULT_CHOICE)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -108,6 +108,8 @@ class SubprocessBackendDiscoveryTC(unittest.TestCase):
         # A subclass that names no executable is never available even though
         # which() would answer for a real name.
         class Nameless(agent.SubprocessBackend):
+            name = "nameless (test)"
+
             def _build_argv(self, exe, user_prompt, system_prompt):
                 return [exe]
 
@@ -293,7 +295,7 @@ class SubprocessBackendPinningTC(unittest.TestCase):
 
 class RegistrationTC(unittest.TestCase):
     def test_claude_registers_on_import(self):
-        backend = agent.BackendRegistry.get("claude (cli)")
+        backend = agent.BackendRegistry.get("Claude Code")
         self.assertIsNotNone(backend)
         self.assertIsInstance(backend, agent.ClaudeCliBackend)
 


### PR DESCRIPTION
A backend now advertises its tunable knobs through settings_spec(), and the AgentBackend base stores and validates them. The Claude Code backend uses it for the model and the reasoning effort, each mapped to a CLI flag and left out on the shared "default" choice. Both lists are hard-coded, since the CLI cannot enumerate them, but every value was checked against the installed CLI.

The console grows a Settings button whose dialog is built from the selected backend's spec, so a backend with no knobs gets a placeholder instead of an empty form. The Claude selector label becomes "Claude Code", so SubprocessBackend now carries a name class attribute instead of a property.

Related to #1206.
