### PR TITLE
Populate mesh boundary-condition groups from Python

### DIFF
--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -153,8 +153,8 @@ struct StaticMeshConstant
  *
  * @ingroup group_mesh
  */
-// TODO: StaticMeshBC may use polymorphism.
-class StaticMeshBC
+// TODO: StaticMeshBc may use polymorphism.
+class StaticMeshBc
     : public NumberBase<int32_t, double>
     , public StaticMeshConstant
 {
@@ -184,14 +184,14 @@ public:
         return str;
     }
 
-    StaticMeshBC() = default;
+    StaticMeshBc() = default;
 
-    explicit StaticMeshBC(ssize_t nbound)
+    explicit StaticMeshBc(ssize_t nbound)
         : m_facn(SimpleArray<int_type>(small_vector<ssize_t>{nbound, BFREL}))
     {
     }
 
-    StaticMeshBC(StaticMeshBC const & other)
+    StaticMeshBc(StaticMeshBc const & other)
     {
         if (this != &other)
         {
@@ -199,7 +199,7 @@ public:
         }
     }
 
-    StaticMeshBC(StaticMeshBC && other) // FIXME: NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations)
+    StaticMeshBc(StaticMeshBc && other) // FIXME: NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations)
     {
         if (this != &other)
         {
@@ -207,7 +207,7 @@ public:
         }
     }
 
-    StaticMeshBC & operator=(StaticMeshBC const & other)
+    StaticMeshBc & operator=(StaticMeshBc const & other)
     {
         if (this != &other)
         {
@@ -216,7 +216,7 @@ public:
         return *this;
     }
 
-    StaticMeshBC & operator=(StaticMeshBC && other) // FIXME: NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations)
+    StaticMeshBc & operator=(StaticMeshBc && other) // FIXME: NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations)
     {
         if (this != &other)
         {
@@ -225,14 +225,14 @@ public:
         return *this;
     }
 
-    ~StaticMeshBC() = default;
+    ~StaticMeshBc() = default;
 
     ssize_t nbound() const { return m_facn.nbody(); }
 
     SimpleArray<int_type> const & facn() const { return m_facn; }
     SimpleArray<int_type> & facn() { return m_facn; }
 
-}; /* end class StaticMeshBC */
+}; /* end class StaticMeshBc */
 
 /**
  * Static unstructured mesh storing nodes, faces, and cells of mixed element
@@ -290,7 +290,7 @@ public:
         , m_clnds(small_vector<ssize_t>{static_cast<ssize_t>(ncell), CLMND + 1})
         , m_clfcs(small_vector<ssize_t>{static_cast<ssize_t>(ncell), CLMFC + 1})
         , m_ednds(small_vector<ssize_t>{0, 2})
-        , m_bndfcs(small_vector<ssize_t>{0, StaticMeshBC::BFREL})
+        , m_bndfcs(small_vector<ssize_t>{0, StaticMeshBc::BFREL})
     {
     }
     StaticMesh() = delete;
@@ -421,7 +421,7 @@ private:                                                                \
     MM_DECL_StaticMesh_ARRAY(int_type, ednds);
     // boundary information.
     MM_DECL_StaticMesh_ARRAY(int_type, bndfcs);
-    std::vector<StaticMeshBC> m_bcs;
+    std::vector<StaticMeshBc> m_bcs;
 
 #undef MM_DECL_StaticMesh_ARRAY
 

--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -17,6 +17,8 @@
 #include <solvcon/buffer/buffer.hpp>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 #include <numeric>
 
@@ -175,6 +177,7 @@ private:
      * block (if exists).
      */
     SimpleArray<int_type> m_facn = SimpleArray<int_type>(small_vector<ssize_t>{0});
+    std::string m_name = NONAME();
 
 public:
 
@@ -187,7 +190,13 @@ public:
     StaticMeshBc() = default;
 
     explicit StaticMeshBc(ssize_t nbound)
-        : m_facn(SimpleArray<int_type>(small_vector<ssize_t>{nbound, BFREL}))
+        : m_facn(SimpleArray<int_type>(small_vector<ssize_t>{nbound, BFREL}, -1))
+    {
+    }
+
+    StaticMeshBc(std::string name, ssize_t nbound)
+        : m_facn(SimpleArray<int_type>(small_vector<ssize_t>{nbound, BFREL}, -1))
+        , m_name(std::move(name))
     {
     }
 
@@ -196,6 +205,7 @@ public:
         if (this != &other)
         {
             m_facn = other.m_facn;
+            m_name = other.m_name;
         }
     }
 
@@ -204,6 +214,7 @@ public:
         if (this != &other)
         {
             m_facn = std::move(other.m_facn);
+            m_name = std::move(other.m_name);
         }
     }
 
@@ -212,6 +223,7 @@ public:
         if (this != &other)
         {
             m_facn = other.m_facn;
+            m_name = other.m_name;
         }
         return *this;
     }
@@ -221,6 +233,7 @@ public:
         if (this != &other)
         {
             m_facn = std::move(other.m_facn);
+            m_name = std::move(other.m_name);
         }
         return *this;
     }
@@ -228,6 +241,9 @@ public:
     ~StaticMeshBc() = default;
 
     ssize_t nbound() const { return m_facn.nbody(); }
+
+    std::string const & name() const { return m_name; }
+    void set_name(std::string name) { m_name = std::move(name); }
 
     SimpleArray<int_type> const & facn() const { return m_facn; }
     SimpleArray<int_type> & facn() { return m_facn; }
@@ -367,6 +383,18 @@ private:
     // Helpers for boundary data (as well as ghost).
 public:
 
+    /**
+     * Attach a boundary-condition group.
+     *
+     * The boundary-condition groups are used by build_boundary.
+     */
+    void add_bc(std::shared_ptr<StaticMeshBc> const & bnd);
+    std::shared_ptr<StaticMeshBc> add_bc(std::string const & name, std::vector<int_type> const & faces);
+
+    std::vector<std::shared_ptr<StaticMeshBc>> const & bcs() const { return m_bcs; }
+    std::shared_ptr<StaticMeshBc> const & bc(size_t ibc) const { return m_bcs.at(ibc); }
+    std::shared_ptr<StaticMeshBc> find_bc(std::string const & name) const;
+
     void build_boundary();
     void build_ghost();
 
@@ -421,7 +449,7 @@ private:                                                                \
     MM_DECL_StaticMesh_ARRAY(int_type, ednds);
     // boundary information.
     MM_DECL_StaticMesh_ARRAY(int_type, bndfcs);
-    std::vector<StaticMeshBc> m_bcs;
+    std::vector<std::shared_ptr<StaticMeshBc>> m_bcs;
 
 #undef MM_DECL_StaticMesh_ARRAY
 

--- a/cpp/solvcon/mesh/StaticMesh_boundary.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_boundary.cpp
@@ -30,7 +30,7 @@ void StaticMesh::build_boundary()
         }
     }
     SimpleArray<int_type>(
-        small_vector<ssize_t>{static_cast<ssize_t>(m_nbound), StaticMeshBC::BFREL},
+        small_vector<ssize_t>{static_cast<ssize_t>(m_nbound), StaticMeshBc::BFREL},
         -1)
         .swap(m_bndfcs);
 
@@ -51,7 +51,7 @@ void StaticMesh::build_boundary()
     ssize_t nleft = m_nbound;
     for (size_t ibnd = 0; ibnd < m_bcs.size(); ++ibnd)
     {
-        StaticMeshBC & bnd = m_bcs[ibnd];
+        StaticMeshBc & bnd = m_bcs[ibnd];
         auto & bfacn = bnd.facn();
         for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
         {
@@ -76,7 +76,7 @@ void StaticMesh::build_boundary()
 
     if (nleft != 0)
     {
-        StaticMeshBC bnd(nleft);
+        StaticMeshBc bnd(nleft);
         auto & bfacn = bnd.facn();
         size_t bfit = 0;
         size_t const ibnd = m_bcs.size();

--- a/cpp/solvcon/mesh/StaticMesh_boundary.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_boundary.cpp
@@ -5,8 +5,89 @@
 
 #include <solvcon/mesh/StaticMesh.hpp>
 
+#include <format>
+#include <stdexcept>
+
 namespace solvcon
 {
+
+void StaticMesh::add_bc(std::shared_ptr<StaticMeshBc> const & bnd)
+{
+    if (0 != m_nbound)
+    {
+        throw std::runtime_error("StaticMesh::add_bc: boundary is already built");
+    }
+    if (!bnd)
+    {
+        throw std::invalid_argument("StaticMesh::add_bc: null boundary condition");
+    }
+    if (bnd->name().empty())
+    {
+        throw std::invalid_argument("StaticMesh::add_bc: empty name");
+    }
+    if (find_bc(bnd->name()))
+    {
+        throw std::invalid_argument(std::format(
+            "StaticMesh::add_bc: duplicated name \"{}\"", bnd->name()));
+    }
+
+    std::vector<bool> claimed(nface(), false);
+    for (auto const & prev : m_bcs)
+    {
+        auto const & pfacn = prev->facn();
+        for (size_t bfit = 0; bfit < pfacn.nbody(); ++bfit)
+        {
+            claimed[pfacn(bfit, 0)] = true;
+        }
+    }
+    auto const & bfacn = bnd->facn();
+    for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
+    {
+        int_type const ifc = bfacn(bfit, 0);
+        if (ifc < 0 || ifc >= static_cast<int_type>(nface()))
+        {
+            throw std::invalid_argument(std::format(
+                "StaticMesh::add_bc: face {} out of range [0, {})", ifc, nface()));
+        }
+        if (fcjcl(ifc) >= 0)
+        {
+            throw std::invalid_argument(std::format(
+                "StaticMesh::add_bc: face {} is not a boundary face", ifc));
+        }
+        if (claimed[ifc])
+        {
+            throw std::invalid_argument(std::format(
+                "StaticMesh::add_bc: face {} is already claimed", ifc));
+        }
+        claimed[ifc] = true;
+    }
+
+    m_bcs.push_back(bnd);
+}
+
+std::shared_ptr<StaticMeshBc> StaticMesh::add_bc(std::string const & name, std::vector<int_type> const & faces)
+{
+    auto bnd = std::make_shared<StaticMeshBc>(name, static_cast<ssize_t>(faces.size()));
+    auto & bfacn = bnd->facn();
+    for (size_t bfit = 0; bfit < faces.size(); ++bfit)
+    {
+        bfacn(bfit, 0) = faces[bfit];
+    }
+    add_bc(bnd);
+    return bnd;
+}
+
+std::shared_ptr<StaticMeshBc> StaticMesh::find_bc(std::string const & name) const
+{
+    for (auto const & bnd : m_bcs)
+    {
+        if (bnd->name() == name)
+        {
+            return bnd;
+        }
+    }
+    return nullptr;
+}
 
 /**
  * Calculate all metric information, including:
@@ -21,7 +102,10 @@ namespace solvcon
 /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 void StaticMesh::build_boundary()
 {
-    assert(0 == m_nbound); // nothing should touch m_nbound beforehand.
+    if (0 != m_nbound)
+    {
+        throw std::runtime_error("StaticMesh::build_boundary: boundary is already built");
+    }
     for (ssize_t it = 0; it < fccls().shape(0); ++it)
     {
         if (fccls()(it, 1) < 0)
@@ -51,8 +135,7 @@ void StaticMesh::build_boundary()
     ssize_t nleft = m_nbound;
     for (size_t ibnd = 0; ibnd < m_bcs.size(); ++ibnd)
     {
-        StaticMeshBc & bnd = m_bcs[ibnd];
-        auto & bfacn = bnd.facn();
+        auto & bfacn = m_bcs[ibnd]->facn();
         for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
         {
             /**
@@ -76,8 +159,8 @@ void StaticMesh::build_boundary()
 
     if (nleft != 0)
     {
-        StaticMeshBc bnd(nleft);
-        auto & bfacn = bnd.facn();
+        auto bnd = std::make_shared<StaticMeshBc>(nleft);
+        auto & bfacn = bnd->facn();
         size_t bfit = 0;
         size_t const ibnd = m_bcs.size();
         for (size_t sit = 0; sit < m_nbound; ++sit) // Specified ITerator.

--- a/cpp/solvcon/mesh/pymod/wrap_StaticMesh.cpp
+++ b/cpp/solvcon/mesh/pymod/wrap_StaticMesh.cpp
@@ -12,6 +12,35 @@ namespace solvcon
 namespace python
 {
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapStaticMeshBc
+    : public WrapBase<WrapStaticMeshBc, StaticMeshBc, std::shared_ptr<StaticMeshBc>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapStaticMeshBc, StaticMeshBc, std::shared_ptr<StaticMeshBc>>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapStaticMeshBc(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapStaticMeshBc */
+
+WrapStaticMeshBc::WrapStaticMeshBc(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    (*this)
+        .def_property("name", &wrapped_type::name, &wrapped_type::set_name)
+        .def_property_readonly("nbound", &wrapped_type::nbound)
+        .expose_SimpleArray("facn", [](wrapped_type & self) -> decltype(auto)
+                            { return self.facn(); });
+
+    this->cls().attr("NONAME") = wrapped_type::NONAME();
+}
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapStaticMesh
     : public WrapBase<WrapStaticMesh, StaticMesh, std::shared_ptr<StaticMesh>>
 {
@@ -34,6 +63,7 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
 {
     namespace py = pybind11;
 
+    using int_type = typename wrapped_type::int_type;
     using uint_type = typename wrapped_type::uint_type;
 
     (*this)
@@ -81,6 +111,33 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
         .def_timed("build_ghost", &wrapped_type::build_ghost)
         .def_timed("build_edge", &wrapped_type::build_edge);
 
+    (*this)
+        .def(
+            "add_bc",
+            [](wrapped_type & self, std::string const & name, std::vector<int_type> const & faces)
+            { return self.add_bc(name, faces); },
+            py::arg("name"),
+            py::arg("faces"))
+        .def(
+            "bc",
+            [](wrapped_type & self, size_t ibc)
+            { return self.bc(ibc); },
+            py::arg("ibc"))
+        .def(
+            "bc",
+            [](wrapped_type & self, std::string const & name)
+            {
+                auto bnd = self.find_bc(name);
+                if (!bnd)
+                {
+                    throw py::key_error(name);
+                }
+                return bnd;
+            },
+            py::arg("name"))
+        .def_property_readonly("bcs", [](wrapped_type & self)
+                               { return self.bcs(); });
+
 #define MM_DECL_ARRAY(NAME) \
     .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
 
@@ -119,6 +176,7 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
 
 void wrap_StaticMesh(pybind11::module & mod)
 {
+    WrapStaticMeshBc::commit(mod, "StaticMeshBc", "StaticMeshBc");
     WrapStaticMesh::commit(mod, "StaticMesh", "StaticMesh");
 }
 

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -65,6 +65,7 @@ list_of_mesh = [
     'StaticGrid2d',
     'StaticGrid3d',
     'StaticMesh',
+    'StaticMeshBc',
 ]
 
 # multidim directory symbols

--- a/solvcon/multidim/euler/oblique.py
+++ b/solvcon/multidim/euler/oblique.py
@@ -3,7 +3,8 @@
 
 
 """
-Mesh, boundary tagging, and solver driver for the oblique-shock reflection.
+Mesh, boundary-condition groups, and solver driver for the oblique-shock
+reflection.
 """
 
 import math
@@ -58,8 +59,10 @@ class ObliqueShockMesher(object):
         which the corner ``'quad'`` cells cannot.  All flavors share the
         boundary layout (nx segments on the bottom and top, ny on the left
         and right) and produce counter-clockwise cells.  The returned mesh
-        has ``ndcrd``/``cltpn``/``clnds`` filled and ``build_interior`` /
-        ``build_boundary`` / ``build_ghost`` run.
+        has ``ndcrd``/``cltpn``/``clnds`` filled, carries one named
+        boundary-condition group per domain edge (:attr:`BOUNDARY_NAMES`),
+        and has ``build_interior`` / ``build_boundary`` / ``build_ghost``
+        run.
         """
         nx, ny = self.nx, self.ny
         if cell_type in ('quad', 'triangle'):
@@ -98,34 +101,16 @@ class ObliqueShockMesher(object):
         mh.cltpn.fill(tpn)
         mh.clnds[:, :len(cells[0])] = cells
         mh.build_interior(do_metric=True)
+        for name, faces in zip(self.BOUNDARY_NAMES,
+                               self.classify_boundary(mh)):
+            mh.add_bc(name, faces)
         mh.build_boundary()
         mh.build_ghost()
-        self.tag_boundary(mh)
         return mh
 
-    #: Boundary-set id per domain edge written by :meth:`tag_boundary`, in
-    #: the order :meth:`classify_boundary` returns the edges.
+    #: Boundary-condition group name per domain edge, in the order
+    #: :meth:`classify_boundary` returns the edges.
     BOUNDARY_NAMES = ('left', 'top', 'bottom', 'right')
-
-    @classmethod
-    def tag_boundary(cls, mh, tol=1e-9):
-        """Write the domain edge of each boundary face into ``bndfcs``.
-
-        ``build_boundary`` collects every unspecified boundary face into one
-        catch-all set, so viewers that color or toggle by boundary set (for
-        example the pilot's ``colorByBoundary``) cannot tell the edges
-        apart.  Overwrite the set column with the :meth:`classify_boundary`
-        edge, indexed per :attr:`BOUNDARY_NAMES`, purely as display
-        metadata: the solver takes its face lists directly and never reads
-        ``bndfcs``.
-        """
-        byface = dict()
-        for ibc, faces in enumerate(cls.classify_boundary(mh, tol=tol)):
-            for ifc in faces:
-                byface[ifc] = ibc
-        bndfcs = mh.bndfcs.ndarray
-        for ibnd in range(bndfcs.shape[0]):
-            bndfcs[ibnd, 1] = byface[bndfcs[ibnd, 0]]
 
     def _jitter_points(self):
         """Collect the unstructured point cloud in a :class:`PointPad`.
@@ -274,7 +259,7 @@ class ObliqueShockMesher(object):
         the real edges.
 
         Returns ``(left, top, bottom, right)`` as sorted face-index lists
-        ready to feed ``add_inlet`` / ``add_slipwall`` / ``add_nonrefl``.
+        ready to feed :meth:`~solvcon.core.StaticMesh.add_bc`.
         """
         bfaces = [ifc for ifc in range(mh.nface) if mh.fccls[ifc, 1] < 0]
         xcs = [mh.fccnd[ifc, 0] for ifc in bfaces]
@@ -490,7 +475,11 @@ class ObliqueShock(object):
         svr.tauscale = tauscale
         svr.init_solution(gamma=self.gamma, rho=self.density,
                           v=[self.velocity, 0.0], p=self.pressure)
-        left, top, bottom, right = self.mesher.classify_boundary(self.mesh)
+        # The mesher attached one named group per domain edge; read the
+        # face lists back from the mesh instead of re-classifying.
+        left, top, bottom, right = (
+            self.mesh.bc(name).facn.ndarray[:, 0].tolist()
+            for name in self.mesher.BOUNDARY_NAMES)
         svr.add_inlet(left, value=[self.density, self.velocity, 0.0,
                                    self.pressure, self.gamma])
         svr.add_inlet(top, value=[self.density2, self.velocity2[0],

--- a/solvcon/pilot/_euler/_oblique.py
+++ b/solvcon/pilot/_euler/_oblique.py
@@ -5,9 +5,9 @@
 """
 Example pilot apps for the oblique-shock reflection.
 
-The mesh construction, boundary tagging, and solver driver live in
-:mod:`solvcon.multidim.euler.oblique`.  :class:`ObliqueShockMesh` draws the
-mesh in a 3D widget and reports the boundary classification (left / top /
+The mesh construction, boundary-condition groups, and solver driver live
+in :mod:`solvcon.multidim.euler.oblique`.  :class:`ObliqueShockMesh` draws
+the mesh in a 3D widget and reports the boundary groups (left / top /
 bottom / right edges) to the console.  Running the solver and animating its
 solution fields is handled by the interactive panel in
 :mod:`._solution_info`.
@@ -23,7 +23,7 @@ __all__ = [  # noqa: F822
 
 class ObliqueShockMesh(_gui_common.PilotFeature):
     """
-    Draw the oblique-shock reflection mesh and tag its boundary.
+    Draw the oblique-shock reflection mesh and its boundary groups.
     """
 
     def mesh_sample_dialog_entries(self):
@@ -53,22 +53,21 @@ class ObliqueShockMesh(_gui_common.PilotFeature):
     def _draw_mesh(self, cell_type):
         mesher = oblique.ObliqueShockMesher()
         mh = mesher.make_mesh(cell_type=cell_type)
-        left, top, bottom, right = mesher.classify_boundary(mh)
         w = self._mgr.add3DWidget()
         w.updateMesh(mh)
         w.showAxis(True)
-        # The mesher tags bndfcs with the domain edges, so each edge can be
-        # ribboned in its own boundary-set color.
-        for ibc in range(len(oblique.ObliqueShockMesher.BOUNDARY_NAMES)):
+        # The mesher attaches one named group per domain edge, so each
+        # edge can be ribboned in its own boundary-set color.
+        for ibc in range(mh.nbcs):
             w.showBoundary(ibc, True)
         self._pycon.writeToHistory(
             f"oblique-shock {cell_type} mesh: {mh.ncell} cells, "
             f"{mh.nedge} edges\n"
             "boundary ribbons: "
-            f"red left inlet ({len(left)} faces), "
-            f"blue top inlet ({len(top)} faces), "
-            f"green bottom slip wall ({len(bottom)} faces), "
-            f"amber right outflow ({len(right)} faces)\n")
+            f"red left inlet ({mh.bc('left').nbound} faces), "
+            f"blue top inlet ({mh.bc('top').nbound} faces), "
+            f"green bottom slip wall ({mh.bc('bottom').nbound} faces), "
+            f"amber right outflow ({mh.bc('right').nbound} faces)\n")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -168,18 +168,20 @@ class MeshInfoTree(TreePanelBase):
 
     @classmethod
     def make_boundary_info(cls, mh):
-        """Return one ``[ibc, nface]`` row per boundary set.
+        """Return one ``[ibc, name, nface]`` row per boundary set.
 
         Each boundary face records its set index in column 1 of ``bndfcs``,
         so grouping the rows by that index yields the face count of every
         set, including the trailing catch-all set of unspecified faces.
+        The name comes from the set's boundary-condition group.
         """
         bnd = mh.bndfcs.ndarray
         if bnd.size:
             counts = np.bincount(bnd[:, 1], minlength=mh.nbcs)
         else:
             counts = np.zeros(mh.nbcs, dtype='int64')
-        return [[ibc, int(counts[ibc])] for ibc in range(mh.nbcs)]
+        return [[ibc, mh.bc(ibc).name, int(counts[ibc])]
+                for ibc in range(mh.nbcs)]
 
     def set_mesh(self, mh):
         """Rebuild the tree from ``mh``, or show "No mesh loaded" when None."""
@@ -248,8 +250,9 @@ class MeshInfoTree(TreePanelBase):
         if not binfo:
             return
         group = QTreeWidgetItem(root, ["Boundaries"])
-        for ibc, count in binfo:
-            item = QTreeWidgetItem(group, [f"bc {ibc}: {count} faces"])
+        for ibc, name, count in binfo:
+            item = QTreeWidgetItem(
+                group, [f"bc {ibc} ({name}): {count} faces"])
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setData(0, self._ROLE_KIND, 'boundary')
             item.setData(0, self._ROLE_IBC, ibc)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -207,4 +207,112 @@ class StaticMeshTC(unittest.TestCase):
         self._check_metric_trivial(mh)
         # TODO: Need to add build_boundary and build_ghost to make sure
         #       Line type behavior.
+
+
+class StaticMeshBcTC(unittest.TestCase):
+    """Populate boundary-condition groups from Python.
+
+    The three-triangle fan of StaticMeshTC has the boundary faces 1, 3,
+    and 5; the other faces are interior.
+    """
+
+    def _make_mesh(self):
+        mh = solvcon.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
+        mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
+        mh.cltpn.ndarray[:] = solvcon.StaticMesh.TRIANGLE
+        mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
+        mh.build_interior()
+        return mh
+
+    def test_populate_and_build(self):
+        mh = self._make_mesh()
+        bottom = mh.add_bc('bottom', [1])
+        flank = mh.add_bc('flank', [3, 5])
+        self.assertEqual(2, mh.nbcs)
+        self.assertEqual('bottom', bottom.name)
+        self.assertEqual(1, bottom.nbound)
+        self.assertEqual(2, flank.nbound)
+
+        mh.build_boundary()
+        # No leftover face: no catch-all group is appended.
+        self.assertEqual(2, mh.nbcs)
+        # Column 1 carries the group index in attach order.
+        self.assertEqual(
+            [[1, 0, -1], [3, 1, -1], [5, 1, -1]],
+            mh.bndfcs.ndarray.tolist())
+        # Column 1 of facn is back-filled with the bndfcs row; column 2
+        # stays at its -1 idle value.
+        self.assertEqual([[1, 0, -1]], bottom.facn.ndarray.tolist())
+        self.assertEqual(
+            [[3, 1, -1], [5, 2, -1]], flank.facn.ndarray.tolist())
+
+    def test_catch_all_collects_leftover(self):
+        mh = self._make_mesh()
+        mh.add_bc('bottom', [1])
+        mh.build_boundary()
+        self.assertEqual(2, mh.nbcs)
+        leftover = mh.bc(1)
+        self.assertEqual(solvcon.StaticMeshBc.NONAME, leftover.name)
+        self.assertEqual(
+            [[3, 1, -1], [5, 2, -1]], leftover.facn.ndarray.tolist())
+        self.assertEqual(
+            [[1, 0, -1], [3, 1, -1], [5, 1, -1]],
+            mh.bndfcs.ndarray.tolist())
+
+    def test_read_back(self):
+        mh = self._make_mesh()
+        bottom = mh.add_bc('bottom', [1])
+        self.assertIs(bottom, mh.bc(0))
+        self.assertIs(bottom, mh.bc('bottom'))
+        self.assertEqual(1, len(mh.bcs))
+        self.assertIs(bottom, mh.bcs[0])
+
+    def test_rename(self):
+        mh = self._make_mesh()
+        mh.add_bc('bottom', [1])
+        mh.bc(0).name = 'floor'
+        self.assertEqual('floor', mh.bc('floor').name)
+        with self.assertRaises(KeyError):
+            mh.bc('bottom')
+
+    def test_add_bc_rejects_bad_faces(self):
+        mh = self._make_mesh()
+        with self.assertRaisesRegex(ValueError, 'not a boundary face'):
+            mh.add_bc('interior', [0])
+        with self.assertRaisesRegex(ValueError, 'out of range'):
+            mh.add_bc('outside', [99])
+        with self.assertRaisesRegex(ValueError, 'out of range'):
+            mh.add_bc('negative', [-1])
+        with self.assertRaisesRegex(ValueError, 'already claimed'):
+            mh.add_bc('doubled', [3, 3])
+        mh.add_bc('bottom', [1])
+        with self.assertRaisesRegex(ValueError, 'already claimed'):
+            mh.add_bc('again', [1])
+
+    def test_add_bc_rejects_bad_names(self):
+        mh = self._make_mesh()
+        mh.add_bc('bottom', [1])
+        with self.assertRaisesRegex(ValueError, 'duplicated name'):
+            mh.add_bc('bottom', [3])
+        with self.assertRaisesRegex(ValueError, 'empty name'):
+            mh.add_bc('', [3])
+
+    def test_add_bc_after_build_raises(self):
+        mh = self._make_mesh()
+        mh.build_boundary()
+        with self.assertRaisesRegex(RuntimeError, 'already built'):
+            mh.add_bc('late', [1])
+
+    def test_double_build_boundary_raises(self):
+        mh = self._make_mesh()
+        mh.build_boundary()
+        with self.assertRaisesRegex(RuntimeError, 'already built'):
+            mh.build_boundary()
+
+    def test_lookup_errors(self):
+        mh = self._make_mesh()
+        with self.assertRaises(IndexError):
+            mh.bc(0)
+        with self.assertRaises(KeyError):
+            mh.bc('absent')
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_multidim_euler_oblique.py
+++ b/tests/test_multidim_euler_oblique.py
@@ -102,6 +102,20 @@ class _ObliqueMeshBase:
         self.assertEqual(self.NX, len(top))
         self.assertEqual(self.NX, len(bottom))
 
+    def test_named_boundary_groups(self):
+        mh = self.mesh
+        names = ObliqueShockMesher.BOUNDARY_NAMES
+        # One group per domain edge and no catch-all leftover.
+        self.assertEqual(list(names), [bnd.name for bnd in mh.bcs])
+        edges = self.mesher.classify_boundary(mh)
+        for name, faces in zip(names, edges):
+            self.assertEqual(faces, mh.bc(name).facn.ndarray[:, 0].tolist())
+        # Every boundary face carries its group index in bndfcs.
+        byface = {ifc: ibc for ibc, faces in enumerate(edges)
+                  for ifc in faces}
+        for ifc, ibc in mh.bndfcs.ndarray[:, :2].tolist():
+            self.assertEqual(byface[ifc], ibc)
+
     def test_boundary_geometry(self):
         mh = self.mesh
         left, top, bottom, right = self.mesher.classify_boundary(mh)

--- a/tests/test_pilot_tree_panel.py
+++ b/tests/test_pilot_tree_panel.py
@@ -60,9 +60,11 @@ class MakeMeshInfoTC(unittest.TestCase):
         mh = _make_sample_mesh()
         binfo = _tree_panel.MeshInfoTree.make_boundary_info(mh)
         # With no add_bc, build_boundary gathers every boundary face into a
-        # single catch-all set, so the one row must report all of them.
+        # single catch-all set, so the one row must report all of them
+        # under the placeholder name.
         self.assertGreater(mh.nbound, 0)
-        self.assertEqual(binfo, [[0, mh.nbound]])
+        self.assertEqual(
+            binfo, [[0, solvcon.StaticMeshBc.NONAME, mh.nbound]])
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
For issue #38.

Now the data of boundary condition treatments are populated from Python and stored in the C++ `StaticMeshBc` class.  The class got renamed from `StaticMeshBC` to follow the acronym naming convention.