### PR TITLE
Say what a backend reply is: transport outcome and parse status

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -40,6 +40,8 @@ list_of_backend = [
     'AgentBackend',
     'BackendResponse',
     'BackendSetting',
+    'TransportOutcome',
+    'ParseStatus',
     'EchoBackend',
     'ToolSurfaceFormatter',
     'HistoryFormatter',
@@ -51,9 +53,11 @@ list_of_backend = [
 # _backends_impl.py
 list_of_backends_impl = [
     'SubprocessBackend',
+    'CancellableBackend',
     'ClaudeCliBackend',
     'OpenAIHttpBackend',
     'ToolCallParser',
+    'ParsedReply',
 ]
 
 # TODO: when the Qt dock module exists in solvcon.pilot, point this at its

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -15,6 +15,7 @@ the registry: it is a test and demo double, not a backend to offer a user.
 
 import abc
 import dataclasses
+import enum
 import json
 
 from . import _command
@@ -338,14 +339,56 @@ class BackendSetting:
     tooltip: str = ""
 
 
+class TransportOutcome(enum.Enum):
+    """How the exchange that carried a request ended.
+
+    Only :attr:`OK` means the model answered; the rest say the reply never
+    arrived, which is what tells a loop to abort instead of retry.
+    """
+
+    OK = "ok"
+    TRANSPORT = "transport"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+
+
+class ParseStatus(enum.Enum):
+    """What a model reply turned out to be once parsed.
+
+    :attr:`EMPTY` and :attr:`PROSE` both yield no commands and must stay
+    distinct: an explicit ``[]`` is the model saying the request is done,
+    while prose is the model talking instead of acting.
+    """
+
+    COMMANDS = "commands"
+    EMPTY = "empty"
+    PROSE = "prose"
+    MALFORMED = "malformed"
+
+
 @dataclasses.dataclass
 class BackendResponse:
-    """One backend reply: ``text`` prose, the proposed ``commands`` the
-    session applies, and an ``error`` reason or ``None``."""
+    """One backend reply.
+
+    ``status`` defaults to what ``commands`` and ``text`` imply, so a backend
+    that only fills the older fields still reports a usable status.
+    """
 
     text: str = ""
     commands: list = dataclasses.field(default_factory=list)
     error: str = None
+    outcome: TransportOutcome = TransportOutcome.OK
+    status: ParseStatus = None
+
+    def __post_init__(self):
+        if self.status is not None:
+            return
+        if self.commands:
+            self.status = ParseStatus.COMMANDS
+        elif self.text:
+            self.status = ParseStatus.PROSE
+        else:
+            self.status = ParseStatus.EMPTY
 
 
 class AgentBackend(abc.ABC):

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -18,6 +18,7 @@ lists it and probes :meth:`~solvcon.agent.AgentBackend.available` before use.
 """
 
 import abc
+import dataclasses
 import http.client
 import json
 import os
@@ -29,22 +30,34 @@ import urllib.parse
 from . import _backend
 
 
+@dataclasses.dataclass
+class ParsedReply:
+    """Commands, parse ``status``, and ``error`` from one model reply."""
+
+    commands: list = dataclasses.field(default_factory=list)
+    status: _backend.ParseStatus = _backend.ParseStatus.EMPTY
+    error: str = None
+
+    def response(self, text):
+        return _backend.BackendResponse(
+            text=text, commands=self.commands, error=self.error,
+            status=self.status)
+
+
 class ToolCallParser:
-    """Turns a model reply into the command dicts a session runs."""
+    """Turns a model reply into the command dicts a session runs.
 
-    @classmethod
-    def op_names(cls, tool_surface):
-        """The set of op names a tool surface advertises via each tool's
-        ``name``.
+    :attr:`NO_JSON` is what says a reply carried no JSON at all, which a
+    reply of the literal ``null`` must not be mistaken for: the first is the
+    model talking, the second is the model answering with the wrong shape.
 
-        Empty when the surface is empty or names nothing, which tells
-        :meth:`parse` to skip op validation rather than reject everything.
-        """
-        names = set()
-        for tool in tool_surface or []:
-            if isinstance(tool, dict) and isinstance(tool.get("name"), str):
-                names.add(tool["name"])
-        return names
+    Op names are not checked here.  An op the tool surface does not advertise
+    is a command the runner rejects with its own error, which the model can
+    see and fix; rejecting it while parsing would throw away the whole batch
+    over one bad entry.
+    """
+
+    NO_JSON = object()
 
     @classmethod
     def strip_code_fences(cls, text):
@@ -65,14 +78,14 @@ class ToolCallParser:
         """Parse the first JSON array or object out of a model reply,
         tolerating a code fence or surrounding prose.
 
-        Return the parsed value, or ``None`` when the reply has no JSON-looking
-        span (plain prose).  Raise :class:`ValueError` when a ``[``/``{`` span
-        is present but does not parse, so a truncated or invalid command batch
-        is not mistaken for an empty one.
+        Return the parsed value, or :attr:`NO_JSON` when the reply has no
+        JSON-looking span (plain prose).  Raise :class:`ValueError` when a
+        ``[``/``{`` span is present but does not parse, so a truncated or
+        invalid command batch is not mistaken for an empty one.
         """
         text = cls.strip_code_fences(text).strip()
         if not text:
-            return None
+            return cls.NO_JSON
         try:
             return json.loads(text)
         except json.JSONDecodeError:
@@ -90,27 +103,20 @@ class ToolCallParser:
                 continue
         if saw_span or text[0] in "[{":
             raise ValueError("model reply has malformed JSON")
-        return None
+        return cls.NO_JSON
 
     @classmethod
-    def parse(cls, text, tool_surface=None):
-        """Turn a model reply into a list of command dicts.
+    def commands_of(cls, data):
+        """The command dicts in an already-parsed JSON payload.
 
-        Accept a JSON array, or a lone object treated as a one-command array.
-        Each command must be an object with an ``op``; when ``tool_surface``
-        names ops, an unknown op is rejected.  Raise :class:`ValueError` on a
-        malformed reply (including invalid JSON that looks like a command
-        batch) so the backend records it as an error rather than running a bad
-        command.  Plain prose with no JSON yields an empty list.
+        Accept an array, or a lone object treated as a one-command array.
+        Each command must be an object with a string ``op``; anything else
+        raises :class:`ValueError`.
         """
-        data = cls.load_json_payload(text)
-        if data is None:
-            return []
         if isinstance(data, dict):
             data = [data]
         if not isinstance(data, list):
             raise ValueError("model reply is not a JSON array of commands")
-        valid = cls.op_names(tool_surface)
         commands = []
         for entry in data:
             if not isinstance(entry, dict):
@@ -119,13 +125,77 @@ class ToolCallParser:
             if not isinstance(op, str):
                 raise ValueError(
                     "command needs a string \"op\": %r" % (entry,))
-            if valid and op not in valid:
-                raise ValueError("unknown op %r" % (op,))
             commands.append(entry)
         return commands
 
+    @classmethod
+    def parse(cls, text):
+        """Turn a model reply into a list of command dicts.
 
-class SubprocessBackend(_backend.AgentBackend):
+        Raise :class:`ValueError` on a malformed reply.  Plain prose yields an
+        empty list; :meth:`parse_reply` is what tells the two apart.
+        """
+        data = cls.load_json_payload(text)
+        return [] if data is cls.NO_JSON else cls.commands_of(data)
+
+    @classmethod
+    def parse_reply(cls, text):
+        """:meth:`parse` as a :class:`ParsedReply`.
+
+        A blank reply is :attr:`~ParseStatus.EMPTY` rather than prose: it
+        carries no text worth recording, and a loop should end on it like an
+        explicit ``[]``.
+        """
+        status = _backend.ParseStatus
+        if not (text or "").strip():
+            return ParsedReply(status=status.EMPTY)
+        try:
+            data = cls.load_json_payload(text)
+        except ValueError as exc:
+            return ParsedReply(status=status.MALFORMED, error=str(exc))
+        if data is cls.NO_JSON:
+            return ParsedReply(status=status.PROSE)
+        try:
+            commands = cls.commands_of(data)
+        except ValueError as exc:
+            return ParsedReply(status=status.MALFORMED, error=str(exc))
+        return ParsedReply(
+            commands, status.COMMANDS if commands else status.EMPTY)
+
+
+class CancellableBackend:
+    """The cancellation bookkeeping a backend with an in-flight call shares.
+
+    A cancelled call surfaces as an ordinary failure (a killed child, a closed
+    socket), so the flag is what lets :meth:`failure` report it as the
+    deliberate stop it was instead of a transport fault a caller might retry.
+    """
+
+    _cancelled = False
+
+    def begin(self):
+        self._cancelled = False
+
+    def failure(self, error, outcome=_backend.TransportOutcome.TRANSPORT):
+        """A failed response, or ``CANCELLED`` when this call was stopped."""
+        if self._cancelled:
+            outcome = _backend.TransportOutcome.CANCELLED
+        return _backend.BackendResponse(error=error, outcome=outcome)
+
+    def cancelled_reply(self):
+        """``CANCELLED`` response if this call was stopped, else ``None``.
+
+        A cancel that lands before the child or the connection is reachable
+        tears down nothing, so the call can still succeed.  That answer is
+        unwanted: returning it would let commands land after the user asked
+        for none.
+        """
+        if not self._cancelled:
+            return None
+        return self.failure("cancelled")
+
+
+class SubprocessBackend(CancellableBackend, _backend.AgentBackend):
     """Base for backends that shell out to an AI CLI found on ``PATH``.
 
     A subclass sets :attr:`command` to the executable name and implements
@@ -180,35 +250,33 @@ class SubprocessBackend(_backend.AgentBackend):
         return (stdout or "").strip()
 
     def send(self, prompt, scene_context, tool_surface, history=()):
+        self.begin()
         exe = self.executable()
         if exe is None:
-            return _backend.BackendResponse(
-                error="%s not found on PATH" % self.command)
+            return self.failure("%s not found on PATH" % self.command)
         user_prompt = self._compose_user(
             prompt, scene_context, tool_surface, history)
         argv = self._build_argv(exe, user_prompt, self._INSTRUCTIONS)
         try:
             code, out, err = self._communicate(argv)
         except subprocess.TimeoutExpired:
-            return _backend.BackendResponse(
-                error="%s timed out" % self.command)
+            return self.failure("%s timed out" % self.command,
+                                _backend.TransportOutcome.TIMEOUT)
         except OSError as exc:
-            return _backend.BackendResponse(
-                error="%s failed: %s" % (self.command, exc))
+            return self.failure("%s failed: %s" % (self.command, exc))
         if code != 0:
-            return _backend.BackendResponse(
-                error="%s exit %d: %s"
-                % (self.command, code, (err or "").strip()))
+            return self.failure(
+                "%s exit %d: %s" % (self.command, code, (err or "").strip()))
+        stopped = self.cancelled_reply()
+        if stopped is not None:
+            return stopped
         text = self._parse_output(out)
-        try:
-            commands = ToolCallParser.parse(text, tool_surface)
-        except ValueError as exc:
-            return _backend.BackendResponse(text=text, error=str(exc))
-        return _backend.BackendResponse(text=text, commands=commands)
+        return ToolCallParser.parse_reply(text).response(text)
 
     def cancel(self):
         """Terminate the in-flight child, if any.  Safe to call from another
         thread while :meth:`send` blocks in :meth:`_communicate`."""
+        self._cancelled = True
         proc = self._proc
         if proc is not None and proc.poll() is None:
             proc.terminate()
@@ -227,6 +295,10 @@ class SubprocessBackend(_backend.AgentBackend):
                 argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, cwd=workdir, env=env)
             self._proc = proc
+            if self._cancelled:
+                # A cancel between spawning the child and publishing it here
+                # found nothing to terminate; act on it now.
+                proc.terminate()
             try:
                 out, err = proc.communicate(timeout=self._timeout)
             except subprocess.TimeoutExpired:
@@ -313,7 +385,7 @@ class ClaudeCliBackend(SubprocessBackend):
 _backend.BackendRegistry.register(ClaudeCliBackend())
 
 
-class OpenAIHttpBackend(_backend.AgentBackend):
+class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):
     """Backend over an OpenAI-compatible Chat Completions HTTP API.
 
     Uses only the stdlib (``http.client`` and ``urllib.parse``); no vendor
@@ -363,9 +435,10 @@ class OpenAIHttpBackend(_backend.AgentBackend):
         return bool(self.base_url) and bool(self._model)
 
     def send(self, prompt, scene_context, tool_surface, history=()):
+        self.begin()
         if not self.available():
-            return _backend.BackendResponse(
-                error="openai http backend needs base_url and model")
+            return self.failure(
+                "openai http backend needs base_url and model")
         user_prompt = self._compose_user(
             prompt, scene_context, tool_surface, history)
         body = {
@@ -379,33 +452,31 @@ class OpenAIHttpBackend(_backend.AgentBackend):
         try:
             status, raw = self._post_chat(body)
         except TimeoutError:
-            return _backend.BackendResponse(
-                error="openai http timed out")
+            return self.failure("openai http timed out",
+                                _backend.TransportOutcome.TIMEOUT)
         except (OSError, http.client.HTTPException) as exc:
-            return _backend.BackendResponse(
-                error="openai http failed: %s" % exc)
+            return self.failure("openai http failed: %s" % exc)
         if status != 200:
             detail = (raw or b"").decode("utf-8", errors="replace").strip()
-            return _backend.BackendResponse(
-                error="openai http status %d: %s" % (status, detail))
+            return self.failure(
+                "openai http status %d: %s" % (status, detail))
         try:
             payload = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return _backend.BackendResponse(
-                error="openai http bad JSON: %s" % exc)
+            return self.failure("openai http bad JSON: %s" % exc)
         text = self._parse_chat_payload(payload)
         if text is None:
-            return _backend.BackendResponse(
-                error="openai http response missing assistant text")
-        try:
-            commands = ToolCallParser.parse(text, tool_surface)
-        except ValueError as exc:
-            return _backend.BackendResponse(text=text, error=str(exc))
-        return _backend.BackendResponse(text=text, commands=commands)
+            return self.failure(
+                "openai http response missing assistant text")
+        stopped = self.cancelled_reply()
+        if stopped is not None:
+            return stopped
+        return ToolCallParser.parse_reply(text).response(text)
 
     def cancel(self):
         """Close the in-flight HTTP connection, if any.  Safe to call from
         another thread while :meth:`send` blocks in :meth:`_post_chat`."""
+        self._cancelled = True
         conn = self._conn
         if conn is not None:
             try:
@@ -483,6 +554,10 @@ class OpenAIHttpBackend(_backend.AgentBackend):
                 host, port, timeout=self._timeout)
         self._conn = conn
         try:
+            if self._cancelled:
+                # Cancel before publish: closing an unconnected conn does not
+                # stop request() from opening the socket.
+                raise OSError("cancelled before the request was sent")
             conn.request("POST", path, body=payload, headers=headers)
             response = conn.getresponse()
             return response.status, response.read()

--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -55,8 +55,10 @@ class AgentSession:
     to a lazily built command executor for ``world``.  ``backend`` is an
     :class:`~solvcon.agent.AgentBackend` or ``None``.  Delete commands are
     hidden from the backend and rejected unless ``allow_destructive`` is true.
-    ``hidden_ops`` names the ops to keep off the tool surface, defaulting to
-    :attr:`HIDDEN_OPS`.
+    ``hidden_ops`` names the ops to keep off the tool surface and out of the
+    runner; it defaults to :attr:`HIDDEN_OPS`, or to nothing once a
+    ``renderer`` is injected, since what that renderer is for is the op
+    :attr:`HIDDEN_OPS` names.
     """
 
     INVENTORY_LIMIT = 40
@@ -70,8 +72,9 @@ class AgentSession:
         self._runner = runner
         self._runner_injected = runner is not None
         self.allow_destructive = allow_destructive
-        self.hidden_ops = frozenset(
-            self.HIDDEN_OPS if hidden_ops is None else hidden_ops)
+        if hidden_ops is None:
+            hidden_ops = () if renderer is not None else self.HIDDEN_OPS
+        self.hidden_ops = frozenset(hidden_ops)
         self._transcript = []
 
     @property
@@ -137,9 +140,7 @@ class AgentSession:
         always.
 
         ``render_png`` is hidden by default: a session with no renderer cannot
-        run it, and its inline base64 result fits no prompt budget.  A caller
-        that does inject a renderer passes its own ``hidden_ops`` to get the op
-        back.
+        run it, and its inline base64 result fits no prompt budget.
         """
         tools = [tool for tool in self._command_provider().tool_definitions()
                  if tool["name"] not in self.hidden_ops]
@@ -147,11 +148,17 @@ class AgentSession:
             return tools
         return [tool for tool in tools if tool["category"] != "delete"]
 
-    def _gated_ops(self):
-        """Op names blocked while destructive commands are disabled: the
-        delete category across the provider's families."""
-        by_category = self._command_provider().commands_by_category()
-        return set(by_category.get("delete", ()))
+    def _blocked_ops(self):
+        """Op names refused at execution: :attr:`hidden_ops` plus the delete
+        category while destructive commands are disabled.
+
+        An op kept off :meth:`tool_surface` is refused here rather than run.
+        """
+        blocked = set(self.hidden_ops)
+        if not self.allow_destructive:
+            by_category = self._command_provider().commands_by_category()
+            blocked |= set(by_category.get("delete", ()))
+        return blocked
 
     @staticmethod
     def _bbox_text(bbox):
@@ -204,20 +211,16 @@ class AgentSession:
         An empty batch builds no runner.  A runner that fails to build, or that
         raises on a command, becomes a failed :class:`_OutcomeStub` (one per
         command), so a bad runner or command never aborts the batch and the
-        results always line up with the commands.  Delete commands are rejected
-        before reaching the runner unless this session allows them.  This does
-        not touch the transcript.
+        results always line up with the commands.  Commands naming an op this
+        session keeps off the tool surface are rejected before reaching the
+        runner (see :meth:`_blocked_ops`).  This does not touch the transcript.
         """
         if not commands:
             return []
-        blocked = set() if self.allow_destructive else self._gated_ops()
-        allowed = [command for command in commands
-                   if _command.op_of(command) not in blocked]
-        if not allowed:
-            return [_OutcomeStub(
-                _command.op_of(command),
-                error="destructive command %r is disabled for this session"
-                % _command.op_of(command)) for command in commands]
+        blocked = self._blocked_ops()
+        gated = [_command.op_of(command) in blocked for command in commands]
+        if all(gated):
+            return [self._blocked_result(command) for command in commands]
         try:
             runner = self.runner
         except Exception as exc:
@@ -225,12 +228,9 @@ class AgentSession:
             return [_OutcomeStub(_command.op_of(c), error=error)
                     for c in commands]
         results = []
-        for command in commands:
-            op = _command.op_of(command)
-            if op in blocked:
-                results.append(_OutcomeStub(
-                    op, error="destructive command %r is disabled for this "
-                    "session" % op))
+        for command, is_gated in zip(commands, gated):
+            if is_gated:
+                results.append(self._blocked_result(command))
                 continue
             try:
                 results.append(runner.run(command))
@@ -239,6 +239,12 @@ class AgentSession:
                     _command.op_of(command),
                     error="%s: %s" % (type(exc).__name__, exc)))
         return results
+
+    @staticmethod
+    def _blocked_result(command):
+        op = _command.op_of(command)
+        return _OutcomeStub(
+            op, error="op %r is disabled for this session" % op)
 
     def _record_agent(self, text, commands=(), results=(), failed=False):
         """Append and return one agent turn."""

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -36,60 +36,89 @@ class ParseToolCallsTC(unittest.TestCase):
     def test_plain_json_array(self):
         text = '[{"op": "add_circle", "r": 1.0}]'
         self.assertEqual(
-            agent.ToolCallParser.parse(text, _TOOLS),
+            agent.ToolCallParser.parse(text),
             [{"op": "add_circle", "r": 1.0}])
 
     def test_lone_object_becomes_one_command(self):
-        commands = agent.ToolCallParser.parse('{"op": "add_line"}', _TOOLS)
+        commands = agent.ToolCallParser.parse('{"op": "add_line"}')
         self.assertEqual(commands, [{"op": "add_line"}])
 
     def test_strips_code_fence(self):
         text = '```json\n[{"op": "add_circle"}]\n```'
-        self.assertEqual(agent.ToolCallParser.parse(text, _TOOLS),
+        self.assertEqual(agent.ToolCallParser.parse(text),
                          [{"op": "add_circle"}])
 
     def test_extracts_array_from_surrounding_prose(self):
         text = 'Sure! Here you go:\n[{"op": "add_circle"}]\nThanks.'
-        self.assertEqual(agent.ToolCallParser.parse(text, _TOOLS),
+        self.assertEqual(agent.ToolCallParser.parse(text),
                          [{"op": "add_circle"}])
 
     def test_empty_array_is_empty(self):
-        self.assertEqual(agent.ToolCallParser.parse("[]", _TOOLS), [])
+        self.assertEqual(agent.ToolCallParser.parse("[]"), [])
 
     def test_no_json_yields_empty(self):
-        self.assertEqual(
-            agent.ToolCallParser.parse("I cannot help.", _TOOLS), [])
+        self.assertEqual(agent.ToolCallParser.parse("I cannot help."), [])
 
     def test_malformed_json_rejected(self):
         # A JSON-looking but invalid payload must not become a successful
         # empty batch; send() should record a parser error instead.
         with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"op": "add_circle",}]', _TOOLS)
+            agent.ToolCallParser.parse('[{"op": "add_circle",}]')
         with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"op": "add_circle"', _TOOLS)
-
-    def test_unknown_op_rejected(self):
-        with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"op": "delete_universe"}]', _TOOLS)
+            agent.ToolCallParser.parse('[{"op": "add_circle"')
 
     def test_missing_op_rejected(self):
         with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"r": 1.0}]', _TOOLS)
+            agent.ToolCallParser.parse('[{"r": 1.0}]')
 
     def test_non_string_op_raises_valueerror_not_typeerror(self):
-        # An unhashable op (list/object) must not blow past the ValueError
-        # contract into a set-membership TypeError, or send() would crash
-        # instead of recording an error.
         with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"op": {"nested": 1}}]', _TOOLS)
+            agent.ToolCallParser.parse('[{"op": {"nested": 1}}]')
         with self.assertRaises(ValueError):
-            agent.ToolCallParser.parse('[{"op": ["a", "b"]}]', _TOOLS)
+            agent.ToolCallParser.parse('[{"op": ["a", "b"]}]')
 
-    def test_no_tool_surface_skips_op_validation(self):
-        # With no advertised ops, any op is accepted, so the pipeline still
-        # runs rather than rejecting everything.
-        commands = agent.ToolCallParser.parse('[{"op": "anything"}]', [])
-        self.assertEqual(commands, [{"op": "anything"}])
+    def test_unknown_op_survives_parsing(self):
+        commands = agent.ToolCallParser.parse(
+            '[{"op": "add_circle"}, {"op": "delete_universe"}]')
+        self.assertEqual([command["op"] for command in commands],
+                         ["add_circle", "delete_universe"])
+
+
+class ParseReplyStatusTC(unittest.TestCase):
+    def _status(self, text):
+        return agent.ToolCallParser.parse_reply(text).status
+
+    def test_commands(self):
+        reply = agent.ToolCallParser.parse_reply('[{"op": "add_line"}]')
+        self.assertEqual(reply.status, agent.ParseStatus.COMMANDS)
+        self.assertEqual(reply.commands, [{"op": "add_line"}])
+        self.assertIsNone(reply.error)
+
+    def test_explicit_empty_batch_is_not_prose(self):
+        self.assertEqual(self._status("[]"), agent.ParseStatus.EMPTY)
+        self.assertEqual(self._status("```json\n[]\n```"),
+                         agent.ParseStatus.EMPTY)
+        self.assertEqual(self._status("I cannot do that."),
+                         agent.ParseStatus.PROSE)
+
+    def test_blank_reply_is_empty(self):
+        self.assertEqual(self._status("   \n"), agent.ParseStatus.EMPTY)
+
+    def test_malformed_carries_the_parse_error(self):
+        reply = agent.ToolCallParser.parse_reply('[{"op": "add_circle",}]')
+        self.assertEqual(reply.status, agent.ParseStatus.MALFORMED)
+        self.assertEqual(reply.commands, [])
+        self.assertTrue(reply.error)
+
+    def test_bad_command_entry_is_malformed(self):
+        self.assertEqual(self._status('[{"r": 1.0}]'),
+                         agent.ParseStatus.MALFORMED)
+
+    def test_a_json_scalar_is_malformed_not_prose(self):
+        # `null` is the trap: it parses, but to the wrong shape.
+        for text in ("null", "42", '"done"', "true"):
+            self.assertEqual(self._status(text),
+                             agent.ParseStatus.MALFORMED, text)
 
 
 class SubprocessBackendDiscoveryTC(unittest.TestCase):
@@ -138,12 +167,14 @@ class ClaudeCliSendTC(unittest.TestCase):
             response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIsNotNone(response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.TRANSPORT)
 
     def test_send_nonzero_exit_is_error(self):
         self.backend._communicate = lambda argv: (1, "", "boom")
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIn("boom", response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.TRANSPORT)
 
     def test_send_timeout_is_error(self):
         def _timeout(argv):
@@ -151,13 +182,63 @@ class ClaudeCliSendTC(unittest.TestCase):
         self.backend._communicate = _timeout
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIn("timed out", response.error)
+        self.assertEqual(response.outcome, agent.TransportOutcome.TIMEOUT)
 
-    def test_send_unknown_op_reports_error_without_commands(self):
+    def test_send_after_cancel_reports_cancelled_not_transport(self):
+        def _killed(argv):
+            self.backend.cancel()
+            return -15, "", ""
+
+        self.backend._communicate = _killed
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(response.outcome, agent.TransportOutcome.CANCELLED)
+
+    def test_a_cancelled_call_that_still_succeeded_applies_nothing(self):
+        def _survived(argv):
+            self.backend.cancel()
+            return 0, _envelope('[{"op": "add_circle"}]'), ""
+
+        self.backend._communicate = _survived
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(response.outcome, agent.TransportOutcome.CANCELLED)
+        self.assertEqual(response.commands, [])
+
+    def test_a_cancel_during_spawn_still_terminates_the_child(self):
+        killed = []
+
+        class _Proc:
+            returncode = 0
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                killed.append(True)
+
+            def communicate(self, timeout=None):
+                return _envelope("[]"), ""
+
+        def _popen(argv, **kwargs):
+            self.backend.cancel()
+            return _Proc()
+
+        with mock.patch("subprocess.Popen", _popen):
+            self.backend.send("draw", "scene", _TOOLS)
+        self.assertTrue(killed)
+
+    def test_send_forgets_an_earlier_cancel(self):
+        self.backend.cancel()
+        self.backend._communicate = lambda argv: (1, "", "boom")
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(response.outcome, agent.TransportOutcome.TRANSPORT)
+
+    def test_send_unknown_op_reaches_the_runner(self):
         reply = _envelope('[{"op": "delete_universe"}]')
         self.backend._communicate = lambda argv: (0, reply, "")
         response = self.backend.send("wreck it", "scene", _TOOLS)
-        self.assertIsNotNone(response.error)
-        self.assertEqual(response.commands, [])
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "delete_universe"}])
+        self.assertEqual(response.status, agent.ParseStatus.COMMANDS)
 
     def test_send_malformed_json_is_error_not_empty_success(self):
         # Invalid JSON must surface as an error, not a silent empty batch.
@@ -166,6 +247,8 @@ class ClaudeCliSendTC(unittest.TestCase):
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIsNotNone(response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.OK)
+        self.assertEqual(response.status, agent.ParseStatus.MALFORMED)
 
     def test_send_unhashable_op_is_error_not_crash(self):
         # A malformed reply must come back as an error result, never an
@@ -362,6 +445,7 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIn("status 500", response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.TRANSPORT)
 
     def test_send_transport_failure_is_error(self):
         def _fail(body):
@@ -370,6 +454,7 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIn("failed", response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.TRANSPORT)
 
     def test_send_timeout_is_error(self):
         def _timeout(body):
@@ -377,13 +462,62 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         self.backend._post_chat = _timeout
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIn("timed out", response.error)
+        self.assertEqual(response.outcome, agent.TransportOutcome.TIMEOUT)
 
-    def test_send_unknown_op_reports_error_without_commands(self):
+    def test_send_after_cancel_reports_cancelled(self):
+        def _closed(body):
+            self.backend.cancel()
+            raise OSError("closed")
+
+        self.backend._post_chat = _closed
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(response.outcome, agent.TransportOutcome.CANCELLED)
+
+    def test_a_cancel_before_the_socket_opens_sends_nothing(self):
+        sent = []
+
+        class FakeConn:
+            def __init__(self, host, port, timeout=None):
+                pass
+
+            def request(self, method, path, body=None, headers=None):
+                sent.append(path)
+
+            def getresponse(self):
+                raise AssertionError("the cancelled request was sent")
+
+            def close(self):
+                pass
+
+        def _cancel_then_build(*args, **kwargs):
+            self.backend.cancel()
+            return FakeConn(*args, **kwargs)
+
+        with mock.patch(
+                "solvcon.agent._backends_impl.http.client.HTTPConnection",
+                _cancel_then_build):
+            response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(sent, [])
+        self.assertEqual(response.outcome, agent.TransportOutcome.CANCELLED)
+
+    def test_a_cancelled_call_that_still_answered_applies_nothing(self):
+        raw = self._chat_body('[{"op": "add_circle"}]')
+
+        def _raced(body):
+            self.backend.cancel()
+            return 200, raw
+
+        self.backend._post_chat = _raced
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertEqual(response.outcome, agent.TransportOutcome.CANCELLED)
+        self.assertEqual(response.commands, [])
+
+    def test_send_unknown_op_reaches_the_runner(self):
         raw = self._chat_body('[{"op": "delete_universe"}]')
         self.backend._post_chat = lambda body: (200, raw)
         response = self.backend.send("wreck it", "scene", _TOOLS)
-        self.assertIsNotNone(response.error)
-        self.assertEqual(response.commands, [])
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "delete_universe"}])
 
     def test_send_malformed_json_is_error_not_empty_success(self):
         raw = self._chat_body('[{"op": "add_circle",}]')
@@ -391,6 +525,7 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         response = self.backend.send("draw", "scene", _TOOLS)
         self.assertIsNotNone(response.error)
         self.assertEqual(response.commands, [])
+        self.assertEqual(response.status, agent.ParseStatus.MALFORMED)
 
     def test_parse_chat_payload_joins_content_parts(self):
         text = agent.OpenAIHttpBackend._parse_chat_payload({

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -336,5 +336,18 @@ class AgentDrawIntegrationTC(unittest.TestCase):
         self.assertIn("render_png",
                       {tool["name"] for tool in opted_in.tool_surface()})
 
+    def test_a_renderer_brings_render_png_back(self):
+        session = agent.AgentSession(renderer=object())
+        self.assertIn("render_png",
+                      {tool["name"] for tool in session.tool_surface()})
+        self.assertNotIn("render_png", session.hidden_ops)
+
+    def test_a_hidden_op_is_refused_instead_of_run(self):
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(world=world)
+        result = session.apply_commands([{"op": "render_png"}])[0]
+        self.assertFalse(result.ok)
+        self.assertIn("disabled", result.error)
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
A `BackendResponse` carried prose, commands, and an untyped `error`, which leaves the two questions a caller has to answer unanswerable. Whether the model replied at all was guesswork over error strings, and `ToolCallParser.parse` mapped an explicit `[]` and plain prose onto the same empty list, so "the request is done" and "the model talked instead of acting" were the same value.

The reply now names both. `TransportOutcome` says how the exchange ended (`ok`, `transport`, `timeout`, `cancelled`) and `ParseStatus` says what the text turned out to be (`commands`, `empty`, `prose`, `malformed`); both backends map their failure modes onto the first, and `parse_reply` returns the second beside the commands. A response that fills only the older fields still reports a usable status, so nothing existing has to change at once.

Cancellation becomes honest as part of this. `CancellableBackend` holds the flag both backends share, a cancel that lands before the child process or the socket is reachable is acted on once it is, and a call that was stopped but answered anyway returns `cancelled` with no commands rather than applying work the user asked to abandon.

Op names leave the parser. Rejecting an unadvertised op while parsing threw away every command that arrived with it; the runner already answers unknown ops with a per-command error, so one bad entry no longer voids its batch. What the session hides from the tool surface it now refuses at execution instead, and injecting a renderer stops hiding `render_png`, which is the op that renderer is for.

This is the first of two stacked changes: the turn loop that reads these statuses follows once this lands.

Related to #1136, #966.
