### PR TITLE
Confine the nightly automation and report its timeouts

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
+    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # from allocating a runner there.
+    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -679,8 +679,14 @@ jobs:
 
   send_email_on_failure:
     needs: [standalone_buffer, build, build_windows, sanitizer, sanitizer_windows]
-    # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    # Run if any of the dependencies failed in master branch. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.ref_name == 'master' &&
+      github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -191,8 +191,14 @@ jobs:
 
   send_email_on_failure:
     needs: [lint]
-    # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    # Run if any of the dependencies failed in master branch. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.ref_name == 'master' &&
+      github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
+    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # from allocating a runner there.
+    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -128,8 +128,14 @@ jobs:
 
   send_email_on_failure:
     needs: [nouse_install]
-    # Run if any of the dependencies failed in master branch
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    # Run if any of the dependencies failed in master branch. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.ref_name == 'master' &&
+      github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
+    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # from allocating a runner there.
+    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -81,7 +81,14 @@ jobs:
 
   send_email_on_failure:
     needs: [profile]
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    # Run if any of the dependencies failed in master branch. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.ref_name == 'master' &&
+      github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -15,6 +15,13 @@ permissions:
 
 jobs:
   remind:
+    # Only perform for the specific repository and make sure it is not a fork.
+    # Both conditions are required so that a non-fork copy of the repository
+    # respects the setting.
+    if: |
+      github.repository == (vars.MMGH_REMIND_REPOSITORY || 'solvcon/solvcon') &&
+      github.event.repository.fork == false
+
     runs-on: ubuntu-latest
 
     steps:

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -119,6 +119,10 @@ Each is read with a default, so an unset variable keeps the default behavior.
   and `MMGH_PUSH_RUN_BRANCH` are unset there. By default only `pull_request`
   events run, so the fast set runs on a pull request opened in the fork, while
   pushes and the nightly schedule run nothing until the variables are set.
+- GitHub creates a run entry for the nightly cron in every fork that has
+  Actions enabled, and offers no way to suppress it. `MMGH_NIGHTLY` gates
+  `check_skip` as well as the heavy jobs, so that entry holds no job and
+  takes no runner.
 - Scheduled workflows run only on the default branch, and GitHub keeps Actions
   disabled on a new fork until it is enabled (a public fork's schedule also
   pauses after 60 days without activity).

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -112,6 +112,9 @@ Each is read with a default, so an unset variable keeps the default behavior.
   the ubuntu, macOS, and sanitizer builds (default 45) and the Windows build,
   which defaults to 60 because its vcpkg plus MSVC compile runs slower than the
   others.
+- `MMGH_REMIND_REPOSITORY` (`solvcon/solvcon`): the repository whose monthly
+  `Update Contributors` cron files its reminder issue. The job also requires a
+  non-fork repository, so a fork never files one whatever this is set to.
 
 ### Behavior on a forked repository
 


### PR DESCRIPTION
This PR fixes two defects in the the scheduled workflows.

1. GitHub fires a `schedule:` trigger in every fork whose owner has enabled Actions. It is a regression 
2. The nightly has been failing without telling anyone, because a job killed by `timeout-minutes` is recorded as `cancelled` rather than `failure`.