### PR TITLE
Reorganize code that conducts the run of obsrefl

### DIFF
--- a/solvcon/pilot/apps/obsrefl/__init__.py
+++ b/solvcon/pilot/apps/obsrefl/__init__.py
@@ -10,7 +10,7 @@ enters horizontally from the left, the top boundary holds the state behind
 an incident oblique shock, the bottom slip wall reflects that shock, and the
 flow leaves through the non-reflective outflow on the right.
 
-The driver and the analysis carry the problem itself and import
+The driver, the analysis, and the session carry the problem itself and import
 unconditionally, so a script or a no-Qt build runs and judges the reflection
 without the GUI that rides behind the pilot toggle.
 """
@@ -18,6 +18,7 @@ without the GUI that rides behind the pilot toggle.
 from ... import _pilot_core as _pcore
 from ._analytic import Reflection
 from ._driver import ObliqueShock, ObliqueShockMesher, ObliqueShockRelation
+from ._session import ReflectionSession
 
 if _pcore.enable:
     from ._app import ObliqueShockApp
@@ -37,6 +38,7 @@ __all__ = [
     'ObliqueShockMesher',
     'ObliqueShockRelation',
     'Reflection',
+    'ReflectionSession',
     'SolutionPanel',
 ]
 

--- a/solvcon/pilot/apps/obsrefl/_session.py
+++ b/solvcon/pilot/apps/obsrefl/_session.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Run the oblique-shock reflection to a steady state.
+
+A reflection run is one long march that has to be watched: it is driven a
+chunk at a time so a caller stays responsive between chunks, it has to keep
+what each chunk measured, and it has to know when marching further buys
+nothing.  :class:`ReflectionSession` holds all three, so the GUI timer, a
+script loop, and a test drive the same run the same way::
+
+    sess = ReflectionSession(mach=3.0, angle=10.0)
+    while not sess.finished:
+        sess.advance()
+    sess.zone_info()
+"""
+
+import collections
+
+from ._analytic import Reflection
+from ._driver import ObliqueShock
+
+__all__ = [
+    'ReflectionSession',
+    'RunHistory',
+    'RunRecord',
+    'SteadyDetector',
+]
+
+
+#: What one marched chunk leaves behind: the step it ended on, the density
+#: residual there, and the total mass, which flattens as the run settles.
+RunRecord = collections.namedtuple('RunRecord', ['step', 'residual', 'mass'])
+
+
+class RunHistory(object):
+    """Keep the newest ``length`` records of a run.
+
+    A run marches for as long as the user lets it, so the history is bounded
+    and drops its oldest record once it is full.  The bound is large enough
+    that a run reaching the default step cap never loses one.
+    """
+
+    def __init__(self, length=2048):
+        self.records = collections.deque(maxlen=length)
+
+    def __len__(self):
+        return len(self.records)
+
+    def append(self, step, residual, mass):
+        """Record one chunk; returns the new :class:`RunRecord`."""
+        record = RunRecord(step, residual, mass)
+        self.records.append(record)
+        return record
+
+    @property
+    def last(self):
+        """The newest record, or None before the first chunk."""
+        return self.records[-1] if self.records else None
+
+    @property
+    def residuals(self):
+        """The ``(step, residual)`` pairs, oldest first."""
+        return [(rec.step, rec.residual) for rec in self.records]
+
+    @property
+    def masses(self):
+        """The ``(step, mass)`` pairs, oldest first."""
+        return [(rec.step, rec.mass) for rec in self.records]
+
+
+class SteadyDetector(object):
+    """Decide when a marching run has settled.
+
+    Two conditions have to hold together, because either alone misreads a
+    run.  The residual has to have fallen to :attr:`drop` times the largest
+    residual the run has seen, which keeps the slow start of a run that has
+    not built its shocks yet from passing for convergence.  It also has to
+    have stopped improving for :attr:`patience` consecutive chunks, which
+    keeps a transient dip from doing the same.  A chunk improves when it
+    lowers the best residual so far by more than :attr:`rtol`; anything less
+    counts as flat.
+
+    :ivar drop: Fraction of the peak residual a steady run reaches.
+    :ivar rtol: Relative fall that still counts as an improvement.
+    :ivar patience: Flat chunks a plateau takes to be believed.
+    :ivar peak: Largest residual seen.
+    :ivar best: Smallest residual seen.
+    :ivar flat: Chunks since the last improvement.
+    :ivar steady: Whether the newest chunk is steady.
+    """
+
+    def __init__(self, drop=1.e-2, rtol=1.e-3, patience=20):
+        self.drop = drop
+        self.rtol = rtol
+        self.patience = patience
+        self.peak = 0.0
+        self.best = float('inf')
+        self.flat = 0
+        self.steady = False
+
+    def update(self, residual):
+        """Fold one chunk's residual in; returns :attr:`steady`."""
+        self.peak = max(self.peak, residual)
+        if residual < self.best * (1.0 - self.rtol):
+            self.flat = 0
+        else:
+            self.flat += 1
+        self.best = min(self.best, residual)
+        self.steady = (self.flat >= self.patience
+                       and residual <= self.peak * self.drop)
+        return self.steady
+
+
+class ReflectionSession(object):
+    """Own one oblique-shock reflection run.
+
+    Building the session builds the flow constants, the mesh, and the solver,
+    so a session exists only around a run that is ready to march.  Each
+    :meth:`advance` marches a chunk and records what it measured; the run
+    ends on the steady state, on the step cap, or on :meth:`stop`, and
+    :attr:`stop_reason` says which.
+
+    :ivar shock: The :class:`~._driver.ObliqueShock` being marched.
+    :ivar analysis: The :class:`~._analytic.Reflection` of its field.
+    :ivar history: The :class:`RunHistory` of the chunks marched so far.
+    :ivar detector: The :class:`SteadyDetector` ending the run.
+    :ivar steps_per_chunk: Full CESE steps one :meth:`advance` marches.
+    :ivar max_steps: Steps after which the run ends whatever the residual.
+    :ivar step: Steps marched so far.
+    :ivar stop_reason: What ended the run, or None while it runs.
+    """
+
+    #: Default :attr:`steps_per_chunk`, one frame of the GUI timer.
+    STEPS_PER_CHUNK = 5
+    #: Default :attr:`max_steps`.
+    MAX_STEPS = 2000
+
+    def __init__(self, gamma=1.4, density=1.0, pressure=1.0, mach=3.0,
+                 angle=10.0, cell_type='quad', time_increment=2.e-3,
+                 nx=64, ny=16, steps_per_chunk=STEPS_PER_CHUNK,
+                 max_steps=MAX_STEPS):
+        self.shock = ObliqueShock()
+        self.shock.build_constant(gamma=gamma, density=density,
+                                  pressure=pressure, mach=mach, angle=angle)
+        self.shock.build_numerical(cell_type=cell_type,
+                                   time_increment=time_increment,
+                                   nx=nx, ny=ny)
+        self.analysis = Reflection(self.shock)
+        self.history = RunHistory()
+        self.detector = SteadyDetector()
+        self.steps_per_chunk = steps_per_chunk
+        self.max_steps = max_steps
+        self.step = 0
+        self.stop_reason = None
+
+    @property
+    def field(self):
+        """The body-cell reader of the running solution."""
+        return self.analysis.field
+
+    @property
+    def finished(self):
+        """Whether the run has ended."""
+        return self.stop_reason is not None
+
+    @property
+    def steady(self):
+        """Whether the run ended on the steady state."""
+        return 'steady' == self.stop_reason
+
+    def advance(self):
+        """March the next chunk and record it.
+
+        Returns the new :class:`RunRecord`, or None once the run has ended.
+        The last chunk is trimmed so the march lands exactly on the step cap.
+        """
+        if self.finished:
+            return None
+        steps = min(self.steps_per_chunk, self.max_steps - self.step)
+        self.shock.march(steps)
+        self.step += steps
+        record = self.history.append(self.step, self.field.calc_residual(),
+                                     self.field.calc_overall_mass())
+        if self.detector.update(record.residual):
+            self.stop_reason = 'steady'
+        elif self.step >= self.max_steps:
+            self.stop_reason = 'cap'
+        return record
+
+    def run(self):
+        """March until the run ends; returns :attr:`stop_reason`."""
+        while not self.finished:
+            self.advance()
+        return self.stop_reason
+
+    def stop(self):
+        """End the run where it stands, keeping the field and the history."""
+        if not self.finished:
+            self.stop_reason = 'stopped'
+
+    def residual(self):
+        """The residual of the newest chunk, or nan before the first."""
+        record = self.history.last
+        return record.residual if record else float('nan')
+
+    def zone_info(self, name='density'):
+        """See :meth:`Reflection.zone_info`."""
+        return self.analysis.zone_info(name)
+
+    def fit_incident_angle(self, nbin=None):
+        """See :meth:`Reflection.fit_incident_angle`."""
+        return self.analysis.fit_incident_angle(nbin)
+
+    def reflection_point(self, nbin=None):
+        """See :meth:`Reflection.reflection_point`."""
+        return self.analysis.reflection_point(nbin)
+
+    def profile(self, height, name='density', halfwidth=None):
+        """See :meth:`Reflection.profile`."""
+        return self.analysis.profile(height, name, halfwidth)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/apps/obsrefl/test_session.py
+++ b/tests/apps/obsrefl/test_session.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The run session of the oblique-shock reflection.
+
+The stop rule is checked on residual sequences rather than on runs, so the
+cases that matter (a run still falling, a plateau that never converged, a
+transient dip) are all reachable without marching anything.  One coarse run
+is then marched to its steady state, which is what pins the session, the
+analysis, and the solver together against the analytic answer.
+"""
+
+import math
+import unittest
+
+from solvcon.pilot.apps.obsrefl import ReflectionSession
+from solvcon.pilot.apps.obsrefl._session import RunHistory, SteadyDetector
+
+
+class SteadyDetectorTC(unittest.TestCase):
+    """The stop rule needs both of its conditions."""
+
+    def _feed(self, residuals, **kw):
+        kw.setdefault('patience', 3)
+        detector = SteadyDetector(**kw)
+        for residual in residuals:
+            detector.update(residual)
+        return detector
+
+    def test_a_falling_residual_keeps_the_run_going(self):
+        # Every chunk improves on the last, so the plateau never starts even
+        # though the residual has long passed the drop.
+        detector = self._feed([0.5 ** it for it in range(40)])
+        self.assertFalse(detector.steady)
+        self.assertEqual(0, detector.flat)
+
+    def test_a_plateau_short_of_the_drop_keeps_the_run_going(self):
+        # A run stuck at a tenth of its peak has flattened, but it has not
+        # converged; only the drop condition can tell the two apart.
+        detector = self._feed([1.0] + [0.1] * 20)
+        self.assertFalse(detector.steady)
+        self.assertGreater(detector.flat, detector.patience)
+
+    def test_a_plateau_below_the_drop_ends_the_run(self):
+        # The run has to sit flat for the whole patience: three chunks after
+        # the improving one, not two.
+        self.assertFalse(self._feed([1.0, 1.e-3, 1.e-3, 1.e-3]).steady)
+        self.assertTrue(self._feed([1.0, 1.e-3, 1.e-3, 1.e-3, 1.e-3]).steady)
+
+    def test_a_dip_does_not_end_the_run(self):
+        # A transient dip below the drop is not a steady state; the residual
+        # climbing back leaves the run above the drop again.
+        detector = self._feed([1.0, 1.e-3, 1.e-3, 1.e-3, 0.5, 0.5, 0.5])
+        self.assertFalse(detector.steady)
+
+
+class RunHistoryTC(unittest.TestCase):
+
+    def test_the_history_pairs_the_steps_and_drops_the_oldest(self):
+        # A run marches for as long as the user lets it, so the history is
+        # bounded and keeps the newest chunks.
+        history = RunHistory(length=3)
+        self.assertIsNone(history.last)
+        for step in range(1, 6):
+            history.append(step, 1.0 / step, 1.0)
+        self.assertEqual(3, len(history))
+        self.assertEqual([(3, 1 / 3), (4, 0.25), (5, 0.2)],
+                         history.residuals)
+        self.assertEqual(5, history.last.step)
+
+
+class ReflectionSessionTC(unittest.TestCase):
+    """The chunked march over a mesh coarse enough to keep it quick."""
+
+    def _session(self, **kw):
+        kw.setdefault('nx', 8)
+        kw.setdefault('ny', 3)
+        return ReflectionSession(**kw)
+
+    def test_a_new_session_is_built_and_waiting(self):
+        sess = self._session()
+        self.assertEqual(0, sess.step)
+        self.assertFalse(sess.finished)
+        self.assertIsNone(sess.stop_reason)
+        self.assertEqual(0, len(sess.history))
+        self.assertTrue(math.isnan(sess.residual()))
+        # The driver is built through the solver, and the analysis reads it.
+        self.assertEqual(sess.shock.mesh.ncell, sess.shock.svr.ncell)
+        self.assertIs(sess.field, sess.analysis.field)
+
+    def test_advance_marches_a_chunk_and_records_it(self):
+        sess = self._session(steps_per_chunk=3)
+        record = sess.advance()
+        self.assertEqual(3, sess.step)
+        self.assertEqual(3, record.step)
+        self.assertEqual(record.residual, sess.residual())
+        self.assertGreater(record.residual, 0.0)
+        self.assertAlmostEqual(record.mass, sess.field.calc_overall_mass())
+        self.assertEqual([(3, record.residual)], sess.history.residuals)
+        self.assertFalse(sess.finished)
+
+    def test_the_last_chunk_lands_on_the_step_cap(self):
+        # The cap is a step count, not a chunk count, so the final chunk is
+        # trimmed instead of marching past it, and the run is over from
+        # there on.
+        sess = self._session(steps_per_chunk=4, max_steps=6)
+        self.assertEqual(4, sess.advance().step)
+        self.assertEqual(6, sess.advance().step)
+        self.assertEqual('cap', sess.stop_reason)
+        self.assertFalse(sess.steady)
+        self.assertIsNone(sess.advance())
+        self.assertEqual(6, sess.step)
+
+    def test_stop_ends_the_run_and_keeps_what_it_measured(self):
+        sess = self._session(steps_per_chunk=2)
+        sess.advance()
+        sess.stop()
+        self.assertTrue(sess.finished)
+        self.assertEqual('stopped', sess.stop_reason)
+        self.assertEqual(1, len(sess.history))
+        self.assertEqual(3, len(sess.zone_info()))
+        # A second stop does not overwrite what ended the run.
+        sess.stop()
+        self.assertEqual('stopped', sess.stop_reason)
+
+
+class SteadyRunTC(unittest.TestCase):
+    """One run marched all the way to its steady state.
+
+    This is the check that the reflection is solved at all: the session has
+    to end itself on the steady state, and the field it settles on has to be
+    the analytic three-zone answer.
+
+    Two things keep it to a few hundredths of a second.  The mesh is coarse,
+    and a coarse mesh takes a long step: the run below sits at a CFL of
+    about 0.76 with a time increment twenty times the default, so it covers
+    the same flow time in a twentieth of the steps.  The stop rule is also
+    made less patient, since a plateau still has to fall two orders of
+    magnitude from the peak to count, and waiting out twenty flat chunks
+    only confirms what five already showed.
+
+    The errors are percents on a mesh this coarse.  They shrink with
+    refinement, which is what a resolution control is for, and the bounds
+    below are loose enough to leave that to the panel rather than pin it.
+    """
+
+    def test_a_coarse_run_settles_onto_the_analytic_answer(self):
+        sess = ReflectionSession(nx=12, ny=4, time_increment=4.e-2,
+                                 steps_per_chunk=20, max_steps=2000)
+        sess.detector = SteadyDetector(patience=5)
+        self.assertEqual('steady', sess.run())
+        self.assertLess(sess.step, sess.max_steps)
+        self.assertEqual(sess.step // 20, len(sess.history))
+        # The long step is only legitimate below a CFL of one.
+        cflc = sess.shock.svr.cflc
+        self.assertLess(float(cflc.ndarray[cflc.nghost:].max()), 1.0)
+        # Every zone holds its analytic state, and the shock stands where
+        # the relations put it.
+        for record in sess.zone_info():
+            self.assertLess(abs(record.error), 0.2)
+        fit = sess.fit_incident_angle()
+        self.assertLess(abs(fit.degree - fit.analytic), 10.0)
+        self.assertLess(abs(sess.reflection_point().error), 0.3)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
For issue #1269.

The oblique-shock reflection problem has steady-state solution (that can be analytically computed).  The time-accurate CESE method (which is always time-accurate) will use many time steps to reach the steady state.

This PR makes `ReflectionSession` to hold the driver, the analysis, and a bounded history of the residual and the mass.  It stops on the steady state, on a step cap, or on request.  It allows to drive the run from the GUI timer, a script loop, and a test in the same way.

A unit test case is added to reach the steady state (numerical) solution quickly.  It takes about 0.1 second on Apple M1.