### PR TITLE
Name the user presets `ide-*` and keep agents on `make`

### DIFF
--- a/.claude/skills/ide-user-presets/SKILL.md
+++ b/.claude/skills/ide-user-presets/SKILL.md
@@ -1,30 +1,32 @@
 ---
-name: cmake-user-presets
-description: Install or refresh CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `scdv-rel` preset carries a real path. Use in a fresh checkout or worktree, when `scdv-rel` is missing from `cmake --list-presets`, or after the template changes.
+name: ide-user-presets
+description: Install or refresh an IDE's CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `ide-scdv-rel` preset carries a real path. Use when setting an IDE up on a checkout, when an IDE cannot find Qt6 or pybind11, or after the template changes. Not a build step; agents build with `make`.
 ---
 
-# CMake User Presets (solvcon)
+# IDE User Presets (solvcon)
 
-`CMakeUserPresets.json` is gitignored, so every fresh checkout and every new
-worktree starts without it and without the `scdv-rel` preset. The `scdv`
-templates in `contrib/cmake/` name the prefix once, as `$penv{SCDV_USRDIR}` in
-the preset's `environment` map, and the three cache variables read it back
-from there as `$env{SCDV_USRDIR}`. Installing one is a copy with that single
-occurrence replaced by the prefix it names.
+An IDE uses `CMakeUserPresets.json`. It is gitignored, it holds one machine's
+literal paths, and its presets are named `ide-*` to keep them apart from the
+shared presets in `CMakePresets.json`. Install it when an IDE needs it, never
+as preparation for a build: an agent builds with `make`, which selects a
+checked-in preset and layers the activated environment on top.
+
+The `scdv` templates in `contrib/cmake/` name the prefix once, as
+`$penv{SCDV_USRDIR}` in the preset's `environment` map, and the three cache
+variables read it back from there as `$env{SCDV_USRDIR}`. Installing one is a
+copy with that single occurrence replaced by the prefix it names.
 
 Substituting rather than leaving the expansion in place is the whole point.
 An IDE started from the desktop inherits the session environment, not the
 shell where an scdv was activated, so `$penv{SCDV_USRDIR}` would expand to
-nothing there and the preset would configure against empty paths. A real path
-in the installed file works in a shell, in a desktop IDE, and in an agent
-session alike.
+nothing there and the preset would configure against empty paths.
 
 ## When to use
 
-A checkout has no `CMakeUserPresets.json`, `cmake --list-presets` does not
-offer `scdv-rel`, an IDE cannot find Qt6 or pybind11, or the template in
-`contrib/cmake/` changed and the installed copy is stale. The `worktree` skill
-calls this after creating a worktree.
+The user is setting an IDE up on a checkout, an IDE cannot find Qt6 or
+pybind11, or the template in `contrib/cmake/` changed and the installed copy
+is stale. Nothing else triggers it. Entering a worktree does not, and neither
+does a task that happens to build.
 
 ## 1. Resolve the scdv prefix
 
@@ -87,10 +89,11 @@ test -d "$(sed -n 's/.*"SCDV_USRDIR": "\(.*\)".*/\1/p' CMakeUserPresets.json)"
 
 The remaining `$env{SCDV_USRDIR}` in the cache variables is correct, and
 resolves from the `environment` map above them. Then `cmake --list-presets`
-has to show `scdv-rel`, and `cmake --list-presets=build` has to show
-`scdv-rel`, `scdv-rel-module`, and `scdv-rel-gtest`. Report the preset names
-and the prefix they carry; do not configure or build unless the user asked for
-it.
+has to show `ide-scdv-rel`, and `cmake --list-presets=build` has to show
+`ide-scdv-rel`, `ide-scdv-rel-module`, and `ide-scdv-rel-gtest`. Report the
+preset names and the prefix they carry, then stop. Listing is the whole
+verification: configuring or building through an `ide-*` preset is the IDE's
+job, and a build of your own is `make`.
 
 Both listings have to work with the scdv deactivated, which is what an IDE
 sees. `env -u SCDV_USRDIR cmake --list-presets` is the cheap way to prove it.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -17,11 +17,7 @@ Based on the agent type, do one of the following:
 - **Cursor:**  use Cursors's builtin `/worktree` command instead. If the built-in command is unavailable, fall back like Codex below.
 - **Codex, otherwise:** run `git worktree add -b worktree-<name> .claude/worktrees/<name> origin/master`, then run all commands from it.
 
-## 2. Seed the local CMake presets
-
-A new worktree is a fresh checkout, so it has no `CMakeUserPresets.json` and no `scdv-rel` preset. Install one with the `cmake-user-presets` skill before the first configure. Skip it when the task touches no build.
-
-## 3. Do the task
+## 2. Do the task
 
 Implement `<description>` in the worktree. Follow normal project rules. Stop when done; do not auto-commit, open a PR, or remove the worktree unless asked.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,16 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
 - `make pilot` -- build the Qt pilot GUI binary.
 - `make clean` / `make cmakeclean` -- remove build artifacts.
 
+Build through `make` unless you are instructed otherwise. The configure knobs
+live in `CMakePresets.json`, which is checked in and shared; `make` selects one
+and layers the environment on top of it, so an activated dependency environment
+already reaches the build. Select another with `make CMAKE_PRESET=<name>`.
+
+`CMakeUserPresets.json` belongs to the users (and IDE) for their manual
+operations, not to an agent. Its presets are named `ide-*`. Agents never
+configure, build, or test through an `ide-*` preset, and create the file only
+when asked to set an IDE up.
+
 **Test**
 
 - `make pytest` -- full Python test suite.

--- a/contrib/cmake/CMakeUserPresets.example.json
+++ b/contrib/cmake/CMakeUserPresets.example.json
@@ -4,9 +4,9 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "local-rel",
+      "name": "ide-local-rel",
       "inherits": "dev-rel",
-      "displayName": "Local dependency prefix",
+      "displayName": "IDE or manual use: local prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
@@ -20,22 +20,22 @@
   ],
   "buildPresets": [
     {
-      "name": "local-rel",
+      "name": "ide-local-rel",
       "inherits": "dev-rel",
-      "configurePreset": "local-rel",
-      "displayName": "local rel"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel"
     },
     {
-      "name": "local-rel-module",
+      "name": "ide-local-rel-module",
       "inherits": "dev-rel-module",
-      "configurePreset": "local-rel",
-      "displayName": "local rel module"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel module"
     },
     {
-      "name": "local-rel-gtest",
+      "name": "ide-local-rel-gtest",
       "inherits": "dev-rel-gtest",
-      "configurePreset": "local-rel",
-      "displayName": "local rel gtest"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel gtest"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.scdv.json
+++ b/contrib/cmake/CMakeUserPresets.scdv.json
@@ -4,9 +4,9 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "scdv-rel",
+      "name": "ide-scdv-rel",
       "inherits": "dev-rel",
-      "displayName": "scdv dependency prefix",
+      "displayName": "IDE or manual use: scdv prefix",
       "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
       "environment": {
         "SCDV_USRDIR": "$penv{SCDV_USRDIR}"
@@ -23,22 +23,22 @@
   ],
   "buildPresets": [
     {
-      "name": "scdv-rel",
+      "name": "ide-scdv-rel",
       "inherits": "dev-rel",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel"
     },
     {
-      "name": "scdv-rel-module",
+      "name": "ide-scdv-rel-module",
       "inherits": "dev-rel-module",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel module"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel module"
     },
     {
-      "name": "scdv-rel-gtest",
+      "name": "ide-scdv-rel-gtest",
       "inherits": "dev-rel-gtest",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel gtest"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel gtest"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.win-example.json
+++ b/contrib/cmake/CMakeUserPresets.win-example.json
@@ -4,9 +4,9 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "local-rel",
+      "name": "ide-local-rel",
       "inherits": "win-rel",
-      "displayName": "Local dependency prefix",
+      "displayName": "IDE or manual use: local prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
@@ -20,22 +20,22 @@
   ],
   "buildPresets": [
     {
-      "name": "local-rel",
+      "name": "ide-local-rel",
       "inherits": "win-rel",
-      "configurePreset": "local-rel",
-      "displayName": "local rel"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel"
     },
     {
-      "name": "local-rel-module",
+      "name": "ide-local-rel-module",
       "inherits": "win-rel-module",
-      "configurePreset": "local-rel",
-      "displayName": "local rel module"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel module"
     },
     {
-      "name": "local-rel-gtest",
+      "name": "ide-local-rel-gtest",
       "inherits": "win-rel-gtest",
-      "configurePreset": "local-rel",
-      "displayName": "local rel gtest"
+      "configurePreset": "ide-local-rel",
+      "displayName": "ide local rel gtest"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.win-scdv.json
+++ b/contrib/cmake/CMakeUserPresets.win-scdv.json
@@ -4,9 +4,9 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "scdv-rel",
+      "name": "ide-scdv-rel",
       "inherits": "win-rel",
-      "displayName": "scdv dependency prefix",
+      "displayName": "IDE or manual use: scdv prefix",
       "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
       "environment": {
         "SCDV_USRDIR": "$penv{SCDV_USRDIR}"
@@ -23,22 +23,22 @@
   ],
   "buildPresets": [
     {
-      "name": "scdv-rel",
+      "name": "ide-scdv-rel",
       "inherits": "win-rel",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel"
     },
     {
-      "name": "scdv-rel-module",
+      "name": "ide-scdv-rel-module",
       "inherits": "win-rel-module",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel module"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel module"
     },
     {
-      "name": "scdv-rel-gtest",
+      "name": "ide-scdv-rel-gtest",
       "inherits": "win-rel-gtest",
-      "configurePreset": "scdv-rel",
-      "displayName": "scdv rel gtest"
+      "configurePreset": "ide-scdv-rel",
+      "displayName": "ide scdv rel gtest"
     }
   ]
 }

--- a/doc/source/devguide/cmake.md
+++ b/doc/source/devguide/cmake.md
@@ -115,6 +115,12 @@ it is gitignored.  Both VS Code and CLion pick it up with no IDE settings at
 all, which is the only way a dependency prefix reaches an IDE build: there is
 no wrapper script to fall back on there.
 
+The file provides the information that can be used by the IDE, and its presets
+are named `ide-*`.  A shell build has no use for it, because an activated
+environment already exports `CMAKE_PREFIX_PATH` and `make` forwards it onto a
+checked-in preset.  Build from a shell with `make`, or with
+`make CMAKE_PRESET=<name>` to pick another checked-in preset.
+
 There is one template per host family, because the checked-in presets a user
 preset builds on are themselves split by host.  Copy the one for your host and
 edit the three paths:
@@ -126,18 +132,18 @@ cp contrib/cmake/CMakeUserPresets.example.json CMakeUserPresets.json
 cp contrib/cmake/CMakeUserPresets.win-example.json CMakeUserPresets.json
 ```
 
-Each defines a configure preset named `local-rel` that inherits a checked-in
-preset and adds the three variables, plus the three build presets that go with
-it:
+Each defines a configure preset named `ide-local-rel` that inherits a
+checked-in preset and adds the three variables, plus the three build presets
+that go with it:
 
 ```json
 {
   "version": 10,
   "configurePresets": [
     {
-      "name": "local-rel",
+      "name": "ide-local-rel",
       "inherits": "dev-rel",
-      "displayName": "Local dependency prefix",
+      "displayName": "IDE or manual use: local prefix",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
@@ -149,24 +155,23 @@ it:
     }
   ],
   "buildPresets": [
-    { "name": "local-rel", "inherits": "dev-rel",
-      "configurePreset": "local-rel" }
+    { "name": "ide-local-rel", "inherits": "dev-rel",
+      "configurePreset": "ide-local-rel" }
   ]
 }
 ```
 
 Every `inherits` in the file names a preset of one host family, and they have
 to stay a matched set.  A `dev-` build preset carries a condition that
-disables it on Windows and a `win-` one carries the opposite, so a `local-rel`
-that inherits a `win-` configure preset and `dev-` build presets configures
-and then refuses to build.  Change them together, or start from the template
-for the family you want.
+disables it on Windows and a `win-` one carries the opposite, so an
+`ide-local-rel` that inherits a `win-` configure preset and `dev-` build
+presets configures and then refuses to build.  Change them together, or start
+from the template for the family you want.
 
 `pybind11_path` names the directory holding `pybind11Config.cmake`, which is
 what `python3 -m pybind11 --cmakedir` prints for the interpreter named above
-it.  After that, `cmake --preset local-rel` configures from a bare checkout,
-and `local-rel` appears in the IDE preset pickers alongside the checked-in
-presets.
+it.  After that, `ide-local-rel` appears in the IDE preset pickers alongside
+the checked-in presets.
 
 In CLion the `enablePythonIntegration` key in the `jetbrains.com/clion` vendor
 map, already set in the checked-in presets, hands the IDE's selected
@@ -175,10 +180,10 @@ interpreter to the configure step.  A CLion user can therefore drop the
 
 `CMakeUserPresets.scdv.json` and `CMakeUserPresets.win-scdv.json` sit beside
 the two templates above for a prefix that `build-scdv.sh` built (see
-{doc}`/start/build_dep`).  Their configure preset is `scdv-rel`, and it names
-that prefix once rather than repeating it in three literal paths, so
+{doc}`/start/build_dep`).  Their configure preset is `ide-scdv-rel`, and it
+names that prefix once rather than repeating it in three literal paths, so
 installing one substitutes a single value instead of editing three.  The
-`cmake-user-presets` skill under `.claude/skills/` states the substitution and
+`ide-user-presets` skill under `.claude/skills/` states the substitution and
 what has to hold for it.
 
 ## IDE notes


### PR DESCRIPTION
PR #1248 updated the worktree skill to install the cmake user presets, and it interfered agent auto building.

Remove the `worktree` step that seeded the file before every build.  Also rename the `cmake-user-presets` skill to `ide-user-presets` with an IDE-scoped trigger, and state the boundary in `CLAUDE.md`, so that agents do not think the configuration is for them.