### PR TITLE
Fence dependency builds by platform

### DIFF
--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -931,6 +931,40 @@ if [ "${SCDV_PRINT_DEPS_ONLY}" = "1" ] ; then
   exit 0
 fi
 
+# The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
+case "$(uname -m)" in
+  x86_64|amd64) SCDV_ARCH=x86_64 ;;
+  arm64|aarch64) SCDV_ARCH=arm64 ;;
+  *)
+    echo "unsupported architecture '$(uname -m)'" >&2
+    exit 1
+    ;;
+esac
+
+case "${SCDV_OS}:${SCDV_ARCH}" in
+  ubuntu:x86_64|macos:arm64)
+    ;;
+  macos:x86_64)
+    # Intel Mac: some dependencies may not build. (e.g. numpy/scipy)
+    echo "warning: some dependencies may not build correctly on" \
+         "macos/x86_64 (Intel Mac)." >&2
+    if ! { : </dev/tty ; } 2>/dev/null ; then
+      echo "no controlling tty to confirm; rerun on a supported" \
+           "OS/architecture." >&2
+      exit 1
+    fi
+    read -r -p "Continue anyway? [y/N] " _ans </dev/tty
+    case "${_ans}" in
+      [Yy]*) ;;
+      *) echo "aborted." >&2 ; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "unsupported OS/architecture '${SCDV_OS}/${SCDV_ARCH}'" >&2
+    exit 1
+    ;;
+esac
+
 # One-time platform setup (e.g. macOS BREW_PREFIX detection).
 plat_init
 


### PR DESCRIPTION
Reject unsupported OS and architecture combinations before starting the dependency build. Allow Ubuntu on 64-bit x86 and macOS on Apple Silicon.

Related to #807

<!--
solvcon pull request guidelines.

- Subject: concise and informative.
- Description: clear prose.  Write single-line paragraphs separated by blank
  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
  columns renders as ragged mid-sentence breaks.
- Draft until ready: open the PR as a draft while work is in progress.  When
  the PR is ready for review, post a global PR comment that explicitly asks for
  review.  Pushing the "ready for review" button alone is not a review request,
  because the push cannot be quoted in follow-ups.
- Inline annotations: as the author, add inline annotations on the diff to
  guide the reviewer, unless the diff is one-liner-ish.
- Issue reference: end the description with "Related to #xxx" or "For issue
  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
  let PR or commit text drive issue management.
- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
  you need to know what you wrote.

Delete this comment block before submitting.
-->

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
